### PR TITLE
common: finish new isa support implementation

### DIFF
--- a/VEX/priv/guest_amd64_toIR.c
+++ b/VEX/priv/guest_amd64_toIR.c
@@ -41,29 +41,29 @@
    to ensure a 64-bit value is being written.
 
    x87 FP Limitations:
- 
+
    * all arithmetic done at 64 bits
- 
+
    * no FP exceptions, except for handling stack over/underflow
- 
+
    * FP rounding mode observed only for float->int conversions and
      int->float conversions which could lose accuracy, and for
      float-to-float rounding.  For all other operations,
      round-to-nearest is used, regardless.
- 
+
    * some of the FCOM cases could do with testing -- not convinced
      that the args are the right way round.
- 
+
    * FSAVE does not re-initialise the FPU; it should do
- 
+
    * FINIT not only initialises the FPU environment, it also zeroes
      all the FP registers.  It should leave the registers unchanged.
- 
+
     SAHF should cause eflags[1] == 1, and in fact it produces 0.  As
     per Intel docs this bit has no meaning anyway.  Since PUSHF is the
     only way to observe eflags[1], a proper fix would be to make that
     bit be set by PUSHF.
- 
+
     This module uses global variables and so is not MT-safe (if that
     should ever become relevant).
 */
@@ -220,7 +220,7 @@ static Bool   guest_RIP_next_mustcheck;
 /*------------------------------------------------------------*/
 /*--- Helpers for constructing IR.                         ---*/
 /*------------------------------------------------------------*/
- 
+
 /* Generate a new temporary of the given type. */
 static IRTemp newTemp ( IRType ty )
 {
@@ -234,7 +234,7 @@ static void stmt ( IRStmt* st )
    addStmtToIRSB( irsb, st );
 }
 
-/* Generate a statement "dst := e". */ 
+/* Generate a statement "dst := e". */
 static void assign ( IRTemp dst, IRExpr* e )
 {
    stmt( IRStmt_WrTmp(dst, e) );
@@ -306,8 +306,8 @@ static IRExpr* loadLE ( IRType ty, IRExpr* addr )
 
 static IROp mkSizedOp ( IRType ty, IROp op8 )
 {
-   vassert(op8 == Iop_Add8 || op8 == Iop_Sub8 
-           || op8 == Iop_Mul8 
+   vassert(op8 == Iop_Add8 || op8 == Iop_Sub8
+           || op8 == Iop_Mul8
            || op8 == Iop_Or8 || op8 == Iop_And8 || op8 == Iop_Xor8
            || op8 == Iop_Shl8 || op8 == Iop_Shr8 || op8 == Iop_Sar8
            || op8 == Iop_CmpEQ8 || op8 == Iop_CmpNE8
@@ -322,7 +322,7 @@ static IROp mkSizedOp ( IRType ty, IROp op8 )
    }
 }
 
-static 
+static
 IRExpr* doScalarWidening ( Int szSmall, Int szBig, Bool signd, IRExpr* src )
 {
    if (szSmall == 1 && szBig == 4) {
@@ -722,42 +722,42 @@ static Bool haveLOCK ( Prefix pfx ) {
 /* Return True iff pfx has 66 set and F2 and F3 clear */
 static Bool have66noF2noF3 ( Prefix pfx )
 {
-  return 
+  return
      toBool((pfx & (PFX_66|PFX_F2|PFX_F3)) == PFX_66);
 }
 
 /* Return True iff pfx has F2 set and 66 and F3 clear */
 static Bool haveF2no66noF3 ( Prefix pfx )
 {
-  return 
+  return
      toBool((pfx & (PFX_66|PFX_F2|PFX_F3)) == PFX_F2);
 }
 
 /* Return True iff pfx has F3 set and 66 and F2 clear */
 static Bool haveF3no66noF2 ( Prefix pfx )
 {
-  return 
+  return
      toBool((pfx & (PFX_66|PFX_F2|PFX_F3)) == PFX_F3);
 }
 
 /* Return True iff pfx has F3 set and F2 clear */
 static Bool haveF3noF2 ( Prefix pfx )
 {
-  return 
+  return
      toBool((pfx & (PFX_F2|PFX_F3)) == PFX_F3);
 }
 
 /* Return True iff pfx has F2 set and F3 clear */
 static Bool haveF2noF3 ( Prefix pfx )
 {
-  return 
+  return
      toBool((pfx & (PFX_F2|PFX_F3)) == PFX_F2);
 }
 
 /* Return True iff pfx has 66, F2 and F3 clear */
 static Bool haveNo66noF2noF3 ( Prefix pfx )
 {
-  return 
+  return
      toBool((pfx & (PFX_66|PFX_F2|PFX_F3)) == 0);
 }
 
@@ -776,7 +776,7 @@ static Bool have66orF3 ( Prefix pfx )
 /* Clear all the segment-override bits in a prefix. */
 static Prefix clearSegBits ( Prefix p )
 {
-   return 
+   return
       p & ~(PFX_CS | PFX_DS | PFX_ES | PFX_FS | PFX_GS | PFX_SS);
 }
 
@@ -808,7 +808,7 @@ static Int getVexL ( Prefix pfx ) {
 */
 
 typedef
-   enum { 
+   enum {
       ESC_NONE=0xF0000000, // none
       ESC_0F,              // 0F
       ESC_0F38,            // 0F 38
@@ -902,7 +902,7 @@ static Int integerGuestReg64Offset ( UInt reg )
    3-bit reg-field number and a REX extension bit.  irregular denotes
    the case where sz==1 and no REX byte is present. */
 
-static 
+static
 const HChar* nameIReg ( Int sz, UInt reg, Bool irregular )
 {
    static const HChar* ireg64_names[16]
@@ -917,7 +917,7 @@ const HChar* nameIReg ( Int sz, UInt reg, Bool irregular )
    static const HChar* ireg8_names[16]
      = { "%al",  "%cl",  "%dl",  "%bl",  "%spl", "%bpl", "%sil", "%dil",
          "%r8b", "%r9b", "%r10b","%r11b","%r12b","%r13b","%r14b","%r15b" };
-   static const HChar* ireg8_irregular[8] 
+   static const HChar* ireg8_irregular[8]
      = { "%al", "%cl", "%dl", "%bl", "%ah", "%ch", "%dh", "%bh" };
 
    vassert(reg < 16);
@@ -944,7 +944,7 @@ const HChar* nameIReg ( Int sz, UInt reg, Bool irregular )
 /* Using the same argument conventions as nameIReg, produce the
    guest state offset of an integer register. */
 
-static 
+static
 Int offsetIReg ( Int sz, UInt reg, Bool irregular )
 {
    vassert(reg < 16);
@@ -1117,7 +1117,7 @@ static IRExpr* getIReg32 ( UInt regno )
 static void putIReg32 ( UInt regno, IRExpr* e )
 {
    vassert(typeOfIRExpr(irsb->tyenv,e) == Ity_I32);
-   stmt( IRStmt_Put( integerGuestReg64Offset(regno), 
+   stmt( IRStmt_Put( integerGuestReg64Offset(regno),
                      unop(Iop_32Uto64,e) ) );
 }
 
@@ -1140,7 +1140,7 @@ static IRExpr* getIReg16 ( UInt regno )
 static void putIReg16 ( UInt regno, IRExpr* e )
 {
    vassert(typeOfIRExpr(irsb->tyenv,e) == Ity_I16);
-   stmt( IRStmt_Put( integerGuestReg64Offset(regno), 
+   stmt( IRStmt_Put( integerGuestReg64Offset(regno),
                      unop(Iop_16Uto64,e) ) );
 }
 
@@ -1152,7 +1152,7 @@ static const HChar* nameIReg16 ( UInt regno )
 
 /* Sometimes what we know is a 3-bit register number, a REX byte, and
    which field of the REX byte is to be used to extend to a 4-bit
-   number.  These functions cater for that situation.  
+   number.  These functions cater for that situation.
 */
 static IRExpr* getIReg64rexX ( Prefix pfx, UInt lo3bits )
 {
@@ -1173,7 +1173,7 @@ static const HChar* nameIRegRexB ( Int sz, Prefix pfx, UInt lo3bits )
    vassert(lo3bits < 8);
    vassert(IS_VALID_PFX(pfx));
    vassert(sz == 8 || sz == 4 || sz == 2 || sz == 1);
-   return nameIReg( sz, lo3bits | (getRexB(pfx) << 3), 
+   return nameIReg( sz, lo3bits | (getRexB(pfx) << 3),
                         toBool(sz==1 && !haveREX(pfx)) );
 }
 
@@ -1186,14 +1186,14 @@ static IRExpr* getIRegRexB ( Int sz, Prefix pfx, UInt lo3bits )
       sz = 8;
       return unop(Iop_64to32,
                   IRExpr_Get(
-                     offsetIReg( sz, lo3bits | (getRexB(pfx) << 3), 
+                     offsetIReg( sz, lo3bits | (getRexB(pfx) << 3),
                                      False/*!irregular*/ ),
                      szToITy(sz)
                  )
              );
    } else {
       return IRExpr_Get(
-                offsetIReg( sz, lo3bits | (getRexB(pfx) << 3), 
+                offsetIReg( sz, lo3bits | (getRexB(pfx) << 3),
                                 toBool(sz==1 && !haveREX(pfx)) ),
                 szToITy(sz)
              );
@@ -1206,8 +1206,8 @@ static void putIRegRexB ( Int sz, Prefix pfx, UInt lo3bits, IRExpr* e )
    vassert(IS_VALID_PFX(pfx));
    vassert(sz == 8 || sz == 4 || sz == 2 || sz == 1);
    vassert(typeOfIRExpr(irsb->tyenv, e) == szToITy(sz));
-   stmt( IRStmt_Put( 
-            offsetIReg( sz, lo3bits | (getRexB(pfx) << 3), 
+   stmt( IRStmt_Put(
+            offsetIReg( sz, lo3bits | (getRexB(pfx) << 3),
                             toBool(sz==1 && !haveREX(pfx)) ),
             sz==4 ? unop(Iop_32Uto64,e) : e
    ));
@@ -1260,7 +1260,7 @@ static UInt offsetIRegG ( Int sz, Prefix pfx, UChar mod_reg_rm )
    return offsetIReg( sz, reg, toBool(sz == 1 && !haveREX(pfx)) );
 }
 
-static 
+static
 IRExpr* getIRegG ( Int sz, Prefix pfx, UChar mod_reg_rm )
 {
    if (sz == 4) {
@@ -1274,7 +1274,7 @@ IRExpr* getIRegG ( Int sz, Prefix pfx, UChar mod_reg_rm )
    }
 }
 
-static 
+static
 void putIRegG ( Int sz, Prefix pfx, UChar mod_reg_rm, IRExpr* e )
 {
    vassert(typeOfIRExpr(irsb->tyenv,e) == szToITy(sz));
@@ -1339,7 +1339,7 @@ static UInt offsetIRegE ( Int sz, Prefix pfx, UChar mod_reg_rm )
    return offsetIReg( sz, reg, toBool(sz == 1 && !haveREX(pfx)) );
 }
 
-static 
+static
 IRExpr* getIRegE ( Int sz, Prefix pfx, UChar mod_reg_rm )
 {
    if (sz == 4) {
@@ -1353,7 +1353,7 @@ IRExpr* getIRegE ( Int sz, Prefix pfx, UChar mod_reg_rm )
    }
 }
 
-static 
+static
 void putIRegE ( Int sz, Prefix pfx, UChar mod_reg_rm, IRExpr* e )
 {
    vassert(typeOfIRExpr(irsb->tyenv,e) == szToITy(sz));
@@ -1588,9 +1588,9 @@ static IRExpr* mkAnd1 ( IRExpr* x, IRExpr* y )
 {
    vassert(typeOfIRExpr(irsb->tyenv,x) == Ity_I1);
    vassert(typeOfIRExpr(irsb->tyenv,y) == Ity_I1);
-   return unop(Iop_64to1, 
-               binop(Iop_And64, 
-                     unop(Iop_1Uto64,x), 
+   return unop(Iop_64to1,
+               binop(Iop_And64,
+                     unop(Iop_1Uto64,x),
                      unop(Iop_1Uto64,y)));
 }
 
@@ -1612,7 +1612,7 @@ static void casLE ( IRExpr* addr, IRExpr* expVal, IRExpr* newVal,
    vassert(tyE == Ity_I64 || tyE == Ity_I32
            || tyE == Ity_I16 || tyE == Ity_I8);
    assign(expTmp, expVal);
-   cas = mkIRCAS( IRTemp_INVALID, oldTmp, Iend_LE, addr, 
+   cas = mkIRCAS( IRTemp_INVALID, oldTmp, Iend_LE, addr,
                   NULL, mkexpr(expTmp), NULL, newVal );
    stmt( IRStmt_CAS(cas) );
    stmt( IRStmt_Exit(
@@ -1644,7 +1644,7 @@ static IRExpr* mk_amd64g_calculate_rflags_all ( void )
    IRExpr* call
       = mkIRExprCCall(
            Ity_I64,
-           0/*regparm*/, 
+           0/*regparm*/,
            "amd64g_calculate_rflags_all", &amd64g_calculate_rflags_all,
            args
         );
@@ -1668,7 +1668,7 @@ static IRExpr* mk_amd64g_calculate_condition ( AMD64Condcode cond )
    IRExpr* call
       = mkIRExprCCall(
            Ity_I64,
-           0/*regparm*/, 
+           0/*regparm*/,
            "amd64g_calculate_condition", &amd64g_calculate_condition,
            args
         );
@@ -1690,7 +1690,7 @@ static IRExpr* mk_amd64g_calculate_rflags_c ( void )
    IRExpr* call
       = mkIRExprCCall(
            Ity_I64,
-           0/*regparm*/, 
+           0/*regparm*/,
            "amd64g_calculate_rflags_c", &amd64g_calculate_rflags_c,
            args
         );
@@ -1772,7 +1772,7 @@ static IRExpr* narrowTo ( IRType dst_ty, IRExpr* e )
 /* Set the flags thunk OP, DEP1 and DEP2 fields.  The supplied op is
    auto-sized up to the real op. */
 
-static 
+static
 void setFlags_DEP1_DEP2 ( IROp op8, IRTemp dep1, IRTemp dep2, IRType ty )
 {
    Int ccOp = 0;
@@ -1797,7 +1797,7 @@ void setFlags_DEP1_DEP2 ( IROp op8, IRTemp dep1, IRTemp dep2, IRType ty )
 
 /* Set the OP and DEP1 fields only, and write zero to DEP2. */
 
-static 
+static
 void setFlags_DEP1 ( IROp op8, IRTemp dep1, IRType ty )
 {
    Int ccOp = 0;
@@ -1865,7 +1865,7 @@ static void setFlags_DEP1_DEP2_shift ( IROp    op64,
                      IRExpr_ITE( mkexpr(guardB),
                                  widenUto64(mkexpr(res)),
                                  IRExpr_Get(OFFB_CC_DEP1,Ity_I64) ) ));
-   stmt( IRStmt_Put( OFFB_CC_DEP2, 
+   stmt( IRStmt_Put( OFFB_CC_DEP2,
                      IRExpr_ITE( mkexpr(guardB),
                                  widenUto64(mkexpr(resUS)),
                                  IRExpr_Get(OFFB_CC_DEP2,Ity_I64) ) ));
@@ -1887,8 +1887,8 @@ static void setFlags_INC_DEC ( Bool inc, IRTemp res, IRType ty )
       case Ity_I64: ccOp += 3; break;
       default: vassert(0);
    }
-   
-   /* This has to come first, because calculating the C flag 
+
+   /* This has to come first, because calculating the C flag
       may require reading all four thunk fields. */
    stmt( IRStmt_Put( OFFB_CC_NDEP, mk_amd64g_calculate_rflags_c()) );
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(ccOp)) );
@@ -1952,7 +1952,7 @@ static const HChar* name_AMD64Condcode ( AMD64Condcode cond )
    }
 }
 
-static 
+static
 AMD64Condcode positiveIse_AMD64Condcode ( AMD64Condcode  cond,
                                           /*OUT*/Bool*   needInvert )
 {
@@ -1987,7 +1987,7 @@ AMD64Condcode positiveIse_AMD64Condcode ( AMD64Condcode  cond,
      if texpVal is not IRTemp_INVALID then a cas-style store is
      generated.  texpVal is the expected value, restart_point
      is the restart point if the store fails, and texpVal must
-     have the same type as tres.   
+     have the same type as tres.
 
 */
 static void helper_ADC ( Int sz,
@@ -2039,7 +2039,7 @@ static void helper_ADC ( Int sz,
 
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(thunkOp) ) );
    stmt( IRStmt_Put( OFFB_CC_DEP1, widenUto64(mkexpr(ta1))  ));
-   stmt( IRStmt_Put( OFFB_CC_DEP2, widenUto64(binop(xor, mkexpr(ta2), 
+   stmt( IRStmt_Put( OFFB_CC_DEP2, widenUto64(binop(xor, mkexpr(ta2),
                                                          mkexpr(oldcn)) )) );
    stmt( IRStmt_Put( OFFB_CC_NDEP, mkexpr(oldc) ) );
 }
@@ -2098,7 +2098,7 @@ static void helper_SBB ( Int sz,
 
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(thunkOp) ) );
    stmt( IRStmt_Put( OFFB_CC_DEP1, widenUto64(mkexpr(ta1) )) );
-   stmt( IRStmt_Put( OFFB_CC_DEP2, widenUto64(binop(xor, mkexpr(ta2), 
+   stmt( IRStmt_Put( OFFB_CC_DEP2, widenUto64(binop(xor, mkexpr(ta2),
                                                          mkexpr(oldcn)) )) );
    stmt( IRStmt_Put( OFFB_CC_NDEP, mkexpr(oldc) ) );
 }
@@ -2108,7 +2108,7 @@ static void helper_SBB ( Int sz,
 
 static const HChar* nameGrp1 ( Int opc_aux )
 {
-   static const HChar* grp1_names[8] 
+   static const HChar* grp1_names[8]
      = { "add", "or", "adc", "sbb", "and", "sub", "xor", "cmp" };
    if (opc_aux < 0 || opc_aux > 7) vpanic("nameGrp1(amd64)");
    return grp1_names[opc_aux];
@@ -2116,7 +2116,7 @@ static const HChar* nameGrp1 ( Int opc_aux )
 
 static const HChar* nameGrp2 ( Int opc_aux )
 {
-   static const HChar* grp2_names[8] 
+   static const HChar* grp2_names[8]
      = { "rol", "ror", "rcl", "rcr", "shl", "shr", "shl", "sar" };
    if (opc_aux < 0 || opc_aux > 7) vpanic("nameGrp2(amd64)");
    return grp2_names[opc_aux];
@@ -2124,7 +2124,7 @@ static const HChar* nameGrp2 ( Int opc_aux )
 
 static const HChar* nameGrp4 ( Int opc_aux )
 {
-   static const HChar* grp4_names[8] 
+   static const HChar* grp4_names[8]
      = { "inc", "dec", "???", "???", "???", "???", "???", "???" };
    if (opc_aux < 0 || opc_aux > 1) vpanic("nameGrp4(amd64)");
    return grp4_names[opc_aux];
@@ -2132,7 +2132,7 @@ static const HChar* nameGrp4 ( Int opc_aux )
 
 static const HChar* nameGrp5 ( Int opc_aux )
 {
-   static const HChar* grp5_names[8] 
+   static const HChar* grp5_names[8]
      = { "inc", "dec", "call*", "call*", "jmp*", "jmp*", "push", "???" };
    if (opc_aux < 0 || opc_aux > 6) vpanic("nameGrp5(amd64)");
    return grp5_names[opc_aux];
@@ -2140,7 +2140,7 @@ static const HChar* nameGrp5 ( Int opc_aux )
 
 static const HChar* nameGrp8 ( Int opc_aux )
 {
-   static const HChar* grp8_names[8] 
+   static const HChar* grp8_names[8]
       = { "???", "???", "???", "???", "bt", "bts", "btr", "btc" };
    if (opc_aux < 4 || opc_aux > 7) vpanic("nameGrp8(amd64)");
    return grp8_names[opc_aux];
@@ -2161,7 +2161,7 @@ static const HChar* nameGrp8 ( Int opc_aux )
 
 static const HChar* nameMMXReg ( Int mmxreg )
 {
-   static const HChar* mmx_names[8] 
+   static const HChar* mmx_names[8]
      = { "%mm0", "%mm1", "%mm2", "%mm3", "%mm4", "%mm5", "%mm6", "%mm7" };
    if (mmxreg < 0 || mmxreg > 7) vpanic("nameMMXReg(amd64,guest)");
    return mmx_names[mmxreg];
@@ -2169,15 +2169,15 @@ static const HChar* nameMMXReg ( Int mmxreg )
 
 static const HChar* nameXMMReg ( Int xmmreg )
 {
-   static const HChar* xmm_names[16] 
-     = { "%xmm0",  "%xmm1",  "%xmm2",  "%xmm3", 
-         "%xmm4",  "%xmm5",  "%xmm6",  "%xmm7", 
-         "%xmm8",  "%xmm9",  "%xmm10", "%xmm11", 
+   static const HChar* xmm_names[16]
+     = { "%xmm0",  "%xmm1",  "%xmm2",  "%xmm3",
+         "%xmm4",  "%xmm5",  "%xmm6",  "%xmm7",
+         "%xmm8",  "%xmm9",  "%xmm10", "%xmm11",
          "%xmm12", "%xmm13", "%xmm14", "%xmm15" };
    if (xmmreg < 0 || xmmreg > 15) vpanic("nameXMMReg(amd64)");
    return xmm_names[xmmreg];
 }
- 
+
 static const HChar* nameMMXGran ( Int gran )
 {
    switch (gran) {
@@ -2202,10 +2202,10 @@ static HChar nameISize ( Int size )
 
 static const HChar* nameYMMReg ( Int ymmreg )
 {
-   static const HChar* ymm_names[16] 
-     = { "%ymm0",  "%ymm1",  "%ymm2",  "%ymm3", 
-         "%ymm4",  "%ymm5",  "%ymm6",  "%ymm7", 
-         "%ymm8",  "%ymm9",  "%ymm10", "%ymm11", 
+   static const HChar* ymm_names[16]
+     = { "%ymm0",  "%ymm1",  "%ymm2",  "%ymm3",
+         "%ymm4",  "%ymm5",  "%ymm6",  "%ymm7",
+         "%ymm8",  "%ymm9",  "%ymm10", "%ymm11",
          "%ymm12", "%ymm13", "%ymm14", "%ymm15" };
    if (ymmreg < 0 || ymmreg > 15) vpanic("nameYMMReg(amd64)");
    return ymm_names[ymmreg];
@@ -2240,7 +2240,7 @@ static void jmp_treg( /*MOD*/DisResult* dres,
    stmt( IRStmt_Put( OFFB_RIP, mkexpr(t) ) );
 }
 
-static 
+static
 void jcc_01 ( /*MOD*/DisResult* dres,
               AMD64Condcode cond, Addr64 d64_false, Addr64 d64_true )
 {
@@ -2274,7 +2274,7 @@ void jcc_01 ( /*MOD*/DisResult* dres,
    This function generates an AbiHint to say that -128(%rsp)
    .. -1(%rsp) should now be regarded as uninitialised.
 */
-static 
+static
 void make_redzone_AbiHint ( VexAbiInfo* vbi,
                             IRTemp new_rsp, IRTemp nia, const HChar* who )
 {
@@ -2290,8 +2290,8 @@ void make_redzone_AbiHint ( VexAbiInfo* vbi,
    vassert(typeOfIRTemp(irsb->tyenv, new_rsp) == Ity_I64);
    vassert(typeOfIRTemp(irsb->tyenv, nia) == Ity_I64);
    if (szB > 0)
-      stmt( IRStmt_AbiHint( 
-               binop(Iop_Sub64, mkexpr(new_rsp), mkU64(szB)), 
+      stmt( IRStmt_AbiHint(
+               binop(Iop_Sub64, mkexpr(new_rsp), mkU64(szB)),
                szB,
                mkexpr(nia)
             ));
@@ -2302,7 +2302,7 @@ void make_redzone_AbiHint ( VexAbiInfo* vbi,
 /*--- Disassembling addressing modes                       ---*/
 /*------------------------------------------------------------*/
 
-static 
+static
 const HChar* segRegTxt ( Prefix pfx )
 {
    if (pfx & PFX_CS) return "%cs:";
@@ -2320,7 +2320,7 @@ const HChar* segRegTxt ( Prefix pfx )
    by sorb, and also dealing with any address size override
    present. */
 static
-IRExpr* handleAddrOverrides ( VexAbiInfo* vbi, 
+IRExpr* handleAddrOverrides ( VexAbiInfo* vbi,
                               Prefix pfx, IRExpr* virtual )
 {
    /* --- segment overrides --- */
@@ -2361,11 +2361,11 @@ IRExpr* handleAddrOverrides ( VexAbiInfo* vbi,
 //..    Int    sreg;
 //..    IRType hWordTy;
 //..    IRTemp ldt_ptr, gdt_ptr, seg_selector, r64;
-//.. 
+//..
 //..    if (sorb == 0)
 //..       /* the common case - no override */
 //..       return virtual;
-//.. 
+//..
 //..    switch (sorb) {
 //..       case 0x3E: sreg = R_DS; break;
 //..       case 0x26: sreg = R_ES; break;
@@ -2373,47 +2373,47 @@ IRExpr* handleAddrOverrides ( VexAbiInfo* vbi,
 //..       case 0x65: sreg = R_GS; break;
 //..       default: vpanic("handleAddrOverrides(x86,guest)");
 //..    }
-//.. 
+//..
 //..    hWordTy = sizeof(HWord)==4 ? Ity_I32 : Ity_I64;
-//.. 
+//..
 //..    seg_selector = newTemp(Ity_I32);
 //..    ldt_ptr      = newTemp(hWordTy);
 //..    gdt_ptr      = newTemp(hWordTy);
 //..    r64          = newTemp(Ity_I64);
-//.. 
+//..
 //..    assign( seg_selector, unop(Iop_16Uto32, getSReg(sreg)) );
 //..    assign( ldt_ptr, IRExpr_Get( OFFB_LDT, hWordTy ));
 //..    assign( gdt_ptr, IRExpr_Get( OFFB_GDT, hWordTy ));
-//.. 
+//..
 //..    /*
-//..    Call this to do the translation and limit checks: 
+//..    Call this to do the translation and limit checks:
 //..    ULong x86g_use_seg_selector ( HWord ldt, HWord gdt,
 //..                                  UInt seg_selector, UInt virtual_addr )
 //..    */
-//..    assign( 
-//..       r64, 
-//..       mkIRExprCCall( 
-//..          Ity_I64, 
-//..          0/*regparms*/, 
-//..          "x86g_use_seg_selector", 
-//..          &x86g_use_seg_selector, 
-//..          mkIRExprVec_4( mkexpr(ldt_ptr), mkexpr(gdt_ptr), 
+//..    assign(
+//..       r64,
+//..       mkIRExprCCall(
+//..          Ity_I64,
+//..          0/*regparms*/,
+//..          "x86g_use_seg_selector",
+//..          &x86g_use_seg_selector,
+//..          mkIRExprVec_4( mkexpr(ldt_ptr), mkexpr(gdt_ptr),
 //..                         mkexpr(seg_selector), virtual)
 //..       )
 //..    );
-//.. 
-//..    /* If the high 32 of the result are non-zero, there was a 
+//..
+//..    /* If the high 32 of the result are non-zero, there was a
 //..       failure in address translation.  In which case, make a
 //..       quick exit.
 //..    */
-//..    stmt( 
+//..    stmt(
 //..       IRStmt_Exit(
 //..          binop(Iop_CmpNE32, unop(Iop_64HIto32, mkexpr(r64)), mkU32(0)),
 //..          Ijk_MapFail,
 //..          IRConst_U32( guest_eip_curr_instr )
 //..       )
 //..    );
-//.. 
+//..
 //..    /* otherwise, here's the translated result. */
 //..    return unop(Iop_64to32, mkexpr(r64));
 //.. }
@@ -2443,9 +2443,9 @@ static IRTemp disAMode_copy2tmp ( IRExpr* addr64 )
    return tmp;
 }
 
-static 
+static
 IRTemp disAMode ( /*OUT*/Int* len,
-                  VexAbiInfo* vbi, Prefix pfx, Long delta, 
+                  VexAbiInfo* vbi, Prefix pfx, Long delta,
                   /*OUT*/HChar* buf, Int extra_bytes )
 {
    UChar mod_reg_rm = getUChar(delta);
@@ -2455,7 +2455,7 @@ IRTemp disAMode ( /*OUT*/Int* len,
    vassert(extra_bytes >= 0 && extra_bytes < 10);
 
    /* squeeze out the reg field from mod_reg_rm, since a 256-entry
-      jump table seems a bit excessive. 
+      jump table seems a bit excessive.
    */
    mod_reg_rm &= 0xC7;                         /* is now XX000YYY */
    mod_reg_rm  = toUChar(mod_reg_rm | (mod_reg_rm >> 3));
@@ -2466,7 +2466,7 @@ IRTemp disAMode ( /*OUT*/Int* len,
       /* REX.B==0: (%rax) .. (%rdi), not including (%rsp) or (%rbp).
          REX.B==1: (%r8)  .. (%r15), not including (%r12) or (%r13).
       */
-      case 0x00: case 0x01: case 0x02: case 0x03: 
+      case 0x00: case 0x01: case 0x02: case 0x03:
       /* ! 04 */ /* ! 05 */ case 0x06: case 0x07:
          { UChar rm = toUChar(mod_reg_rm & 7);
            DIS(buf, "%s(%s)", segRegTxt(pfx), nameIRegRexB(8,pfx,rm));
@@ -2475,10 +2475,10 @@ IRTemp disAMode ( /*OUT*/Int* len,
                   handleAddrOverrides(vbi, pfx, getIRegRexB(8,pfx,rm)));
          }
 
-      /* REX.B==0: d8(%rax) ... d8(%rdi), not including d8(%rsp) 
-         REX.B==1: d8(%r8)  ... d8(%r15), not including d8(%r12) 
+      /* REX.B==0: d8(%rax) ... d8(%rdi), not including d8(%rsp)
+         REX.B==1: d8(%r8)  ... d8(%r15), not including d8(%r12)
       */
-      case 0x08: case 0x09: case 0x0A: case 0x0B: 
+      case 0x08: case 0x09: case 0x0A: case 0x0B:
       /* ! 0C */ case 0x0D: case 0x0E: case 0x0F:
          { UChar rm = toUChar(mod_reg_rm & 7);
            Long d   = getSDisp8(delta);
@@ -2496,7 +2496,7 @@ IRTemp disAMode ( /*OUT*/Int* len,
       /* REX.B==0: d32(%rax) ... d32(%rdi), not including d32(%rsp)
          REX.B==1: d32(%r8)  ... d32(%r15), not including d32(%r12)
       */
-      case 0x10: case 0x11: case 0x12: case 0x13: 
+      case 0x10: case 0x11: case 0x12: case 0x13:
       /* ! 14 */ case 0x15: case 0x16: case 0x17:
          { UChar rm = toUChar(mod_reg_rm & 7);
            Long  d  = getSDisp32(delta);
@@ -2515,7 +2515,7 @@ IRTemp disAMode ( /*OUT*/Int* len,
 
       /* RIP + disp32.  This assumes that guest_RIP_curr_instr is set
          correctly at the start of handling each instruction. */
-      case 0x05: 
+      case 0x05:
          { Long d = getSDisp32(delta);
            *len = 5;
            DIS(buf, "%s%lld(%%rip)", segRegTxt(pfx), d);
@@ -2525,21 +2525,21 @@ IRTemp disAMode ( /*OUT*/Int* len,
               guessed right, after the instruction is completely
               decoded. */
            guest_RIP_next_mustcheck = True;
-           guest_RIP_next_assumed = guest_RIP_bbstart 
+           guest_RIP_next_assumed = guest_RIP_bbstart
                                     + delta+4 + extra_bytes;
-           return disAMode_copy2tmp( 
-                     handleAddrOverrides(vbi, pfx, 
-                        binop(Iop_Add64, mkU64(guest_RIP_next_assumed), 
+           return disAMode_copy2tmp(
+                     handleAddrOverrides(vbi, pfx,
+                        binop(Iop_Add64, mkU64(guest_RIP_next_assumed),
                                          mkU64(d))));
          }
 
       case 0x04: {
          /* SIB, with no displacement.  Special cases:
-            -- %rsp cannot act as an index value.  
+            -- %rsp cannot act as an index value.
                If index_r indicates %rsp, zero is used for the index.
-            -- when mod is zero and base indicates RBP or R13, base is 
+            -- when mod is zero and base indicates RBP or R13, base is
                instead a 32-bit sign-extended literal.
-            It's all madness, I tell you.  Extract %index, %base and 
+            It's all madness, I tell you.  Extract %index, %base and
             scale from the SIB byte.  The value denoted is then:
                | %index == %RSP && (%base == %RBP || %base == %R13)
                = d32 following SIB byte
@@ -2561,19 +2561,19 @@ IRTemp disAMode ( /*OUT*/Int* len,
 
          if ((!index_is_SP) && (!base_is_BPor13)) {
             if (scale == 0) {
-               DIS(buf, "%s(%s,%s)", segRegTxt(pfx), 
-                         nameIRegRexB(8,pfx,base_r), 
+               DIS(buf, "%s(%s,%s)", segRegTxt(pfx),
+                         nameIRegRexB(8,pfx,base_r),
                          nameIReg64rexX(pfx,index_r));
             } else {
-               DIS(buf, "%s(%s,%s,%d)", segRegTxt(pfx), 
-                         nameIRegRexB(8,pfx,base_r), 
+               DIS(buf, "%s(%s,%s,%d)", segRegTxt(pfx),
+                         nameIRegRexB(8,pfx,base_r),
                          nameIReg64rexX(pfx,index_r), 1<<scale);
             }
             *len = 2;
             return
-               disAMode_copy2tmp( 
+               disAMode_copy2tmp(
                handleAddrOverrides(vbi, pfx,
-                  binop(Iop_Add64, 
+                  binop(Iop_Add64,
                         getIRegRexB(8,pfx,base_r),
                         binop(Iop_Shl64, getIReg64rexX(pfx,index_r),
                               mkU8(scale)))));
@@ -2581,14 +2581,14 @@ IRTemp disAMode ( /*OUT*/Int* len,
 
          if ((!index_is_SP) && base_is_BPor13) {
             Long d = getSDisp32(delta);
-            DIS(buf, "%s%lld(,%s,%d)", segRegTxt(pfx), d, 
+            DIS(buf, "%s%lld(,%s,%d)", segRegTxt(pfx), d,
                       nameIReg64rexX(pfx,index_r), 1<<scale);
             *len = 6;
             return
                disAMode_copy2tmp(
-               handleAddrOverrides(vbi, pfx, 
+               handleAddrOverrides(vbi, pfx,
                   binop(Iop_Add64,
-                        binop(Iop_Shl64, getIReg64rexX(pfx,index_r), 
+                        binop(Iop_Shl64, getIReg64rexX(pfx,index_r),
                                          mkU8(scale)),
                         mkU64(d))));
          }
@@ -2612,7 +2612,7 @@ IRTemp disAMode ( /*OUT*/Int* len,
       }
 
       /* SIB, with 8-bit displacement.  Special cases:
-         -- %esp cannot act as an index value.  
+         -- %esp cannot act as an index value.
             If index_r indicates %esp, zero is used for the index.
          Denoted value is:
             | %index == %ESP
@@ -2628,30 +2628,30 @@ IRTemp disAMode ( /*OUT*/Int* len,
          Long d        = getSDisp8(delta+1);
 
          if (index_r == R_RSP && 0==getRexX(pfx)) {
-            DIS(buf, "%s%lld(%s)", segRegTxt(pfx), 
+            DIS(buf, "%s%lld(%s)", segRegTxt(pfx),
                                    d, nameIRegRexB(8,pfx,base_r));
             *len = 3;
             return disAMode_copy2tmp(
-                   handleAddrOverrides(vbi, pfx, 
+                   handleAddrOverrides(vbi, pfx,
                       binop(Iop_Add64, getIRegRexB(8,pfx,base_r), mkU64(d)) ));
          } else {
             if (scale == 0) {
-               DIS(buf, "%s%lld(%s,%s)", segRegTxt(pfx), d, 
-                         nameIRegRexB(8,pfx,base_r), 
+               DIS(buf, "%s%lld(%s,%s)", segRegTxt(pfx), d,
+                         nameIRegRexB(8,pfx,base_r),
                          nameIReg64rexX(pfx,index_r));
             } else {
-               DIS(buf, "%s%lld(%s,%s,%d)", segRegTxt(pfx), d, 
-                         nameIRegRexB(8,pfx,base_r), 
+               DIS(buf, "%s%lld(%s,%s,%d)", segRegTxt(pfx), d,
+                         nameIRegRexB(8,pfx,base_r),
                          nameIReg64rexX(pfx,index_r), 1<<scale);
             }
             *len = 3;
-            return 
+            return
                 disAMode_copy2tmp(
                 handleAddrOverrides(vbi, pfx,
                   binop(Iop_Add64,
-                        binop(Iop_Add64, 
-                              getIRegRexB(8,pfx,base_r), 
-                              binop(Iop_Shl64, 
+                        binop(Iop_Add64,
+                              getIRegRexB(8,pfx,base_r),
+                              binop(Iop_Shl64,
                                     getIReg64rexX(pfx,index_r), mkU8(scale))),
                         mkU64(d))));
          }
@@ -2659,7 +2659,7 @@ IRTemp disAMode ( /*OUT*/Int* len,
       }
 
       /* SIB, with 32-bit displacement.  Special cases:
-         -- %rsp cannot act as an index value.  
+         -- %rsp cannot act as an index value.
             If index_r indicates %rsp, zero is used for the index.
          Denoted value is:
             | %index == %RSP
@@ -2675,30 +2675,30 @@ IRTemp disAMode ( /*OUT*/Int* len,
          Long d        = getSDisp32(delta+1);
 
          if (index_r == R_RSP && 0==getRexX(pfx)) {
-            DIS(buf, "%s%lld(%s)", segRegTxt(pfx), 
+            DIS(buf, "%s%lld(%s)", segRegTxt(pfx),
                                    d, nameIRegRexB(8,pfx,base_r));
             *len = 6;
             return disAMode_copy2tmp(
-                   handleAddrOverrides(vbi, pfx, 
+                   handleAddrOverrides(vbi, pfx,
                       binop(Iop_Add64, getIRegRexB(8,pfx,base_r), mkU64(d)) ));
          } else {
             if (scale == 0) {
-               DIS(buf, "%s%lld(%s,%s)", segRegTxt(pfx), d, 
-                         nameIRegRexB(8,pfx,base_r), 
+               DIS(buf, "%s%lld(%s,%s)", segRegTxt(pfx), d,
+                         nameIRegRexB(8,pfx,base_r),
                          nameIReg64rexX(pfx,index_r));
             } else {
-               DIS(buf, "%s%lld(%s,%s,%d)", segRegTxt(pfx), d, 
-                         nameIRegRexB(8,pfx,base_r), 
+               DIS(buf, "%s%lld(%s,%s,%d)", segRegTxt(pfx), d,
+                         nameIRegRexB(8,pfx,base_r),
                          nameIReg64rexX(pfx,index_r), 1<<scale);
             }
             *len = 6;
-            return 
+            return
                 disAMode_copy2tmp(
                 handleAddrOverrides(vbi, pfx,
                   binop(Iop_Add64,
-                        binop(Iop_Add64, 
-                              getIRegRexB(8,pfx,base_r), 
-                              binop(Iop_Shl64, 
+                        binop(Iop_Add64,
+                              getIRegRexB(8,pfx,base_r),
+                              binop(Iop_Shl64,
                                     getIReg64rexX(pfx,index_r), mkU8(scale))),
                         mkU64(d))));
          }
@@ -2804,7 +2804,7 @@ static UInt lengthAMode ( Prefix pfx, Long delta )
    delta++;
 
    /* squeeze out the reg field from mod_reg_rm, since a 256-entry
-      jump table seems a bit excessive. 
+      jump table seems a bit excessive.
    */
    mod_reg_rm &= 0xC7;                         /* is now XX000YYY */
    mod_reg_rm  = toUChar(mod_reg_rm | (mod_reg_rm >> 3));
@@ -2815,21 +2815,21 @@ static UInt lengthAMode ( Prefix pfx, Long delta )
       /* REX.B==0: (%rax) .. (%rdi), not including (%rsp) or (%rbp).
          REX.B==1: (%r8)  .. (%r15), not including (%r12) or (%r13).
       */
-      case 0x00: case 0x01: case 0x02: case 0x03: 
+      case 0x00: case 0x01: case 0x02: case 0x03:
       /* ! 04 */ /* ! 05 */ case 0x06: case 0x07:
          return 1;
 
-      /* REX.B==0: d8(%rax) ... d8(%rdi), not including d8(%rsp) 
-         REX.B==1: d8(%r8)  ... d8(%r15), not including d8(%r12) 
+      /* REX.B==0: d8(%rax) ... d8(%rdi), not including d8(%rsp)
+         REX.B==1: d8(%r8)  ... d8(%r15), not including d8(%r12)
       */
-      case 0x08: case 0x09: case 0x0A: case 0x0B: 
+      case 0x08: case 0x09: case 0x0A: case 0x0B:
       /* ! 0C */ case 0x0D: case 0x0E: case 0x0F:
          return 2;
 
       /* REX.B==0: d32(%rax) ... d32(%rdi), not including d32(%rsp)
          REX.B==1: d32(%r8)  ... d32(%r15), not including d32(%r12)
       */
-      case 0x10: case 0x11: case 0x12: case 0x13: 
+      case 0x10: case 0x11: case 0x12: case 0x13:
       /* ! 14 */ case 0x15: case 0x16: case 0x17:
          return 5;
 
@@ -2841,7 +2841,7 @@ static UInt lengthAMode ( Prefix pfx, Long delta )
          return 1;
 
       /* RIP + disp32. */
-      case 0x05: 
+      case 0x05:
          return 5;
 
       case 0x04: {
@@ -2890,8 +2890,8 @@ static UInt lengthAMode ( Prefix pfx, Long delta )
    If E is reg, -->    GET %G,  tmp
                        OP %E,   tmp
                        PUT tmp, %G
- 
-   If E is mem and OP is not reversible, 
+
+   If E is mem and OP is not reversible,
                 -->    (getAddr E) -> tmpa
                        LD (tmpa), tmpa
                        GET %G, tmp2
@@ -2908,9 +2908,9 @@ static
 ULong dis_op2_E_G ( VexAbiInfo* vbi,
                     Prefix      pfx,
                     Bool        addSubCarry,
-                    IROp        op8, 
+                    IROp        op8,
                     Bool        keep,
-                    Int         size, 
+                    Int         size,
                     Long        delta0,
                     const HChar* t_amd64opc )
 {
@@ -2964,7 +2964,7 @@ ULong dis_op2_E_G ( VexAbiInfo* vbi,
             putIRegG(size, pfx, rm, mkexpr(dst1));
       }
 
-      DIP("%s%c %s,%s\n", t_amd64opc, nameISize(size), 
+      DIP("%s%c %s,%s\n", t_amd64opc, nameISize(size),
                           nameIRegE(size,pfx,rm),
                           nameIRegG(size,pfx,rm));
       return 1+delta0;
@@ -2993,7 +2993,7 @@ ULong dis_op2_E_G ( VexAbiInfo* vbi,
             putIRegG(size, pfx, rm, mkexpr(dst1));
       }
 
-      DIP("%s%c %s,%s\n", t_amd64opc, nameISize(size), 
+      DIP("%s%c %s,%s\n", t_amd64opc, nameISize(size),
                           dis_buf, nameIRegG(size, pfx, rm));
       return len+delta0;
    }
@@ -3014,7 +3014,7 @@ ULong dis_op2_E_G ( VexAbiInfo* vbi,
    If E is reg, -->    GET %E,  tmp
                        OP %G,   tmp
                        PUT tmp, %E
- 
+
    If E is mem, -->    (getAddr E) -> tmpa
                        LD (tmpa), tmpv
                        OP %G, tmpv
@@ -3024,9 +3024,9 @@ static
 ULong dis_op2_G_E ( VexAbiInfo* vbi,
                     Prefix      pfx,
                     Bool        addSubCarry,
-                    IROp        op8, 
+                    IROp        op8,
                     Bool        keep,
-                    Int         size, 
+                    Int         size,
                     Long        delta0,
                     const HChar* t_amd64opc )
 {
@@ -3078,13 +3078,13 @@ ULong dis_op2_G_E ( VexAbiInfo* vbi,
             putIRegE(size, pfx, rm, mkexpr(dst1));
       }
 
-      DIP("%s%c %s,%s\n", t_amd64opc, nameISize(size), 
+      DIP("%s%c %s,%s\n", t_amd64opc, nameISize(size),
                           nameIRegG(size,pfx,rm),
                           nameIRegE(size,pfx,rm));
       return 1+delta0;
    }
 
-   /* E refers to memory */    
+   /* E refers to memory */
    {
       addr = disAMode ( &len, vbi, pfx, delta0, dis_buf, 0 );
       assign(dst0, loadLE(ty,mkexpr(addr)));
@@ -3117,7 +3117,7 @@ ULong dis_op2_G_E ( VexAbiInfo* vbi,
             if (haveLOCK(pfx)) {
                if (0) vex_printf("locked case\n" );
                casLE( mkexpr(addr),
-                      mkexpr(dst0)/*expval*/, 
+                      mkexpr(dst0)/*expval*/,
                       mkexpr(dst1)/*newval*/, guest_RIP_curr_instr );
             } else {
                if (0) vex_printf("nonlocked case\n");
@@ -3130,7 +3130,7 @@ ULong dis_op2_G_E ( VexAbiInfo* vbi,
             setFlags_DEP1(op8, dst1, ty);
       }
 
-      DIP("%s%c %s,%s\n", t_amd64opc, nameISize(size), 
+      DIP("%s%c %s,%s\n", t_amd64opc, nameISize(size),
                           nameIRegG(size,pfx,rm), dis_buf);
       return len+delta0;
    }
@@ -3148,7 +3148,7 @@ ULong dis_op2_G_E ( VexAbiInfo* vbi,
 
    If E is reg, -->    GET %E,  tmpv
                        PUT tmpv, %G
- 
+
    If E is mem  -->    (getAddr E) -> tmpa
                        LD (tmpa), tmpb
                        PUT tmpb, %G
@@ -3156,7 +3156,7 @@ ULong dis_op2_G_E ( VexAbiInfo* vbi,
 static
 ULong dis_mov_E_G ( VexAbiInfo* vbi,
                     Prefix      pfx,
-                    Int         size, 
+                    Int         size,
                     Long        delta0 )
 {
    Int len;
@@ -3171,11 +3171,11 @@ ULong dis_mov_E_G ( VexAbiInfo* vbi,
       return 1+delta0;
    }
 
-   /* E refers to memory */    
+   /* E refers to memory */
    {
       IRTemp addr = disAMode ( &len, vbi, pfx, delta0, dis_buf, 0 );
       putIRegG(size, pfx, rm, loadLE(szToITy(size), mkexpr(addr)));
-      DIP("mov%c %s,%s\n", nameISize(size), 
+      DIP("mov%c %s,%s\n", nameISize(size),
                            dis_buf,
                            nameIRegG(size,pfx,rm));
       return delta0+len;
@@ -3195,15 +3195,15 @@ ULong dis_mov_E_G ( VexAbiInfo* vbi,
 
    If E is reg, -->    GET %G,  tmp
                        PUT tmp, %E
- 
+
    If E is mem, -->    (getAddr E) -> tmpa
                        GET %G, tmpv
-                       ST tmpv, (tmpa) 
+                       ST tmpv, (tmpa)
 */
 static
 ULong dis_mov_G_E ( VexAbiInfo*  vbi,
                     Prefix       pfx,
-                    Int          size, 
+                    Int          size,
                     Long         delta0,
                     /*OUT*/Bool* ok )
 {
@@ -3222,14 +3222,14 @@ ULong dis_mov_G_E ( VexAbiInfo*  vbi,
       return 1+delta0;
    }
 
-   /* E refers to memory */    
+   /* E refers to memory */
    {
       if (haveF2(pfx)) { *ok = False; return delta0; }
       /* F3(XRELEASE) is acceptable, though. */
       IRTemp addr = disAMode ( &len, vbi, pfx, delta0, dis_buf, 0 );
       storeLE( mkexpr(addr), getIRegG(size, pfx, rm) );
-      DIP("mov%c %s,%s\n", nameISize(size), 
-                           nameIRegG(size,pfx,rm), 
+      DIP("mov%c %s,%s\n", nameISize(size),
+                           nameIRegG(size,pfx,rm),
                            dis_buf);
       return len+delta0;
    }
@@ -3280,7 +3280,7 @@ ULong dis_op_imm_A ( Int    size,
    if (keep)
       putIRegRAX(size, mkexpr(dst1));
 
-   DIP("%s%c $%lld, %s\n", t_amd64opc, nameISize(size), 
+   DIP("%s%c $%lld, %s\n", t_amd64opc, nameISize(size),
                            lit, nameIRegRAX(size));
    return delta+size4;
 }
@@ -3299,26 +3299,26 @@ ULong dis_movx_E_G ( VexAbiInfo* vbi,
                        szs,szd,sign_extend,
                        getIRegE(szs,pfx,rm)));
       DIP("mov%c%c%c %s,%s\n", sign_extend ? 's' : 'z',
-                               nameISize(szs), 
+                               nameISize(szs),
                                nameISize(szd),
                                nameIRegE(szs,pfx,rm),
                                nameIRegG(szd,pfx,rm));
       return 1+delta;
    }
 
-   /* E refers to memory */    
+   /* E refers to memory */
    {
       Int    len;
       HChar  dis_buf[50];
       IRTemp addr = disAMode ( &len, vbi, pfx, delta, dis_buf, 0 );
       putIRegG(szd, pfx, rm,
                     doScalarWidening(
-                       szs,szd,sign_extend, 
+                       szs,szd,sign_extend,
                        loadLE(szToITy(szs),mkexpr(addr))));
       DIP("mov%c%c%c %s,%s\n", sign_extend ? 's' : 'z',
-                               nameISize(szs), 
+                               nameISize(szs),
                                nameISize(szd),
-                               dis_buf, 
+                               dis_buf,
                                nameIRegG(szd,pfx,rm));
       return len+delta;
    }
@@ -3332,26 +3332,26 @@ void codegen_div ( Int sz, IRTemp t, Bool signed_divide )
 {
    /* special-case the 64-bit case */
    if (sz == 8) {
-      IROp   op     = signed_divide ? Iop_DivModS128to64 
+      IROp   op     = signed_divide ? Iop_DivModS128to64
                                     : Iop_DivModU128to64;
       IRTemp src128 = newTemp(Ity_I128);
       IRTemp dst128 = newTemp(Ity_I128);
-      assign( src128, binop(Iop_64HLto128, 
-                            getIReg64(R_RDX), 
+      assign( src128, binop(Iop_64HLto128,
+                            getIReg64(R_RDX),
                             getIReg64(R_RAX)) );
       assign( dst128, binop(op, mkexpr(src128), mkexpr(t)) );
       putIReg64( R_RAX, unop(Iop_128to64,mkexpr(dst128)) );
       putIReg64( R_RDX, unop(Iop_128HIto64,mkexpr(dst128)) );
    } else {
-      IROp   op    = signed_divide ? Iop_DivModS64to32 
+      IROp   op    = signed_divide ? Iop_DivModS64to32
                                    : Iop_DivModU64to32;
       IRTemp src64 = newTemp(Ity_I64);
       IRTemp dst64 = newTemp(Ity_I64);
       switch (sz) {
       case 4:
-         assign( src64, 
+         assign( src64,
                  binop(Iop_32HLto64, getIRegRDX(4), getIRegRAX(4)) );
-         assign( dst64, 
+         assign( dst64,
                  binop(op, mkexpr(src64), mkexpr(t)) );
          putIRegRAX( 4, unop(Iop_64to32,mkexpr(dst64)) );
          putIRegRDX( 4, unop(Iop_64HIto32,mkexpr(dst64)) );
@@ -3360,8 +3360,8 @@ void codegen_div ( Int sz, IRTemp t, Bool signed_divide )
          IROp widen3264 = signed_divide ? Iop_32Sto64 : Iop_32Uto64;
          IROp widen1632 = signed_divide ? Iop_16Sto32 : Iop_16Uto32;
          assign( src64, unop(widen3264,
-                             binop(Iop_16HLto32, 
-                                   getIRegRDX(2), 
+                             binop(Iop_16HLto32,
+                                   getIRegRDX(2),
                                    getIRegRAX(2))) );
          assign( dst64, binop(op, mkexpr(src64), unop(widen1632,mkexpr(t))) );
          putIRegRAX( 2, unop(Iop_32to16,unop(Iop_64to32,mkexpr(dst64))) );
@@ -3372,29 +3372,29 @@ void codegen_div ( Int sz, IRTemp t, Bool signed_divide )
          IROp widen3264 = signed_divide ? Iop_32Sto64 : Iop_32Uto64;
          IROp widen1632 = signed_divide ? Iop_16Sto32 : Iop_16Uto32;
          IROp widen816  = signed_divide ? Iop_8Sto16  : Iop_8Uto16;
-         assign( src64, unop(widen3264, 
+         assign( src64, unop(widen3264,
                         unop(widen1632, getIRegRAX(2))) );
-         assign( dst64, 
-                 binop(op, mkexpr(src64), 
+         assign( dst64,
+                 binop(op, mkexpr(src64),
                            unop(widen1632, unop(widen816, mkexpr(t)))) );
-         putIRegRAX( 1, unop(Iop_16to8, 
+         putIRegRAX( 1, unop(Iop_16to8,
                         unop(Iop_32to16,
                         unop(Iop_64to32,mkexpr(dst64)))) );
-         putIRegAH( unop(Iop_16to8, 
+         putIRegAH( unop(Iop_16to8,
                     unop(Iop_32to16,
                     unop(Iop_64HIto32,mkexpr(dst64)))) );
          break;
       }
-      default: 
+      default:
          vpanic("codegen_div(amd64)");
       }
    }
 }
 
-static 
+static
 ULong dis_Grp1 ( VexAbiInfo* vbi,
                  Prefix pfx,
-                 Long delta, UChar modrm, 
+                 Long delta, UChar modrm,
                  Int am_sz, Int d_sz, Int sz, Long d64 )
 {
    Int     len;
@@ -3426,7 +3426,7 @@ ULong dis_Grp1 ( VexAbiInfo* vbi,
       if (gregLO3ofRM(modrm) == 2 /* ADC */) {
          helper_ADC( sz, dst1, dst0, src,
                      /*no store*/IRTemp_INVALID, IRTemp_INVALID, 0 );
-      } else 
+      } else
       if (gregLO3ofRM(modrm) == 3 /* SBB */) {
          helper_SBB( sz, dst1, dst0, src,
                      /*no store*/IRTemp_INVALID, IRTemp_INVALID, 0 );
@@ -3442,8 +3442,8 @@ ULong dis_Grp1 ( VexAbiInfo* vbi,
          putIRegE(sz, pfx, modrm, mkexpr(dst1));
 
       delta += (am_sz + d_sz);
-      DIP("%s%c $%lld, %s\n", 
-          nameGrp1(gregLO3ofRM(modrm)), nameISize(sz), d64, 
+      DIP("%s%c $%lld, %s\n",
+          nameGrp1(gregLO3ofRM(modrm)), nameISize(sz), d64,
           nameIRegE(sz,pfx,modrm));
    } else {
       addr = disAMode ( &len, vbi, pfx, delta, dis_buf, /*xtra*/d_sz );
@@ -3461,7 +3461,7 @@ ULong dis_Grp1 ( VexAbiInfo* vbi,
             helper_ADC( sz, dst1, dst0, src,
                         /*store*/addr, IRTemp_INVALID, 0 );
          }
-      } else 
+      } else
       if (gregLO3ofRM(modrm) == 3 /* SBB */) {
          if (haveLOCK(pfx)) {
             /* cas-style store */
@@ -3476,7 +3476,7 @@ ULong dis_Grp1 ( VexAbiInfo* vbi,
          assign(dst1, binop(mkSizedOp(ty,op8), mkexpr(dst0), mkexpr(src)));
          if (gregLO3ofRM(modrm) < 7) {
             if (haveLOCK(pfx)) {
-               casLE( mkexpr(addr), mkexpr(dst0)/*expVal*/, 
+               casLE( mkexpr(addr), mkexpr(dst0)/*expVal*/,
                                     mkexpr(dst1)/*newVal*/,
                                     guest_RIP_curr_instr );
             } else {
@@ -3490,7 +3490,7 @@ ULong dis_Grp1 ( VexAbiInfo* vbi,
       }
 
       delta += (len+d_sz);
-      DIP("%s%c $%lld, %s\n", 
+      DIP("%s%c $%lld, %s\n",
           nameGrp1(gregLO3ofRM(modrm)), nameISize(sz),
           d64, dis_buf);
    }
@@ -3569,25 +3569,25 @@ ULong dis_Grp2 ( VexAbiInfo* vbi,
                           widenUto64(shift_expr),   /* rotate amount */
                           mkexpr(old_rflags),
                           mkU64(sz) );
-      assign( new_value, 
+      assign( new_value,
                  mkIRExprCCall(
-                    Ity_I64, 
-                    0/*regparm*/, 
+                    Ity_I64,
+                    0/*regparm*/,
                     left ? "amd64g_calculate_RCL" : "amd64g_calculate_RCR",
                     left ? &amd64g_calculate_RCL  : &amd64g_calculate_RCR,
                     argsVALUE
                  )
             );
-      
+
       argsRFLAGS
          = mkIRExprVec_4( widenUto64(mkexpr(dst0)), /* thing to rotate */
                           widenUto64(shift_expr),   /* rotate amount */
                           mkexpr(old_rflags),
                           mkU64(-sz) );
-      assign( new_rflags, 
+      assign( new_rflags,
                  mkIRExprCCall(
-                    Ity_I64, 
-                    0/*regparm*/, 
+                    Ity_I64,
+                    0/*regparm*/,
                     left ? "amd64g_calculate_RCL" : "amd64g_calculate_RCR",
                     left ? &amd64g_calculate_RCL  : &amd64g_calculate_RCR,
                     argsRFLAGS
@@ -3611,7 +3611,7 @@ ULong dis_Grp2 ( VexAbiInfo* vbi,
       UChar  mask      = toUChar(sz==8 ? 63 : 31);
       IROp   op64;
 
-      switch (gregLO3ofRM(modrm)) { 
+      switch (gregLO3ofRM(modrm)) {
          case 4: op64 = Iop_Shl64; break;
          case 5: op64 = Iop_Shr64; break;
          case 6: op64 = Iop_Shl64; break;
@@ -3628,7 +3628,7 @@ ULong dis_Grp2 ( VexAbiInfo* vbi,
          advantage that the only IR level shifts generated are of 64
          bit values, and the shift amount is guaranteed to be in the
          range 0 .. 63, thereby observing the IR semantics requiring
-         all shift values to be in the range 0 .. 2^word_size-1. 
+         all shift values to be in the range 0 .. 2^word_size-1.
 
          Therefore the shift amount is masked with 63 for 64-bit shifts
          and 31 for all others.
@@ -3646,7 +3646,7 @@ ULong dis_Grp2 ( VexAbiInfo* vbi,
       /* res64ss = pre64 `shift` ((shift_amt - 1) & MASK) */
       assign( res64ss,
               binop(op64,
-                    mkexpr(pre64), 
+                    mkexpr(pre64),
                     binop(Iop_And8,
                           binop(Iop_Sub8,
                                 mkexpr(shift_amt), mkU8(1)),
@@ -3660,9 +3660,9 @@ ULong dis_Grp2 ( VexAbiInfo* vbi,
 
    } /* if (isShift) */
 
-   else 
+   else
    if (isRotate) {
-      Int    ccOp      = ty==Ity_I8 ? 0 : (ty==Ity_I16 ? 1 
+      Int    ccOp      = ty==Ity_I8 ? 0 : (ty==Ity_I16 ? 1
                                         : (ty==Ity_I32 ? 2 : 3));
       Bool   left      = toBool(gregLO3ofRM(modrm) == 0);
       IRTemp rot_amt   = newTemp(Ity_I8);
@@ -3684,14 +3684,14 @@ ULong dis_Grp2 ( VexAbiInfo* vbi,
       if (left) {
 
          /* dst1 = (dst0 << rot_amt) | (dst0 >>u (wordsize-rot_amt)) */
-         assign(dst1, 
+         assign(dst1,
             binop( mkSizedOp(ty,Iop_Or8),
-                   binop( mkSizedOp(ty,Iop_Shl8), 
+                   binop( mkSizedOp(ty,Iop_Shl8),
                           mkexpr(dst0),
                           mkexpr(rot_amt)
                    ),
-                   binop( mkSizedOp(ty,Iop_Shr8), 
-                          mkexpr(dst0), 
+                   binop( mkSizedOp(ty,Iop_Shr8),
+                          mkexpr(dst0),
                           binop(Iop_Sub8,mkU8(8*sz), mkexpr(rot_amt))
                    )
             )
@@ -3701,14 +3701,14 @@ ULong dis_Grp2 ( VexAbiInfo* vbi,
       } else { /* right */
 
          /* dst1 = (dst0 >>u rot_amt) | (dst0 << (wordsize-rot_amt)) */
-         assign(dst1, 
+         assign(dst1,
             binop( mkSizedOp(ty,Iop_Or8),
-                   binop( mkSizedOp(ty,Iop_Shr8), 
+                   binop( mkSizedOp(ty,Iop_Shr8),
                           mkexpr(dst0),
                           mkexpr(rot_amt)
                    ),
-                   binop( mkSizedOp(ty,Iop_Shl8), 
-                          mkexpr(dst0), 
+                   binop( mkSizedOp(ty,Iop_Shl8),
+                          mkexpr(dst0),
                           binop(Iop_Sub8,mkU8(8*sz), mkexpr(rot_amt))
                    )
             )
@@ -3732,15 +3732,15 @@ ULong dis_Grp2 ( VexAbiInfo* vbi,
                         IRExpr_ITE( mkexpr(rot_amt64b),
                                     mkU64(ccOp),
                                     IRExpr_Get(OFFB_CC_OP,Ity_I64) ) ));
-      stmt( IRStmt_Put( OFFB_CC_DEP1, 
+      stmt( IRStmt_Put( OFFB_CC_DEP1,
                         IRExpr_ITE( mkexpr(rot_amt64b),
                                     widenUto64(mkexpr(dst1)),
                                     IRExpr_Get(OFFB_CC_DEP1,Ity_I64) ) ));
-      stmt( IRStmt_Put( OFFB_CC_DEP2, 
+      stmt( IRStmt_Put( OFFB_CC_DEP2,
                         IRExpr_ITE( mkexpr(rot_amt64b),
                                     mkU64(0),
                                     IRExpr_Get(OFFB_CC_DEP2,Ity_I64) ) ));
-      stmt( IRStmt_Put( OFFB_CC_NDEP, 
+      stmt( IRStmt_Put( OFFB_CC_NDEP,
                         IRExpr_ITE( mkexpr(rot_amt64b),
                                     mkexpr(oldFlags),
                                     IRExpr_Get(OFFB_CC_NDEP,Ity_I64) ) ));
@@ -3842,7 +3842,7 @@ ULong dis_Grp8_Imm ( VexAbiInfo* vbi,
       vassert(am_sz == 1);
       assign( t2, widenUto64(getIRegE(sz, pfx, modrm)) );
       delta += (am_sz + 1);
-      DIP("%s%c $0x%llx, %s\n", nameGrp8(gregLO3ofRM(modrm)), 
+      DIP("%s%c $0x%llx, %s\n", nameGrp8(gregLO3ofRM(modrm)),
                                 nameISize(sz),
                                 src_val, nameIRegE(sz,pfx,modrm));
    } else {
@@ -3850,7 +3850,7 @@ ULong dis_Grp8_Imm ( VexAbiInfo* vbi,
       t_addr = disAMode ( &len, vbi, pfx, delta, dis_buf, 1 );
       delta  += (len+1);
       assign( t2, widenUto64(loadLE(ty, mkexpr(t_addr))) );
-      DIP("%s%c $0x%llx, %s\n", nameGrp8(gregLO3ofRM(modrm)), 
+      DIP("%s%c $0x%llx, %s\n", nameGrp8(gregLO3ofRM(modrm)),
                                 nameISize(sz),
                                 src_val, dis_buf);
    }
@@ -3868,7 +3868,7 @@ ULong dis_Grp8_Imm ( VexAbiInfo* vbi,
       case 7: /* BTC */
          assign( t2m, binop(Iop_Xor64, mkU64(mask), mkexpr(t2)) );
          break;
-     default: 
+     default:
          /*NOTREACHED*/ /*the previous switch guards this*/
          vassert(0);
    }
@@ -3893,7 +3893,7 @@ ULong dis_Grp8_Imm ( VexAbiInfo* vbi,
    /* Flags: C=selected bit, O,S,Z,A,P undefined, so are set to zero. */
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
    stmt( IRStmt_Put( OFFB_CC_DEP2, mkU64(0) ));
-   stmt( IRStmt_Put( 
+   stmt( IRStmt_Put(
             OFFB_CC_DEP1,
             binop(Iop_And64,
                   binop(Iop_Shr64, mkexpr(t2), mkU8(src_val)),
@@ -3911,7 +3911,7 @@ ULong dis_Grp8_Imm ( VexAbiInfo* vbi,
    value in RAX/EAX/AX/AL by the given IRTemp, and park the result in
    RDX:RAX/EDX:EAX/DX:AX/AX.
 */
-static void codegen_mulL_A_D ( Int sz, Bool syned, 
+static void codegen_mulL_A_D ( Int sz, Bool syned,
                                IRTemp tmp, const HChar* tmp_txt )
 {
    IRType ty = szToITy(sz);
@@ -3985,8 +3985,8 @@ static void codegen_mulL_A_D ( Int sz, Bool syned,
 
 /* Group 3 extended opcodes.  We have to decide here whether F2 and F3
    might be valid.*/
-static 
-ULong dis_Grp3 ( VexAbiInfo* vbi, 
+static
+ULong dis_Grp3 ( VexAbiInfo* vbi,
                  Prefix pfx, Int sz, Long delta, Bool* decode_OK )
 {
    Long    d64;
@@ -4004,16 +4004,16 @@ ULong dis_Grp3 ( VexAbiInfo* vbi,
       if (haveF2orF3(pfx)) goto unhandled;
       switch (gregLO3ofRM(modrm)) {
          case 0: { /* TEST */
-            delta++; 
-            d64 = getSDisp(imin(4,sz), delta); 
+            delta++;
+            d64 = getSDisp(imin(4,sz), delta);
             delta += imin(4,sz);
             dst1 = newTemp(ty);
             assign(dst1, binop(mkSizedOp(ty,Iop_And8),
                                getIRegE(sz,pfx,modrm),
                                mkU(ty, d64 & mkSizeMask(sz))));
             setFlags_DEP1( Iop_And8, dst1, ty );
-            DIP("test%c $%lld, %s\n", 
-                nameISize(sz), d64, 
+            DIP("test%c $%lld, %s\n",
+                nameISize(sz), d64,
                 nameIRegE(sz, pfx, modrm));
             break;
          }
@@ -4025,7 +4025,7 @@ ULong dis_Grp3 ( VexAbiInfo* vbi,
             putIRegE(sz, pfx, modrm,
                               unop(mkSizedOp(ty,Iop_Not8),
                                    getIRegE(sz, pfx, modrm)));
-            DIP("not%c %s\n", nameISize(sz), 
+            DIP("not%c %s\n", nameISize(sz),
                               nameIRegE(sz, pfx, modrm));
             break;
          case 3: /* NEG */
@@ -4059,17 +4059,17 @@ ULong dis_Grp3 ( VexAbiInfo* vbi,
             delta++;
             assign( t1, getIRegE(sz, pfx, modrm) );
             codegen_div ( sz, t1, False );
-            DIP("div%c %s\n", nameISize(sz), 
+            DIP("div%c %s\n", nameISize(sz),
                               nameIRegE(sz, pfx, modrm));
             break;
          case 7: /* IDIV */
             delta++;
             assign( t1, getIRegE(sz, pfx, modrm) );
             codegen_div ( sz, t1, True );
-            DIP("idiv%c %s\n", nameISize(sz), 
+            DIP("idiv%c %s\n", nameISize(sz),
                                nameIRegE(sz, pfx, modrm));
             break;
-         default: 
+         default:
             /*NOTREACHED*/
             vpanic("Grp3(amd64,R)");
       }
@@ -4094,11 +4094,11 @@ ULong dis_Grp3 ( VexAbiInfo* vbi,
       assign(t1, loadLE(ty,mkexpr(addr)));
       switch (gregLO3ofRM(modrm)) {
          case 0: { /* TEST */
-            d64 = getSDisp(imin(4,sz), delta); 
+            d64 = getSDisp(imin(4,sz), delta);
             delta += imin(4,sz);
             dst1 = newTemp(ty);
             assign(dst1, binop(mkSizedOp(ty,Iop_And8),
-                               mkexpr(t1), 
+                               mkexpr(t1),
                                mkU(ty, d64 & mkSizeMask(sz))));
             setFlags_DEP1( Iop_And8, dst1, ty );
             DIP("test%c $%lld, %s\n", nameISize(sz), d64, dis_buf);
@@ -4149,7 +4149,7 @@ ULong dis_Grp3 ( VexAbiInfo* vbi,
             codegen_div ( sz, t1, True );
             DIP("idiv%c %s\n", nameISize(sz), dis_buf);
             break;
-         default: 
+         default:
             /*NOTREACHED*/
             vpanic("Grp3(amd64,M)");
       }
@@ -4192,7 +4192,7 @@ ULong dis_Grp4 ( VexAbiInfo* vbi,
             putIRegE(1, pfx, modrm, mkexpr(t2));
             setFlags_INC_DEC( False, t2, ty );
             break;
-         default: 
+         default:
             *decode_OK = False;
             return delta;
       }
@@ -4214,7 +4214,7 @@ ULong dis_Grp4 ( VexAbiInfo* vbi,
          case 0: /* INC */
             assign(t2, binop(Iop_Add8, mkexpr(t1), mkU8(1)));
             if (haveLOCK(pfx)) {
-               casLE( mkexpr(addr), mkexpr(t1)/*expd*/, mkexpr(t2)/*new*/, 
+               casLE( mkexpr(addr), mkexpr(t1)/*expd*/, mkexpr(t2)/*new*/,
                       guest_RIP_curr_instr );
             } else {
                storeLE( mkexpr(addr), mkexpr(t2) );
@@ -4224,14 +4224,14 @@ ULong dis_Grp4 ( VexAbiInfo* vbi,
          case 1: /* DEC */
             assign(t2, binop(Iop_Sub8, mkexpr(t1), mkU8(1)));
             if (haveLOCK(pfx)) {
-               casLE( mkexpr(addr), mkexpr(t1)/*expd*/, mkexpr(t2)/*new*/, 
+               casLE( mkexpr(addr), mkexpr(t1)/*expd*/, mkexpr(t2)/*new*/,
                       guest_RIP_curr_instr );
             } else {
                storeLE( mkexpr(addr), mkexpr(t2) );
             }
             setFlags_INC_DEC( False, t2, ty );
             break;
-         default: 
+         default:
             *decode_OK = False;
             return delta;
       }
@@ -4337,7 +4337,7 @@ ULong dis_Grp5 ( VexAbiInfo* vbi,
       }
       delta++;
       DIP("%s%c %s\n", nameGrp5(gregLO3ofRM(modrm)),
-                       showSz ? nameISize(sz) : ' ', 
+                       showSz ? nameISize(sz) : ' ',
                        nameIRegE(sz, pfx, modrm));
    } else {
       /* Decide if F2/XACQ, F3/XREL, F2/CALL or F2/JMP might be valid. */
@@ -4357,7 +4357,7 @@ ULong dis_Grp5 ( VexAbiInfo* vbi,
          assign(t1, loadLE(ty,mkexpr(addr)));
       }
       switch (gregLO3ofRM(modrm)) {
-         case 0: /* INC */ 
+         case 0: /* INC */
             t2 = newTemp(ty);
             assign(t2, binop(mkSizedOp(ty,Iop_Add8),
                              mkexpr(t1), mkU(ty,1)));
@@ -4369,7 +4369,7 @@ ULong dis_Grp5 ( VexAbiInfo* vbi,
             }
             setFlags_INC_DEC( True, t2, ty );
             break;
-         case 1: /* DEC */ 
+         case 1: /* DEC */
             t2 = newTemp(ty);
             assign(t2, binop(mkSizedOp(ty,Iop_Sub8),
                              mkexpr(t1), mkU(ty,1)));
@@ -4423,14 +4423,14 @@ ULong dis_Grp5 ( VexAbiInfo* vbi,
             } else {
                goto unhandledM; /* awaiting test case */
             }
-         default: 
+         default:
          unhandledM:
             *decode_OK = False;
             return delta;
       }
       delta += len;
       DIP("%s%c %s\n", nameGrp5(gregLO3ofRM(modrm)),
-                       showSz ? nameISize(sz) : ' ', 
+                       showSz ? nameISize(sz) : ' ',
                        dis_buf);
    }
    return delta;
@@ -4450,11 +4450,11 @@ void dis_string_op_increment ( Int sz, IRTemp t_inc )
       logSz = 1;
       if (sz == 4) logSz = 2;
       if (sz == 8) logSz = 3;
-      assign( t_inc, 
+      assign( t_inc,
               binop(Iop_Shl64, IRExpr_Get( OFFB_DFLAG, Ity_I64 ),
                                mkU8(logSz) ) );
    } else {
-      assign( t_inc, 
+      assign( t_inc,
               IRExpr_Get( OFFB_DFLAG, Ity_I64 ) );
    }
 }
@@ -4472,7 +4472,7 @@ void dis_string_op( void (*dis_OP)( Int, IRTemp, Prefix pfx ),
    DIP("%s%c\n", name, nameISize(sz));
 }
 
-static 
+static
 void dis_MOVS ( Int sz, IRTemp t_inc, Prefix pfx )
 {
    IRType ty = szToITy(sz);
@@ -4500,7 +4500,7 @@ void dis_MOVS ( Int sz, IRTemp t_inc, Prefix pfx )
    putIReg64( R_RSI, incs );
 }
 
-static 
+static
 void dis_LODS ( Int sz, IRTemp t_inc, Prefix pfx )
 {
    IRType ty = szToITy(sz);
@@ -4520,7 +4520,7 @@ void dis_LODS ( Int sz, IRTemp t_inc, Prefix pfx )
    putIReg64( R_RSI, incs );
 }
 
-static 
+static
 void dis_STOS ( Int sz, IRTemp t_inc, Prefix pfx )
 {
    IRType ty = szToITy(sz);
@@ -4543,7 +4543,7 @@ void dis_STOS ( Int sz, IRTemp t_inc, Prefix pfx )
    putIReg64( R_RDI, incd );
 }
 
-static 
+static
 void dis_CMPS ( Int sz, IRTemp t_inc, Prefix pfx )
 {
    IRType ty  = szToITy(sz);
@@ -4577,7 +4577,7 @@ void dis_CMPS ( Int sz, IRTemp t_inc, Prefix pfx )
    putIReg64( R_RSI, incs );
 }
 
-static 
+static
 void dis_SCAS ( Int sz, IRTemp t_inc, Prefix pfx )
 {
    IRType ty  = szToITy(sz);
@@ -4607,7 +4607,7 @@ void dis_SCAS ( Int sz, IRTemp t_inc, Prefix pfx )
 /* Wrap the appropriate string op inside a REP/REPE/REPNE.  We assume
    the insn is the last one in the basic block, and so emit a jump to
    the next insn, rather than just falling through. */
-static 
+static
 void dis_REP_op ( /*MOD*/DisResult* dres,
                   AMD64Condcode cond,
                   void (*dis_OP)(Int, IRTemp, Prefix),
@@ -4666,7 +4666,7 @@ void dis_REP_op ( /*MOD*/DisResult* dres,
 static
 ULong dis_mul_E_G ( VexAbiInfo* vbi,
                     Prefix      pfx,
-                    Int         size, 
+                    Int         size,
                     Long        delta0 )
 {
    Int    alen;
@@ -4692,13 +4692,13 @@ ULong dis_mul_E_G ( VexAbiInfo* vbi,
    putIRegG(size, pfx, rm, mkexpr(resLo) );
 
    if (epartIsReg(rm)) {
-      DIP("imul%c %s, %s\n", nameISize(size), 
+      DIP("imul%c %s, %s\n", nameISize(size),
                              nameIRegE(size,pfx,rm),
                              nameIRegG(size,pfx,rm));
       return 1+delta0;
    } else {
-      DIP("imul%c %s, %s\n", nameISize(size), 
-                             dis_buf, 
+      DIP("imul%c %s, %s\n", nameISize(size),
+                             dis_buf,
                              nameIRegG(size,pfx,rm));
       return alen+delta0;
    }
@@ -4709,7 +4709,7 @@ ULong dis_mul_E_G ( VexAbiInfo* vbi,
 static
 ULong dis_imul_I_E_G ( VexAbiInfo* vbi,
                        Prefix      pfx,
-                       Int         size, 
+                       Int         size,
                        Long        delta,
                        Int         litsize )
 {
@@ -4728,7 +4728,7 @@ ULong dis_imul_I_E_G ( VexAbiInfo* vbi,
       assign(te, getIRegE(size, pfx, rm));
       delta++;
    } else {
-      IRTemp addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+      IRTemp addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                                      imin(4,litsize) );
       assign(te, loadLE(ty, mkexpr(addr)));
       delta += alen;
@@ -4745,8 +4745,8 @@ ULong dis_imul_I_E_G ( VexAbiInfo* vbi,
 
    putIRegG(size, pfx, rm, mkexpr(resLo));
 
-   DIP("imul%c $%lld, %s, %s\n", 
-       nameISize(size), d64, 
+   DIP("imul%c $%lld, %s, %s\n",
+       nameISize(size), d64,
        ( epartIsReg(rm) ? nameIRegE(size,pfx,rm) : dis_buf ),
        nameIRegG(size,pfx,rm) );
    return delta;
@@ -4775,7 +4775,7 @@ static IRTemp gen_POPCOUNT ( IRType ty, IRTemp src )
       for (i = 0; i < 4; i++) {
          nyu = newTemp(ty);
          assign(nyu,
-                binop(Iop_Add16, 
+                binop(Iop_Add16,
                       binop(Iop_And16,
                             mkexpr(old),
                             mkexpr(mask[i])),
@@ -4803,7 +4803,7 @@ static IRTemp gen_POPCOUNT ( IRType ty, IRTemp src )
       for (i = 0; i < 5; i++) {
          nyu = newTemp(ty);
          assign(nyu,
-                binop(Iop_Add32, 
+                binop(Iop_Add32,
                       binop(Iop_And32,
                             mkexpr(old),
                             mkexpr(mask[i])),
@@ -4832,7 +4832,7 @@ static IRTemp gen_POPCOUNT ( IRType ty, IRTemp src )
       for (i = 0; i < 6; i++) {
          nyu = newTemp(ty);
          assign(nyu,
-                binop(Iop_Add64, 
+                binop(Iop_Add64,
                       binop(Iop_And64,
                             mkexpr(old),
                             mkexpr(mask[i])),
@@ -4861,7 +4861,7 @@ static IRTemp gen_LZCNT ( IRType ty, IRTemp src )
    assign(src64, widenUto64( mkexpr(src) ));
 
    IRTemp src64x = newTemp(Ity_I64);
-   assign(src64x, 
+   assign(src64x,
           binop(Iop_Shl64, mkexpr(src64),
                            mkU8(64 - 8 * sizeofIRType(ty))));
 
@@ -4929,7 +4929,7 @@ static void put_emwarn ( IRExpr* e /* :: Ity_I32 */ )
 
 static IRExpr* mkQNaN64 ( void )
 {
-  /* QNaN is 0 2047 1 0(51times) 
+  /* QNaN is 0 2047 1 0(51times)
      == 0b 11111111111b 1 0(51times)
      == 0x7FF8 0000 0000 0000
    */
@@ -5058,7 +5058,7 @@ static IRExpr* get_ST_UNCHECKED ( Int i )
 }
 
 
-/* Given i, generate an expression yielding 
+/* Given i, generate an expression yielding
   is_full(i) ? ST(i) : NaN
 */
 
@@ -5104,7 +5104,7 @@ static void maybe_put_ST ( IRTemp cond, Int i, IRExpr* value )
                      mkexpr(old_val)));
 
    put_ST_UNCHECKED(i, mkexpr(new_val));
-   // put_ST_UNCHECKED incorrectly sets tag(i) to always be FULL.  So 
+   // put_ST_UNCHECKED incorrectly sets tag(i) to always be FULL.  So
    // now set it to new_tag instead.
    put_ST_TAG(i, mkexpr(new_tag));
 }
@@ -5134,7 +5134,7 @@ static void fp_pop ( void )
 }
 
 /* Set the C2 bit of the FPU status register to e[0].  Assumes that
-   e[31:1] == 0. 
+   e[31:1] == 0.
 */
 static void set_C2 ( IRExpr* e )
 {
@@ -5186,10 +5186,10 @@ static IRExpr* get_FPU_sw ( void )
    return
       unop(Iop_32to16,
            binop(Iop_Or32,
-                 binop(Iop_Shl32, 
-                       binop(Iop_And32, get_ftop(), mkU32(7)), 
+                 binop(Iop_Shl32,
+                       binop(Iop_And32, get_ftop(), mkU32(7)),
                              mkU8(11)),
-                       binop(Iop_And32, unop(Iop_64to32, get_C3210()), 
+                       binop(Iop_And32, unop(Iop_64to32, get_C3210()),
                                         mkU32(0x4700))
       ));
 }
@@ -5197,29 +5197,29 @@ static IRExpr* get_FPU_sw ( void )
 
 /* ------------------------------------------------------- */
 /* Given all that stack-mangling junk, we can now go ahead
-   and describe FP instructions. 
+   and describe FP instructions.
 */
 
 /* ST(0) = ST(0) `op` mem64/32(addr)
    Need to check ST(0)'s tag on read, but not on write.
 */
 static
-void fp_do_op_mem_ST_0 ( IRTemp addr, const HChar* op_txt, HChar* dis_buf, 
+void fp_do_op_mem_ST_0 ( IRTemp addr, const HChar* op_txt, HChar* dis_buf,
                          IROp op, Bool dbl )
 {
    DIP("f%s%c %s\n", op_txt, dbl?'l':'s', dis_buf);
    if (dbl) {
-      put_ST_UNCHECKED(0, 
-         triop( op, 
+      put_ST_UNCHECKED(0,
+         triop( op,
                 get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
-                get_ST(0), 
+                get_ST(0),
                 loadLE(Ity_F64,mkexpr(addr))
          ));
    } else {
-      put_ST_UNCHECKED(0, 
-         triop( op, 
+      put_ST_UNCHECKED(0,
+         triop( op,
                 get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
-                get_ST(0), 
+                get_ST(0),
                 unop(Iop_F32toF64, loadLE(Ity_F32,mkexpr(addr)))
          ));
    }
@@ -5230,20 +5230,20 @@ void fp_do_op_mem_ST_0 ( IRTemp addr, const HChar* op_txt, HChar* dis_buf,
    Need to check ST(0)'s tag on read, but not on write.
 */
 static
-void fp_do_oprev_mem_ST_0 ( IRTemp addr, const HChar* op_txt, HChar* dis_buf, 
+void fp_do_oprev_mem_ST_0 ( IRTemp addr, const HChar* op_txt, HChar* dis_buf,
                             IROp op, Bool dbl )
 {
    DIP("f%s%c %s\n", op_txt, dbl?'l':'s', dis_buf);
    if (dbl) {
-      put_ST_UNCHECKED(0, 
-         triop( op, 
+      put_ST_UNCHECKED(0,
+         triop( op,
                 get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                 loadLE(Ity_F64,mkexpr(addr)),
                 get_ST(0)
          ));
    } else {
-      put_ST_UNCHECKED(0, 
-         triop( op, 
+      put_ST_UNCHECKED(0,
+         triop( op,
                 get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                 unop(Iop_F32toF64, loadLE(Ity_F32,mkexpr(addr))),
                 get_ST(0)
@@ -5260,12 +5260,12 @@ void fp_do_op_ST_ST ( const HChar* op_txt, IROp op, UInt st_src, UInt st_dst,
                       Bool pop_after )
 {
    DIP("f%s%s st(%u), st(%u)\n", op_txt, pop_after?"p":"", st_src, st_dst );
-   put_ST_UNCHECKED( 
-      st_dst, 
-      triop( op, 
+   put_ST_UNCHECKED(
+      st_dst,
+      triop( op,
              get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
-             get_ST(st_dst), 
-             get_ST(st_src) ) 
+             get_ST(st_dst),
+             get_ST(st_src) )
    );
    if (pop_after)
       fp_pop();
@@ -5279,12 +5279,12 @@ void fp_do_oprev_ST_ST ( const HChar* op_txt, IROp op, UInt st_src, UInt st_dst,
                          Bool pop_after )
 {
    DIP("f%s%s st(%u), st(%u)\n", op_txt, pop_after?"p":"", st_src, st_dst );
-   put_ST_UNCHECKED( 
-      st_dst, 
-      triop( op, 
+   put_ST_UNCHECKED(
+      st_dst,
+      triop( op,
              get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
-             get_ST(st_src), 
-             get_ST(st_dst) ) 
+             get_ST(st_src),
+             get_ST(st_dst) )
    );
    if (pop_after)
       fp_pop();
@@ -5296,13 +5296,13 @@ static void fp_do_ucomi_ST0_STi ( UInt i, Bool pop_after )
    DIP("fucomi%s %%st(0),%%st(%u)\n", pop_after ? "p" : "", i);
    /* This is a bit of a hack (and isn't really right).  It sets
       Z,P,C,O correctly, but forces A and S to zero, whereas the Intel
-      documentation implies A and S are unchanged. 
+      documentation implies A and S are unchanged.
    */
    /* It's also fishy in that it is used both for COMIP and
       UCOMIP, and they aren't the same (although similar). */
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
    stmt( IRStmt_Put( OFFB_CC_DEP2, mkU64(0) ));
-   stmt( IRStmt_Put( 
+   stmt( IRStmt_Put(
             OFFB_CC_DEP1,
             binop( Iop_And64,
                    unop( Iop_32Uto64,
@@ -5314,7 +5314,7 @@ static void fp_do_ucomi_ST0_STi ( UInt i, Bool pop_after )
 }
 
 
-/* returns 
+/* returns
    32to16( if e32 <s -32768 || e32 >s 32767 then -32768 else e32 )
 */
 static IRExpr* x87ishly_qnarrow_32_to_16 ( IRExpr* e32 )
@@ -5322,10 +5322,10 @@ static IRExpr* x87ishly_qnarrow_32_to_16 ( IRExpr* e32 )
    IRTemp t32 = newTemp(Ity_I32);
    assign( t32, e32 );
    return
-      IRExpr_ITE( 
-         binop(Iop_CmpLT64U, 
-               unop(Iop_32Uto64, 
-                    binop(Iop_Add32, mkexpr(t32), mkU32(32768))), 
+      IRExpr_ITE(
+         binop(Iop_CmpLT64U,
+               unop(Iop_32Uto64,
+                    binop(Iop_Add32, mkexpr(t32), mkU32(32768))),
                mkU64(65536)),
          unop(Iop_32to16, mkexpr(t32)),
          mkU16( 0x8000 ) );
@@ -5333,7 +5333,7 @@ static IRExpr* x87ishly_qnarrow_32_to_16 ( IRExpr* e32 )
 
 
 static
-ULong dis_FPU ( /*OUT*/Bool* decode_ok, 
+ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                 VexAbiInfo* vbi, Prefix pfx, Long delta )
 {
    Int    len;
@@ -5371,37 +5371,37 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                /* This forces C1 to zero, which isn't right. */
                /* The AMD documentation suggests that forcing C1 to
                   zero is correct (Eliot Moss) */
-               put_C3210( 
+               put_C3210(
                    unop( Iop_32Uto64,
                        binop( Iop_And32,
-                              binop(Iop_Shl32, 
-                                    binop(Iop_CmpF64, 
+                              binop(Iop_Shl32,
+                                    binop(Iop_CmpF64,
                                           get_ST(0),
-                                          unop(Iop_F32toF64, 
+                                          unop(Iop_F32toF64,
                                                loadLE(Ity_F32,mkexpr(addr)))),
                                     mkU8(8)),
                               mkU32(0x4500)
                    )));
-               break;  
+               break;
 
             case 3: /* FCOMP single-real */
                /* The AMD documentation suggests that forcing C1 to
                   zero is correct (Eliot Moss) */
                DIP("fcomps %s\n", dis_buf);
                /* This forces C1 to zero, which isn't right. */
-               put_C3210( 
+               put_C3210(
                    unop( Iop_32Uto64,
                        binop( Iop_And32,
-                              binop(Iop_Shl32, 
-                                    binop(Iop_CmpF64, 
+                              binop(Iop_Shl32,
+                                    binop(Iop_CmpF64,
                                           get_ST(0),
-                                          unop(Iop_F32toF64, 
+                                          unop(Iop_F32toF64,
                                                loadLE(Ity_F32,mkexpr(addr)))),
                                     mkU8(8)),
                               mkU32(0x4500)
                    )));
                fp_pop();
-               break;  
+               break;
 
             case 4: /* FSUB single-real */
                fp_do_op_mem_ST_0 ( addr, "sub", dis_buf, Iop_SubF64, False );
@@ -5441,10 +5441,10 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                r_dst = (UInt)modrm - 0xD0;
                DIP("fcom %%st(0),%%st(%d)\n", r_dst);
                /* This forces C1 to zero, which isn't right. */
-               put_C3210( 
+               put_C3210(
                    unop(Iop_32Uto64,
                    binop( Iop_And32,
-                          binop(Iop_Shl32, 
+                          binop(Iop_Shl32,
                                 binop(Iop_CmpF64, get_ST(0), get_ST(r_dst)),
                                 mkU8(8)),
                           mkU32(0x4500)
@@ -5456,10 +5456,10 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                r_dst = (UInt)modrm - 0xD8;
                DIP("fcomp %%st(0),%%st(%d)\n", r_dst);
                /* This forces C1 to zero, which isn't right. */
-               put_C3210( 
+               put_C3210(
                    unop(Iop_32Uto64,
                    binop( Iop_And32,
-                          binop(Iop_Shl32, 
+                          binop(Iop_Shl32,
                                 binop(Iop_CmpF64, get_ST(0), get_ST(r_dst)),
                                 mkU8(8)),
                           mkU32(0x4500)
@@ -5516,19 +5516,19 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 
             case 3: /* FSTP single-real */
                DIP("fstps %s\n", dis_buf);
-               storeLE(mkexpr(addr), 
+               storeLE(mkexpr(addr),
                        binop(Iop_F64toF32, get_roundingmode(), get_ST(0)));
                fp_pop();
                break;
 
             case 4: { /* FLDENV m28 */
-               /* Uses dirty helper: 
+               /* Uses dirty helper:
                      VexEmNote amd64g_do_FLDENV ( VexGuestX86State*, HWord ) */
                IRTemp    ew = newTemp(Ity_I32);
                IRTemp   w64 = newTemp(Ity_I64);
-               IRDirty*   d = unsafeIRDirty_0_N ( 
-                                 0/*regparms*/, 
-                                 "amd64g_dirtyhelper_FLDENV", 
+               IRDirty*   d = unsafeIRDirty_0_N (
+                                 0/*regparms*/,
+                                 "amd64g_dirtyhelper_FLDENV",
                                  &amd64g_dirtyhelper_FLDENV,
                                  mkIRExprVec_2( IRExpr_BBPTR(), mkexpr(addr) )
                               );
@@ -5566,7 +5566,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                   sees the warning. */
                assign(ew, unop(Iop_64to32,mkexpr(w64)) );
                put_emwarn( mkexpr(ew) );
-               stmt( 
+               stmt(
                   IRStmt_Exit(
                      binop(Iop_CmpNE32, mkexpr(ew), mkU32(0)),
                      Ijk_EmWarn,
@@ -5593,11 +5593,11 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                IRTemp ew = newTemp(Ity_I32);
                DIP("fldcw %s\n", dis_buf);
                assign( t64, mkIRExprCCall(
-                               Ity_I64, 0/*regparms*/, 
+                               Ity_I64, 0/*regparms*/,
                                "amd64g_check_fldcw",
-                               &amd64g_check_fldcw, 
-                               mkIRExprVec_1( 
-                                  unop( Iop_16Uto64, 
+                               &amd64g_check_fldcw,
+                               mkIRExprVec_1(
+                                  unop( Iop_16Uto64,
                                         loadLE(Ity_I16, mkexpr(addr)))
                                )
                             )
@@ -5609,7 +5609,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                /* Finally, if an emulation warning was reported,
                   side-exit to the next insn, reporting the warning,
                   so that Valgrind's dispatcher sees the warning. */
-               stmt( 
+               stmt(
                   IRStmt_Exit(
                      binop(Iop_CmpNE32, mkexpr(ew), mkU32(0)),
                      Ijk_EmWarn,
@@ -5621,11 +5621,11 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             }
 
             case 6: { /* FNSTENV m28 */
-               /* Uses dirty helper: 
+               /* Uses dirty helper:
                      void amd64g_do_FSTENV ( VexGuestAMD64State*, HWord ) */
-               IRDirty* d = unsafeIRDirty_0_N ( 
-                               0/*regparms*/, 
-                               "amd64g_dirtyhelper_FSTENV", 
+               IRDirty* d = unsafeIRDirty_0_N (
+                               0/*regparms*/,
+                               "amd64g_dirtyhelper_FSTENV",
                                &amd64g_dirtyhelper_FSTENV,
                                mkIRExprVec_2( IRExpr_BBPTR(), mkexpr(addr) )
                             );
@@ -5667,14 +5667,14 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                /* ULong amd64g_create_fpucw ( ULong fpround ) */
                DIP("fnstcw %s\n", dis_buf);
                storeLE(
-                  mkexpr(addr), 
-                  unop( Iop_64to16, 
+                  mkexpr(addr),
+                  unop( Iop_64to16,
                         mkIRExprCCall(
                            Ity_I64, 0/*regp*/,
-                           "amd64g_create_fpucw", &amd64g_create_fpucw, 
-                           mkIRExprVec_1( unop(Iop_32Uto64, get_fpround()) ) 
-                        ) 
-                  ) 
+                           "amd64g_create_fpucw", &amd64g_create_fpucw,
+                           mkIRExprVec_1( unop(Iop_32Uto64, get_fpround()) )
+                        )
+                  )
                );
                break;
 
@@ -5726,11 +5726,11 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                   function. */
                IRExpr** args
                   = mkIRExprVec_2( unop(Iop_8Uto64, get_ST_TAG(0)),
-                                   unop(Iop_ReinterpF64asI64, 
+                                   unop(Iop_ReinterpF64asI64,
                                         get_ST_UNCHECKED(0)) );
                put_C3210(mkIRExprCCall(
-                            Ity_I64, 
-                            0/*regparm*/, 
+                            Ity_I64,
+                            0/*regparm*/,
                             "amd64g_calculate_FXAM", &amd64g_calculate_FXAM,
                             args
                         ));
@@ -5789,18 +5789,18 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 
             case 0xF0: /* F2XM1 */
                DIP("f2xm1\n");
-               put_ST_UNCHECKED(0, 
-                  binop(Iop_2xm1F64, 
+               put_ST_UNCHECKED(0,
+                  binop(Iop_2xm1F64,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                         get_ST(0)));
                break;
 
             case 0xF1: /* FYL2X */
                DIP("fyl2x\n");
-               put_ST_UNCHECKED(1, 
+               put_ST_UNCHECKED(1,
                   triop(Iop_Yl2xF64,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
-                        get_ST(1), 
+                        get_ST(1),
                         get_ST(0)));
                fp_pop();
                break;
@@ -5813,7 +5813,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                IRTemp resD = newTemp(Ity_F64);
                assign(resD,
                   IRExpr_ITE(
-                     mkexpr(argOK), 
+                     mkexpr(argOK),
                      binop(Iop_TanF64,
                            get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                            mkexpr(argD)),
@@ -5826,17 +5826,17 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                maybe_put_ST(argOK, 0,
                             IRExpr_Const(IRConst_F64(1.0)));
                set_C2( binop(Iop_Xor64,
-                             unop(Iop_1Uto64, mkexpr(argOK)), 
+                             unop(Iop_1Uto64, mkexpr(argOK)),
                              mkU64(1)) );
                break;
             }
 
             case 0xF3: /* FPATAN */
                DIP("fpatan\n");
-               put_ST_UNCHECKED(1, 
+               put_ST_UNCHECKED(1,
                   triop(Iop_AtanF64,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
-                        get_ST(1), 
+                        get_ST(1),
                         get_ST(0)));
                fp_pop();
                break;
@@ -5851,21 +5851,21 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                DIP("fxtract\n");
                assign( argF, get_ST(0) );
                assign( argI, unop(Iop_ReinterpF64asI64, mkexpr(argF)));
-               assign( sigI, 
+               assign( sigI,
                        mkIRExprCCall(
-                          Ity_I64, 0/*regparms*/, 
-                          "x86amd64g_calculate_FXTRACT", 
-                          &x86amd64g_calculate_FXTRACT, 
-                          mkIRExprVec_2( mkexpr(argI), 
-                                         mkIRExpr_HWord(0)/*sig*/ )) 
+                          Ity_I64, 0/*regparms*/,
+                          "x86amd64g_calculate_FXTRACT",
+                          &x86amd64g_calculate_FXTRACT,
+                          mkIRExprVec_2( mkexpr(argI),
+                                         mkIRExpr_HWord(0)/*sig*/ ))
                );
-               assign( expI, 
+               assign( expI,
                        mkIRExprCCall(
-                          Ity_I64, 0/*regparms*/, 
-                          "x86amd64g_calculate_FXTRACT", 
-                          &x86amd64g_calculate_FXTRACT, 
-                          mkIRExprVec_2( mkexpr(argI), 
-                                         mkIRExpr_HWord(1)/*exp*/ )) 
+                          Ity_I64, 0/*regparms*/,
+                          "x86amd64g_calculate_FXTRACT",
+                          &x86amd64g_calculate_FXTRACT,
+                          mkIRExprVec_2( mkexpr(argI),
+                                         mkIRExpr_HWord(1)/*exp*/ ))
                );
                assign( sigF, unop(Iop_ReinterpI64asF64, mkexpr(sigI)) );
                assign( expF, unop(Iop_ReinterpI64asF64, mkexpr(expI)) );
@@ -5928,18 +5928,18 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 
             case 0xF9: /* FYL2XP1 */
                DIP("fyl2xp1\n");
-               put_ST_UNCHECKED(1, 
+               put_ST_UNCHECKED(1,
                   triop(Iop_Yl2xp1F64,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
-                        get_ST(1), 
+                        get_ST(1),
                         get_ST(0)));
                fp_pop();
                break;
 
             case 0xFA: /* FSQRT */
                DIP("fsqrt\n");
-               put_ST_UNCHECKED(0, 
-                  binop(Iop_SqrtF64, 
+               put_ST_UNCHECKED(0,
+                  binop(Iop_SqrtF64,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                         get_ST(0)));
                break;
@@ -5952,7 +5952,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                IRTemp resD = newTemp(Ity_F64);
                assign(resD,
                   IRExpr_ITE(
-                     mkexpr(argOK), 
+                     mkexpr(argOK),
                      binop(Iop_SinF64,
                            get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                            mkexpr(argD)),
@@ -5967,7 +5967,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                         mkexpr(argD)));
                set_C2( binop(Iop_Xor64,
-                             unop(Iop_1Uto64, mkexpr(argOK)), 
+                             unop(Iop_1Uto64, mkexpr(argOK)),
                              mkU64(1)) );
                break;
             }
@@ -5980,10 +5980,10 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 
             case 0xFD: /* FSCALE */
                DIP("fscale\n");
-               put_ST_UNCHECKED(0, 
+               put_ST_UNCHECKED(0,
                   triop(Iop_ScaleF64,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
-                        get_ST(0), 
+                        get_ST(0),
                         get_ST(1)));
                break;
 
@@ -5997,7 +5997,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                IRTemp resD = newTemp(Ity_F64);
                assign(resD,
                   IRExpr_ITE(
-                     mkexpr(argOK), 
+                     mkexpr(argOK),
                      binop(isSIN ? Iop_SinF64 : Iop_CosF64,
                            get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                            mkexpr(argD)),
@@ -6005,7 +6005,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                );
                put_ST_UNCHECKED(0, mkexpr(resD));
                set_C2( binop(Iop_Xor64,
-                             unop(Iop_1Uto64, mkexpr(argOK)), 
+                             unop(Iop_1Uto64, mkexpr(argOK)),
                              mkU64(1)) );
                break;
             }
@@ -6060,8 +6060,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                goto do_foprev_m32;
 
             do_fop_m32:
-               put_ST_UNCHECKED(0, 
-                  triop(fop, 
+               put_ST_UNCHECKED(0,
+                  triop(fop,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                         get_ST(0),
                         unop(Iop_I32StoF64,
@@ -6069,8 +6069,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                break;
 
             do_foprev_m32:
-               put_ST_UNCHECKED(0, 
-                  triop(fop, 
+               put_ST_UNCHECKED(0,
+                  triop(fop,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                         unop(Iop_I32StoF64,
                              loadLE(Ity_I32, mkexpr(addr))),
@@ -6091,8 +6091,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 0xC0 ... 0xC7: /* FCMOVB ST(i), ST(0) */
                r_src = (UInt)modrm - 0xC0;
                DIP("fcmovb %%st(%u), %%st(0)\n", r_src);
-               put_ST_UNCHECKED(0, 
-                                IRExpr_ITE( 
+               put_ST_UNCHECKED(0,
+                                IRExpr_ITE(
                                     mk_amd64g_calculate_condition(AMD64CondB),
                                     get_ST(r_src), get_ST(0)) );
                break;
@@ -6100,8 +6100,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 0xC8 ... 0xCF: /* FCMOVE(Z) ST(i), ST(0) */
                r_src = (UInt)modrm - 0xC8;
                DIP("fcmovz %%st(%u), %%st(0)\n", r_src);
-               put_ST_UNCHECKED(0, 
-                                IRExpr_ITE( 
+               put_ST_UNCHECKED(0,
+                                IRExpr_ITE(
                                     mk_amd64g_calculate_condition(AMD64CondZ),
                                     get_ST(r_src), get_ST(0)) );
                break;
@@ -6109,8 +6109,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 0xD0 ... 0xD7: /* FCMOVBE ST(i), ST(0) */
                r_src = (UInt)modrm - 0xD0;
                DIP("fcmovbe %%st(%u), %%st(0)\n", r_src);
-               put_ST_UNCHECKED(0, 
-                                IRExpr_ITE( 
+               put_ST_UNCHECKED(0,
+                                IRExpr_ITE(
                                     mk_amd64g_calculate_condition(AMD64CondBE),
                                     get_ST(r_src), get_ST(0)) );
                break;
@@ -6118,8 +6118,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 0xD8 ... 0xDF: /* FCMOVU ST(i), ST(0) */
                r_src = (UInt)modrm - 0xD8;
                DIP("fcmovu %%st(%u), %%st(0)\n", r_src);
-               put_ST_UNCHECKED(0, 
-                                IRExpr_ITE( 
+               put_ST_UNCHECKED(0,
+                                IRExpr_ITE(
                                     mk_amd64g_calculate_condition(AMD64CondP),
                                     get_ST(r_src), get_ST(0)) );
                break;
@@ -6127,10 +6127,10 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 0xE9: /* FUCOMPP %st(0),%st(1) */
                DIP("fucompp %%st(0),%%st(1)\n");
                /* This forces C1 to zero, which isn't right. */
-               put_C3210( 
+               put_C3210(
                    unop(Iop_32Uto64,
                    binop( Iop_And32,
-                          binop(Iop_Shl32, 
+                          binop(Iop_Shl32,
                                 binop(Iop_CmpF64, get_ST(0), get_ST(1)),
                                 mkU8(8)),
                           mkU32(0x4500)
@@ -6167,38 +6167,38 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 
             case 1: /* FISTTPL m32 (SSE3) */
                DIP("fisttpl %s\n", dis_buf);
-               storeLE( mkexpr(addr), 
+               storeLE( mkexpr(addr),
                         binop(Iop_F64toI32S, mkU32(Irrm_ZERO), get_ST(0)) );
                fp_pop();
                break;
 
             case 2: /* FIST m32 */
                DIP("fistl %s\n", dis_buf);
-               storeLE( mkexpr(addr), 
+               storeLE( mkexpr(addr),
                         binop(Iop_F64toI32S, get_roundingmode(), get_ST(0)) );
                break;
 
             case 3: /* FISTP m32 */
                DIP("fistpl %s\n", dis_buf);
-               storeLE( mkexpr(addr), 
+               storeLE( mkexpr(addr),
                         binop(Iop_F64toI32S, get_roundingmode(), get_ST(0)) );
                fp_pop();
                break;
 
             case 5: { /* FLD extended-real */
-               /* Uses dirty helper: 
+               /* Uses dirty helper:
                      ULong amd64g_loadF80le ( ULong )
                   addr holds the address.  First, do a dirty call to
                   get hold of the data. */
                IRTemp   val  = newTemp(Ity_I64);
                IRExpr** args = mkIRExprVec_1 ( mkexpr(addr) );
 
-               IRDirty* d = unsafeIRDirty_1_N ( 
-                               val, 
-                               0/*regparms*/, 
-                               "amd64g_dirtyhelper_loadF80le", 
-                               &amd64g_dirtyhelper_loadF80le, 
-                               args 
+               IRDirty* d = unsafeIRDirty_1_N (
+                               val,
+                               0/*regparms*/,
+                               "amd64g_dirtyhelper_loadF80le",
+                               &amd64g_dirtyhelper_loadF80le,
+                               args
                             );
                /* declare that we're reading memory */
                d->mFx   = Ifx_Read;
@@ -6215,18 +6215,18 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             }
 
             case 7: { /* FSTP extended-real */
-               /* Uses dirty helper: 
-                     void amd64g_storeF80le ( ULong addr, ULong data ) 
+               /* Uses dirty helper:
+                     void amd64g_storeF80le ( ULong addr, ULong data )
                */
-               IRExpr** args 
-                  = mkIRExprVec_2( mkexpr(addr), 
+               IRExpr** args
+                  = mkIRExprVec_2( mkexpr(addr),
                                    unop(Iop_ReinterpF64asI64, get_ST(0)) );
 
-               IRDirty* d = unsafeIRDirty_0_N ( 
-                               0/*regparms*/, 
-                               "amd64g_dirtyhelper_storeF80le", 
+               IRDirty* d = unsafeIRDirty_0_N (
+                               0/*regparms*/,
+                               "amd64g_dirtyhelper_storeF80le",
                                &amd64g_dirtyhelper_storeF80le,
-                               args 
+                               args
                             );
                /* declare we're writing memory */
                d->mFx   = Ifx_Write;
@@ -6255,8 +6255,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 0xC0 ... 0xC7: /* FCMOVNB ST(i), ST(0) */
                r_src = (UInt)modrm - 0xC0;
                DIP("fcmovnb %%st(%u), %%st(0)\n", r_src);
-               put_ST_UNCHECKED(0, 
-                                IRExpr_ITE( 
+               put_ST_UNCHECKED(0,
+                                IRExpr_ITE(
                                     mk_amd64g_calculate_condition(AMD64CondNB),
                                     get_ST(r_src), get_ST(0)) );
                break;
@@ -6265,8 +6265,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                r_src = (UInt)modrm - 0xC8;
                DIP("fcmovnz %%st(%u), %%st(0)\n", r_src);
                put_ST_UNCHECKED(
-                  0, 
-                  IRExpr_ITE( 
+                  0,
+                  IRExpr_ITE(
                      mk_amd64g_calculate_condition(AMD64CondNZ),
                      get_ST(r_src),
                      get_ST(0)
@@ -6278,12 +6278,12 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                r_src = (UInt)modrm - 0xD0;
                DIP("fcmovnbe %%st(%u), %%st(0)\n", r_src);
                put_ST_UNCHECKED(
-                  0, 
-                  IRExpr_ITE( 
+                  0,
+                  IRExpr_ITE(
                      mk_amd64g_calculate_condition(AMD64CondNBE),
                      get_ST(r_src),
                      get_ST(0)
-                  ) 
+                  )
                );
                break;
 
@@ -6291,8 +6291,8 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                r_src = (UInt)modrm - 0xD8;
                DIP("fcmovnu %%st(%u), %%st(0)\n", r_src);
                put_ST_UNCHECKED(
-                  0, 
-                  IRExpr_ITE( 
+                  0,
+                  IRExpr_ITE(
                      mk_amd64g_calculate_condition(AMD64CondNP),
                      get_ST(r_src),
                      get_ST(0)
@@ -6305,11 +6305,11 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                break;
 
             case 0xE3: {
-               /* Uses dirty helper: 
+               /* Uses dirty helper:
                      void amd64g_do_FINIT ( VexGuestAMD64State* ) */
-               IRDirty* d  = unsafeIRDirty_0_N ( 
-                                0/*regparms*/, 
-                                "amd64g_dirtyhelper_FINIT", 
+               IRDirty* d  = unsafeIRDirty_0_N (
+                                0/*regparms*/,
+                                "amd64g_dirtyhelper_FINIT",
                                 &amd64g_dirtyhelper_FINIT,
                                 mkIRExprVec_1( IRExpr_BBPTR() )
                              );
@@ -6381,32 +6381,32 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 //..             case 2: /* FCOM double-real */
 //..                DIP("fcoml %s\n", dis_buf);
 //..                /* This forces C1 to zero, which isn't right. */
-//..                put_C3210( 
+//..                put_C3210(
 //..                    binop( Iop_And32,
-//..                           binop(Iop_Shl32, 
-//..                                 binop(Iop_CmpF64, 
+//..                           binop(Iop_Shl32,
+//..                                 binop(Iop_CmpF64,
 //..                                       get_ST(0),
 //..                                       loadLE(Ity_F64,mkexpr(addr))),
 //..                                 mkU8(8)),
 //..                           mkU32(0x4500)
 //..                    ));
-//..                break;  
+//..                break;
 
             case 3: /* FCOMP double-real */
                DIP("fcompl %s\n", dis_buf);
                /* This forces C1 to zero, which isn't right. */
-               put_C3210( 
+               put_C3210(
                    unop(Iop_32Uto64,
                    binop( Iop_And32,
-                          binop(Iop_Shl32, 
-                                binop(Iop_CmpF64, 
+                          binop(Iop_Shl32,
+                                binop(Iop_CmpF64,
                                       get_ST(0),
                                       loadLE(Ity_F64,mkexpr(addr))),
                                 mkU8(8)),
                           mkU32(0x4500)
                    )));
                fp_pop();
-               break;  
+               break;
 
             case 4: /* FSUB double-real */
                fp_do_op_mem_ST_0 ( addr, "sub", dis_buf, Iop_SubF64, True );
@@ -6487,7 +6487,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 
             case 1: /* FISTTPQ m64 (SSE3) */
                DIP("fistppll %s\n", dis_buf);
-               storeLE( mkexpr(addr), 
+               storeLE( mkexpr(addr),
                         binop(Iop_F64toI64S, mkU32(Irrm_ZERO), get_ST(0)) );
                fp_pop();
                break;
@@ -6508,22 +6508,22 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                IRTemp  w64 = newTemp(Ity_I64);
                IRDirty*  d;
                if ( have66(pfx) ) {
-                  /* Uses dirty helper: 
+                  /* Uses dirty helper:
                      VexEmNote amd64g_dirtyhelper_FRSTORS
                                   ( VexGuestAMD64State*, HWord ) */
-                  d = unsafeIRDirty_0_N ( 
-                         0/*regparms*/, 
+                  d = unsafeIRDirty_0_N (
+                         0/*regparms*/,
                          "amd64g_dirtyhelper_FRSTORS",
                          &amd64g_dirtyhelper_FRSTORS,
                          mkIRExprVec_1( mkexpr(addr) )
                       );
                   d->mSize = 94;
                } else {
-                  /* Uses dirty helper: 
-                     VexEmNote amd64g_dirtyhelper_FRSTOR 
+                  /* Uses dirty helper:
+                     VexEmNote amd64g_dirtyhelper_FRSTOR
                                   ( VexGuestAMD64State*, HWord ) */
-                  d = unsafeIRDirty_0_N ( 
-                         0/*regparms*/, 
+                  d = unsafeIRDirty_0_N (
+                         0/*regparms*/,
                          "amd64g_dirtyhelper_FRSTOR",
                          &amd64g_dirtyhelper_FRSTOR,
                          mkIRExprVec_2( IRExpr_BBPTR(), mkexpr(addr) )
@@ -6569,7 +6569,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                   sees the warning. */
                assign(ew, unop(Iop_64to32,mkexpr(w64)) );
                put_emwarn( mkexpr(ew) );
-               stmt( 
+               stmt(
                   IRStmt_Exit(
                      binop(Iop_CmpNE32, mkexpr(ew), mkU32(0)),
                      Ijk_EmWarn,
@@ -6589,22 +6589,22 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 6: { /* FNSAVE m94/m108 */
                IRDirty *d;
                if ( have66(pfx) ) {
-                 /* Uses dirty helper: 
+                 /* Uses dirty helper:
                     void amd64g_dirtyhelper_FNSAVES ( VexGuestAMD64State*,
                                                       HWord ) */
-                  d = unsafeIRDirty_0_N ( 
-                         0/*regparms*/, 
-                         "amd64g_dirtyhelper_FNSAVES", 
+                  d = unsafeIRDirty_0_N (
+                         0/*regparms*/,
+                         "amd64g_dirtyhelper_FNSAVES",
                          &amd64g_dirtyhelper_FNSAVES,
                          mkIRExprVec_1( mkexpr(addr) )
                          );
                   d->mSize = 94;
                } else {
-                 /* Uses dirty helper: 
+                 /* Uses dirty helper:
                     void amd64g_dirtyhelper_FNSAVE ( VexGuestAMD64State*,
                                                      HWord ) */
-                  d = unsafeIRDirty_0_N ( 
-                         0/*regparms*/, 
+                  d = unsafeIRDirty_0_N (
+                         0/*regparms*/,
                          "amd64g_dirtyhelper_FNSAVE",
                          &amd64g_dirtyhelper_FNSAVE,
                          mkIRExprVec_2( IRExpr_BBPTR(), mkexpr(addr) )
@@ -6698,9 +6698,9 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                DIP("fucom %%st(0),%%st(%u)\n", r_dst);
                /* This forces C1 to zero, which isn't right. */
                put_C3210(
-                   unop(Iop_32Uto64, 
+                   unop(Iop_32Uto64,
                    binop( Iop_And32,
-                          binop(Iop_Shl32, 
+                          binop(Iop_Shl32,
                                 binop(Iop_CmpF64, get_ST(0), get_ST(r_dst)),
                                 mkU8(8)),
                           mkU32(0x4500)
@@ -6711,10 +6711,10 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                r_dst = (UInt)modrm - 0xE8;
                DIP("fucomp %%st(0),%%st(%u)\n", r_dst);
                /* This forces C1 to zero, which isn't right. */
-               put_C3210( 
-                   unop(Iop_32Uto64, 
+               put_C3210(
+                   unop(Iop_32Uto64,
                    binop( Iop_And32,
-                          binop(Iop_Shl32, 
+                          binop(Iop_Shl32,
                                 binop(Iop_CmpF64, get_ST(0), get_ST(r_dst)),
                                 mkU8(8)),
                           mkU32(0x4500)
@@ -6773,21 +6773,21 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                goto do_foprev_m16;
 
             do_fop_m16:
-               put_ST_UNCHECKED(0, 
-                  triop(fop, 
+               put_ST_UNCHECKED(0,
+                  triop(fop,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                         get_ST(0),
                         unop(Iop_I32StoF64,
-                             unop(Iop_16Sto32, 
+                             unop(Iop_16Sto32,
                                   loadLE(Ity_I16, mkexpr(addr))))));
                break;
 
             do_foprev_m16:
-               put_ST_UNCHECKED(0, 
-                  triop(fop, 
+               put_ST_UNCHECKED(0,
+                  triop(fop,
                         get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                         unop(Iop_I32StoF64,
-                             unop(Iop_16Sto32, 
+                             unop(Iop_16Sto32,
                                   loadLE(Ity_I16, mkexpr(addr)))),
                         get_ST(0)));
                break;
@@ -6814,10 +6814,10 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 0xD9: /* FCOMPP %st(0),%st(1) */
                DIP("fcompp %%st(0),%%st(1)\n");
                /* This forces C1 to zero, which isn't right. */
-               put_C3210( 
+               put_C3210(
                    unop(Iop_32Uto64,
                    binop( Iop_And32,
-                          binop(Iop_Shl32, 
+                          binop(Iop_Shl32,
                                 binop(Iop_CmpF64, get_ST(0), get_ST(1)),
                                 mkU8(8)),
                           mkU32(0x4500)
@@ -6842,7 +6842,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                fp_do_op_ST_ST ( "div", Iop_DivF64, 0, modrm - 0xF8, True );
                break;
 
-            default: 
+            default:
                goto decode_fail;
          }
 
@@ -6872,15 +6872,15 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 
             case 1: /* FISTTPS m16 (SSE3) */
                DIP("fisttps %s\n", dis_buf);
-               storeLE( mkexpr(addr), 
-                        x87ishly_qnarrow_32_to_16( 
+               storeLE( mkexpr(addr),
+                        x87ishly_qnarrow_32_to_16(
                         binop(Iop_F64toI32S, mkU32(Irrm_ZERO), get_ST(0)) ));
                fp_pop();
                break;
 
             case 2: /* FIST m16 */
                DIP("fists %s\n", dis_buf);
-               storeLE( mkexpr(addr), 
+               storeLE( mkexpr(addr),
                         x87ishly_qnarrow_32_to_16(
                         binop(Iop_F64toI32S, get_roundingmode(), get_ST(0)) ));
                break;
@@ -6888,7 +6888,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
             case 3: /* FISTP m16 */
                DIP("fistps %s\n", dis_buf);
                storeLE( mkexpr(addr),
-                        x87ishly_qnarrow_32_to_16( 
+                        x87ishly_qnarrow_32_to_16(
                         binop(Iop_F64toI32S, get_roundingmode(), get_ST(0)) ));
                fp_pop();
                break;
@@ -6903,7 +6903,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 
             case 7: /* FISTP m64 */
                DIP("fistpll %s\n", dis_buf);
-               storeLE( mkexpr(addr), 
+               storeLE( mkexpr(addr),
                         binop(Iop_F64toI64S, get_roundingmode(), get_ST(0)) );
                fp_pop();
                break;
@@ -6935,11 +6935,11 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                   2,
                   unop(Iop_32to16,
                        binop(Iop_Or32,
-                             binop(Iop_Shl32, 
-                                   binop(Iop_And32, get_ftop(), mkU32(7)), 
+                             binop(Iop_Shl32,
+                                   binop(Iop_And32, get_ftop(), mkU32(7)),
                                    mkU8(11)),
-                             binop(Iop_And32, 
-                                   unop(Iop_64to32, get_C3210()), 
+                             binop(Iop_And32,
+                                   unop(Iop_64to32, get_C3210()),
                                    mkU32(0x4700))
                )));
                break;
@@ -6953,7 +6953,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
                fp_do_ucomi_ST0_STi( (UInt)modrm - 0xF0, True );
                break;
 
-            default: 
+            default:
                goto decode_fail;
          }
       }
@@ -6978,7 +6978,7 @@ ULong dis_FPU ( /*OUT*/Bool* decode_ok,
 /*---                                                      ---*/
 /*------------------------------------------------------------*/
 
-/* Effect of MMX insns on x87 FPU state (table 11-2 of 
+/* Effect of MMX insns on x87 FPU state (table 11-2 of
    IA32 arch manual, volume 3):
 
    Read from, or write to MMX register (viz, any insn except EMMS):
@@ -7032,7 +7032,7 @@ static void putMMXReg ( UInt archreg, IRExpr* e )
    sense that it does not first call do_MMX_preamble() -- that is the
    responsibility of its caller. */
 
-static 
+static
 ULong dis_MMXop_regmem_to_reg ( VexAbiInfo* vbi,
                                 Prefix      pfx,
                                 Long        delta,
@@ -7124,7 +7124,7 @@ ULong dis_MMXop_regmem_to_reg ( VexAbiInfo* vbi,
       case 0xD4: op = Iop_Add64; break;
       case 0xFB: op = Iop_Sub64; break;
 
-      default: 
+      default:
          vex_printf("\n0x%x\n", (Int)opc);
          vpanic("dis_MMXop_regmem_to_reg");
    }
@@ -7160,18 +7160,18 @@ ULong dis_MMXop_regmem_to_reg ( VexAbiInfo* vbi,
    } else {
       vassert(hName != NULL);
       vassert(hAddr != NULL);
-      assign( res, 
+      assign( res,
               mkIRExprCCall(
-                 Ity_I64, 
+                 Ity_I64,
                  0/*regparms*/, hName, hAddr,
                  mkIRExprVec_2( argL, argR )
-              ) 
+              )
             );
    }
 
    putMMXReg( gregLO3ofRM(modrm), mkexpr(res) );
 
-   DIP("%s%s %s, %s\n", 
+   DIP("%s%s %s, %s\n",
        name, show_granularity ? nameMMXGran(opc & 3) : "",
        ( isReg ? nameMMXReg(eregLO3ofRM(modrm)) : dis_buf ),
        nameMMXReg(gregLO3ofRM(modrm)) );
@@ -7184,7 +7184,7 @@ ULong dis_MMXop_regmem_to_reg ( VexAbiInfo* vbi,
    of E.  This is a straight copy of dis_SSE_shiftG_byE. */
 
 static ULong dis_MMX_shiftG_byE ( VexAbiInfo* vbi,
-                                  Prefix pfx, Long delta, 
+                                  Prefix pfx, Long delta,
                                   const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -7229,7 +7229,7 @@ static ULong dis_MMX_shiftG_byE ( VexAbiInfo* vbi,
    }
 
    if (shl || shr) {
-     assign( 
+     assign(
         g1,
         IRExpr_ITE(
            binop(Iop_CmpLT64U,mkexpr(amt),mkU64(size)),
@@ -7237,9 +7237,9 @@ static ULong dis_MMX_shiftG_byE ( VexAbiInfo* vbi,
            mkU64(0)
         )
      );
-   } else 
+   } else
    if (sar) {
-     assign( 
+     assign(
         g1,
         IRExpr_ITE(
            binop(Iop_CmpLT64U,mkexpr(amt),mkU64(size)),
@@ -7259,7 +7259,7 @@ static ULong dis_MMX_shiftG_byE ( VexAbiInfo* vbi,
 /* Vector by scalar shift of E by an immediate byte.  This is a
    straight copy of dis_SSE_shiftE_imm. */
 
-static 
+static
 ULong dis_MMX_shiftE_imm ( Long delta, const HChar* opname, IROp op )
 {
    Bool    shl, shr, sar;
@@ -7268,7 +7268,7 @@ ULong dis_MMX_shiftE_imm ( Long delta, const HChar* opname, IROp op )
    IRTemp  e1   = newTemp(Ity_I64);
    UChar   amt, size;
    vassert(epartIsReg(rm));
-   vassert(gregLO3ofRM(rm) == 2 
+   vassert(gregLO3ofRM(rm) == 2
            || gregLO3ofRM(rm) == 4 || gregLO3ofRM(rm) == 6);
    amt = getUChar(delta+1);
    delta += 2;
@@ -7293,13 +7293,13 @@ ULong dis_MMX_shiftE_imm ( Long delta, const HChar* opname, IROp op )
    }
 
    if (shl || shr) {
-     assign( e1, amt >= size 
+     assign( e1, amt >= size
                     ? mkU64(0)
                     : binop(op, mkexpr(e0), mkU8(amt))
      );
-   } else 
+   } else
    if (sar) {
-     assign( e1, amt >= size 
+     assign( e1, amt >= size
                     ? binop(op, mkexpr(e0), mkU8(size-1))
                     : binop(op, mkexpr(e0), mkU8(amt))
      );
@@ -7329,7 +7329,7 @@ ULong dis_MMX ( Bool* decode_ok,
 
    switch (opc) {
 
-      case 0x6E: 
+      case 0x6E:
          if (sz == 4) {
             /* MOVD (src)ireg32-or-mem32 (E), (dst)mmxreg (G)*/
             modrm = getUChar(delta);
@@ -7340,8 +7340,8 @@ ULong dis_MMX ( Bool* decode_ok,
                   binop( Iop_32HLto64,
                          mkU32(0),
                          getIReg32(eregOfRexRM(pfx,modrm)) ) );
-               DIP("movd %s, %s\n", 
-                   nameIReg32(eregOfRexRM(pfx,modrm)), 
+               DIP("movd %s, %s\n",
+                   nameIReg32(eregOfRexRM(pfx,modrm)),
                    nameMMXReg(gregLO3ofRM(modrm)));
             } else {
                IRTemp addr = disAMode( &len, vbi, pfx, delta, dis_buf, 0 );
@@ -7353,7 +7353,7 @@ ULong dis_MMX ( Bool* decode_ok,
                          loadLE(Ity_I32, mkexpr(addr)) ) );
                DIP("movd %s, %s\n", dis_buf, nameMMXReg(gregLO3ofRM(modrm)));
             }
-         } 
+         }
          else
          if (sz == 8) {
             /* MOVD (src)ireg64-or-mem64 (E), (dst)mmxreg (G)*/
@@ -7362,8 +7362,8 @@ ULong dis_MMX ( Bool* decode_ok,
                delta++;
                putMMXReg( gregLO3ofRM(modrm),
                           getIReg64(eregOfRexRM(pfx,modrm)) );
-               DIP("movd %s, %s\n", 
-                   nameIReg64(eregOfRexRM(pfx,modrm)), 
+               DIP("movd %s, %s\n",
+                   nameIReg64(eregOfRexRM(pfx,modrm)),
                    nameMMXReg(gregLO3ofRM(modrm)));
             } else {
                IRTemp addr = disAMode( &len, vbi, pfx, delta, dis_buf, 0 );
@@ -7386,8 +7386,8 @@ ULong dis_MMX ( Bool* decode_ok,
                delta++;
                putIReg32( eregOfRexRM(pfx,modrm),
                           unop(Iop_64to32, getMMXReg(gregLO3ofRM(modrm)) ) );
-               DIP("movd %s, %s\n", 
-                   nameMMXReg(gregLO3ofRM(modrm)), 
+               DIP("movd %s, %s\n",
+                   nameMMXReg(gregLO3ofRM(modrm)),
                    nameIReg32(eregOfRexRM(pfx,modrm)));
             } else {
                IRTemp addr = disAMode( &len, vbi, pfx, delta, dis_buf, 0 );
@@ -7405,8 +7405,8 @@ ULong dis_MMX ( Bool* decode_ok,
                delta++;
                putIReg64( eregOfRexRM(pfx,modrm),
                           getMMXReg(gregLO3ofRM(modrm)) );
-               DIP("movd %s, %s\n", 
-                   nameMMXReg(gregLO3ofRM(modrm)), 
+               DIP("movd %s, %s\n",
+                   nameMMXReg(gregLO3ofRM(modrm)),
                    nameIReg64(eregOfRexRM(pfx,modrm)));
             } else {
                IRTemp addr = disAMode( &len, vbi, pfx, delta, dis_buf, 0 );
@@ -7423,20 +7423,20 @@ ULong dis_MMX ( Bool* decode_ok,
       case 0x6F:
          /* MOVQ (src)mmxreg-or-mem, (dst)mmxreg */
          if (sz != 4
-             && /*ignore redundant REX.W*/!(sz==8 && haveNo66noF2noF3(pfx))) 
+             && /*ignore redundant REX.W*/!(sz==8 && haveNo66noF2noF3(pfx)))
             goto mmx_decode_failure;
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
             delta++;
             putMMXReg( gregLO3ofRM(modrm), getMMXReg(eregLO3ofRM(modrm)) );
-            DIP("movq %s, %s\n", 
-                nameMMXReg(eregLO3ofRM(modrm)), 
+            DIP("movq %s, %s\n",
+                nameMMXReg(eregLO3ofRM(modrm)),
                 nameMMXReg(gregLO3ofRM(modrm)));
          } else {
             IRTemp addr = disAMode( &len, vbi, pfx, delta, dis_buf, 0 );
             delta += len;
             putMMXReg( gregLO3ofRM(modrm), loadLE(Ity_I64, mkexpr(addr)) );
-            DIP("movq %s, %s\n", 
+            DIP("movq %s, %s\n",
                 dis_buf, nameMMXReg(gregLO3ofRM(modrm)));
          }
          break;
@@ -7457,20 +7457,20 @@ ULong dis_MMX ( Bool* decode_ok,
             IRTemp addr = disAMode( &len, vbi, pfx, delta, dis_buf, 0 );
             delta += len;
             storeLE( mkexpr(addr), getMMXReg(gregLO3ofRM(modrm)) );
-            DIP("mov(nt)q %s, %s\n", 
+            DIP("mov(nt)q %s, %s\n",
                 nameMMXReg(gregLO3ofRM(modrm)), dis_buf);
          }
          break;
 
-      case 0xFC: 
-      case 0xFD: 
+      case 0xFC:
+      case 0xFD:
       case 0xFE: /* PADDgg (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "padd", True );
          break;
 
-      case 0xEC: 
+      case 0xEC:
       case 0xED: /* PADDSgg (src)mmxreg-or-mem, (dst)mmxreg */
          if (sz != 4
              && /*ignore redundant REX.W*/!(sz==8 && haveNo66noF2noF3(pfx)))
@@ -7478,43 +7478,43 @@ ULong dis_MMX ( Bool* decode_ok,
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "padds", True );
          break;
 
-      case 0xDC: 
+      case 0xDC:
       case 0xDD: /* PADDUSgg (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "paddus", True );
          break;
 
-      case 0xF8: 
-      case 0xF9: 
+      case 0xF8:
+      case 0xF9:
       case 0xFA: /* PSUBgg (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "psub", True );
          break;
 
-      case 0xE8: 
+      case 0xE8:
       case 0xE9: /* PSUBSgg (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "psubs", True );
          break;
 
-      case 0xD8: 
+      case 0xD8:
       case 0xD9: /* PSUBUSgg (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "psubus", True );
          break;
 
       case 0xE5: /* PMULHW (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "pmulhw", False );
          break;
 
       case 0xD5: /* PMULLW (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "pmullw", False );
          break;
@@ -7524,81 +7524,81 @@ ULong dis_MMX ( Bool* decode_ok,
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "pmaddwd", False );
          break;
 
-      case 0x74: 
-      case 0x75: 
+      case 0x74:
+      case 0x75:
       case 0x76: /* PCMPEQgg (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "pcmpeq", True );
          break;
 
-      case 0x64: 
-      case 0x65: 
+      case 0x64:
+      case 0x65:
       case 0x66: /* PCMPGTgg (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "pcmpgt", True );
          break;
 
       case 0x6B: /* PACKSSDW (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "packssdw", False );
          break;
 
       case 0x63: /* PACKSSWB (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "packsswb", False );
          break;
 
       case 0x67: /* PACKUSWB (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "packuswb", False );
          break;
 
-      case 0x68: 
-      case 0x69: 
+      case 0x68:
+      case 0x69:
       case 0x6A: /* PUNPCKHgg (src)mmxreg-or-mem, (dst)mmxreg */
          if (sz != 4
-             && /*ignore redundant REX.W*/!(sz==8 && haveNo66noF2noF3(pfx))) 
+             && /*ignore redundant REX.W*/!(sz==8 && haveNo66noF2noF3(pfx)))
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "punpckh", True );
          break;
 
-      case 0x60: 
-      case 0x61: 
+      case 0x60:
+      case 0x61:
       case 0x62: /* PUNPCKLgg (src)mmxreg-or-mem, (dst)mmxreg */
          if (sz != 4
-             && /*ignore redundant REX.W*/!(sz==8 && haveNo66noF2noF3(pfx))) 
+             && /*ignore redundant REX.W*/!(sz==8 && haveNo66noF2noF3(pfx)))
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "punpckl", True );
          break;
 
       case 0xDB: /* PAND (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "pand", False );
          break;
 
       case 0xDF: /* PANDN (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "pandn", False );
          break;
 
       case 0xEB: /* POR (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "por", False );
          break;
 
       case 0xEF: /* PXOR (src)mmxreg-or-mem, (dst)mmxreg */
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          delta = dis_MMXop_regmem_to_reg ( vbi, pfx, delta, opc, "pxor", False );
-         break; 
+         break;
 
 #     define SHIFT_BY_REG(_name,_op)                                     \
                 delta = dis_MMX_shiftG_byE(vbi, pfx, delta, _name, _op); \
@@ -7620,12 +7620,12 @@ ULong dis_MMX ( Bool* decode_ok,
 
 #     undef SHIFT_BY_REG
 
-      case 0x71: 
-      case 0x72: 
+      case 0x71:
+      case 0x72:
       case 0x73: {
          /* (sz==4): PSLLgg/PSRAgg/PSRLgg mmxreg by imm8 */
          UChar byte2, subopc;
-         if (sz != 4) 
+         if (sz != 4)
             goto mmx_decode_failure;
          byte2  = getUChar(delta);      /* amode / sub-opcode */
          subopc = toUChar( (byte2 >> 3) & 7 );
@@ -7634,23 +7634,23 @@ ULong dis_MMX ( Bool* decode_ok,
             do { delta = dis_MMX_shiftE_imm(delta,_name,_op);  \
             } while (0)
 
-              if (subopc == 2 /*SRL*/ && opc == 0x71) 
+              if (subopc == 2 /*SRL*/ && opc == 0x71)
                   SHIFT_BY_IMM("psrlw", Iop_ShrN16x4);
-         else if (subopc == 2 /*SRL*/ && opc == 0x72) 
+         else if (subopc == 2 /*SRL*/ && opc == 0x72)
                  SHIFT_BY_IMM("psrld", Iop_ShrN32x2);
-         else if (subopc == 2 /*SRL*/ && opc == 0x73) 
+         else if (subopc == 2 /*SRL*/ && opc == 0x73)
                  SHIFT_BY_IMM("psrlq", Iop_Shr64);
 
-         else if (subopc == 4 /*SAR*/ && opc == 0x71) 
+         else if (subopc == 4 /*SAR*/ && opc == 0x71)
                  SHIFT_BY_IMM("psraw", Iop_SarN16x4);
-         else if (subopc == 4 /*SAR*/ && opc == 0x72) 
+         else if (subopc == 4 /*SAR*/ && opc == 0x72)
                  SHIFT_BY_IMM("psrad", Iop_SarN32x2);
 
-         else if (subopc == 6 /*SHL*/ && opc == 0x71) 
+         else if (subopc == 6 /*SHL*/ && opc == 0x71)
                  SHIFT_BY_IMM("psllw", Iop_ShlN16x4);
-         else if (subopc == 6 /*SHL*/ && opc == 0x72) 
+         else if (subopc == 6 /*SHL*/ && opc == 0x72)
                   SHIFT_BY_IMM("pslld", Iop_ShlN32x2);
-         else if (subopc == 6 /*SHL*/ && opc == 0x73) 
+         else if (subopc == 6 /*SHL*/ && opc == 0x73)
                  SHIFT_BY_IMM("psllq", Iop_Shl64);
 
          else goto mmx_decode_failure;
@@ -7677,12 +7677,12 @@ ULong dis_MMX ( Bool* decode_ok,
          assign( regD, getMMXReg( gregLO3ofRM(modrm) ));
          assign( mask, binop(Iop_SarN8x8, mkexpr(regM), mkU8(7)) );
          assign( olddata, loadLE( Ity_I64, mkexpr(addr) ));
-         assign( newdata, 
-                 binop(Iop_Or64, 
-                       binop(Iop_And64, 
-                             mkexpr(regD), 
+         assign( newdata,
+                 binop(Iop_Or64,
+                       binop(Iop_And64,
+                             mkexpr(regD),
                              mkexpr(mask) ),
-                       binop(Iop_And64, 
+                       binop(Iop_And64,
                              mkexpr(olddata),
                              unop(Iop_Not64, mkexpr(mask)))) );
          storeLE( mkexpr(addr), mkexpr(newdata) );
@@ -7710,19 +7710,19 @@ ULong dis_MMX ( Bool* decode_ok,
 
 /* Generate base << amt with vacated places filled with stuff
    from xtra.  amt guaranteed in 0 .. 63. */
-static 
+static
 IRExpr* shiftL64_with_extras ( IRTemp base, IRTemp xtra, IRTemp amt )
 {
-   /* if   amt == 0 
+   /* if   amt == 0
       then base
       else (base << amt) | (xtra >>u (64-amt))
    */
    return
-      IRExpr_ITE( 
+      IRExpr_ITE(
          binop(Iop_CmpNE8, mkexpr(amt), mkU8(0)),
-         binop(Iop_Or64, 
+         binop(Iop_Or64,
                binop(Iop_Shl64, mkexpr(base), mkexpr(amt)),
-               binop(Iop_Shr64, mkexpr(xtra), 
+               binop(Iop_Shr64, mkexpr(xtra),
                                 binop(Iop_Sub8, mkU8(64), mkexpr(amt)))
                ),
          mkexpr(base)
@@ -7731,19 +7731,19 @@ IRExpr* shiftL64_with_extras ( IRTemp base, IRTemp xtra, IRTemp amt )
 
 /* Generate base >>u amt with vacated places filled with stuff
    from xtra.  amt guaranteed in 0 .. 63. */
-static 
+static
 IRExpr* shiftR64_with_extras ( IRTemp xtra, IRTemp base, IRTemp amt )
 {
-   /* if   amt == 0 
+   /* if   amt == 0
       then base
       else (base >>u amt) | (xtra << (64-amt))
    */
    return
-      IRExpr_ITE( 
+      IRExpr_ITE(
          binop(Iop_CmpNE8, mkexpr(amt), mkU8(0)),
-         binop(Iop_Or64, 
+         binop(Iop_Or64,
                binop(Iop_Shr64, mkexpr(base), mkexpr(amt)),
-               binop(Iop_Shl64, mkexpr(xtra), 
+               binop(Iop_Shl64, mkexpr(xtra),
                                 binop(Iop_Sub8, mkU8(64), mkexpr(amt)))
                ),
          mkexpr(base)
@@ -7784,7 +7784,7 @@ ULong dis_SHLRD_Gv_Ev ( VexAbiInfo* vbi,
 
    /* The E-part is the destination; this is shifted.  The G-part
       supplies bits to be shifted into the E-part, but is not
-      changed.  
+      changed.
 
       If shifting left, form a double-length word with E at the top
       and G at the bottom, and shift this left.  The result is then in
@@ -7802,17 +7802,17 @@ ULong dis_SHLRD_Gv_Ev ( VexAbiInfo* vbi,
       delta++;
       assign( esrc, getIRegE(sz, pfx, modrm) );
       DIP("sh%cd%c %s, %s, %s\n",
-          ( left_shift ? 'l' : 'r' ), nameISize(sz), 
+          ( left_shift ? 'l' : 'r' ), nameISize(sz),
           shift_amt_txt,
           nameIRegG(sz, pfx, modrm), nameIRegE(sz, pfx, modrm));
    } else {
-      addr = disAMode ( &len, vbi, pfx, delta, dis_buf, 
+      addr = disAMode ( &len, vbi, pfx, delta, dis_buf,
                         /* # bytes following amode */
                         amt_is_literal ? 1 : 0 );
       delta += len;
       assign( esrc, loadLE(ty, mkexpr(addr)) );
-      DIP("sh%cd%c %s, %s, %s\n", 
-          ( left_shift ? 'l' : 'r' ), nameISize(sz), 
+      DIP("sh%cd%c %s, %s, %s\n",
+          ( left_shift ? 'l' : 'r' ), nameISize(sz),
           shift_amt_txt,
           nameIRegG(sz, pfx, modrm), dis_buf);
    }
@@ -7822,7 +7822,7 @@ ULong dis_SHLRD_Gv_Ev ( VexAbiInfo* vbi,
       value (rss64). */
 
    assign( tmpSH, binop(Iop_And8, shift_amt, mkU8(mask)) );
-   assign( tmpSS, binop(Iop_And8, 
+   assign( tmpSS, binop(Iop_And8,
                         binop(Iop_Sub8, mkexpr(tmpSH), mkU8(1) ),
                         mkU8(mask)));
 
@@ -7836,12 +7836,12 @@ ULong dis_SHLRD_Gv_Ev ( VexAbiInfo* vbi,
       /* what a freaking nightmare: */
       if (sz == 4 && left_shift) {
          assign( tmp64, binop(Iop_32HLto64, mkexpr(esrc), mkexpr(gsrc)) );
-         assign( res64, 
-                 binop(Iop_Shr64, 
+         assign( res64,
+                 binop(Iop_Shr64,
                        binop(Iop_Shl64, mkexpr(tmp64), mkexpr(tmpSH)),
                        mkU8(32)) );
-         assign( rss64, 
-                 binop(Iop_Shr64, 
+         assign( rss64,
+                 binop(Iop_Shr64,
                        binop(Iop_Shl64, mkexpr(tmp64), mkexpr(tmpSS)),
                        mkU8(32)) );
       }
@@ -7859,14 +7859,14 @@ ULong dis_SHLRD_Gv_Ev ( VexAbiInfo* vbi,
                        binop(Iop_16HLto32, mkexpr(gsrc), mkexpr(gsrc))
          ));
          /* result formed by shifting [esrc'gsrc'gsrc'gsrc] */
-         assign( res64, 
-                 binop(Iop_Shr64, 
+         assign( res64,
+                 binop(Iop_Shr64,
                        binop(Iop_Shl64, mkexpr(tmp64), mkexpr(tmpSH)),
                        mkU8(48)) );
          /* subshift formed by shifting [esrc'0000'0000'0000] */
-         assign( rss64, 
-                 binop(Iop_Shr64, 
-                       binop(Iop_Shl64, 
+         assign( rss64,
+                 binop(Iop_Shr64,
+                       binop(Iop_Shl64,
                              binop(Iop_Shl64, unop(Iop_16Uto64, mkexpr(esrc)),
                                               mkU8(48)),
                              mkexpr(tmpSS)),
@@ -7882,8 +7882,8 @@ ULong dis_SHLRD_Gv_Ev ( VexAbiInfo* vbi,
          /* result formed by shifting [gsrc'gsrc'gsrc'esrc] */
          assign( res64, binop(Iop_Shr64, mkexpr(tmp64), mkexpr(tmpSH)) );
          /* subshift formed by shifting [0000'0000'0000'esrc] */
-         assign( rss64, binop(Iop_Shr64, 
-                              unop(Iop_16Uto64, mkexpr(esrc)), 
+         assign( rss64, binop(Iop_Shr64,
+                              unop(Iop_16Uto64, mkexpr(esrc)),
                               mkexpr(tmpSS)) );
       }
 
@@ -7945,12 +7945,12 @@ ULong dis_bt_G_E ( VexAbiInfo* vbi,
    HChar  dis_buf[50];
    UChar  modrm;
    Int    len;
-   IRTemp t_fetched, t_bitno0, t_bitno1, t_bitno2, t_addr0, 
+   IRTemp t_fetched, t_bitno0, t_bitno1, t_bitno2, t_addr0,
           t_addr1, t_rsp, t_mask, t_new;
 
    vassert(sz == 2 || sz == 4 || sz == 8);
 
-   t_fetched = t_bitno0 = t_bitno1 = t_bitno2 
+   t_fetched = t_bitno0 = t_bitno1 = t_bitno2
              = t_addr0 = t_addr1 = t_rsp
              = t_mask = t_new = IRTemp_INVALID;
 
@@ -7981,7 +7981,7 @@ ULong dis_bt_G_E ( VexAbiInfo* vbi,
    }
 
    assign( t_bitno0, widenSto64(getIRegG(sz, pfx, modrm)) );
-   
+
    if (epartIsReg(modrm)) {
       delta++;
       /* Get it onto the client's stack.  Oh, this is a horrible
@@ -8012,8 +8012,8 @@ ULong dis_bt_G_E ( VexAbiInfo* vbi,
 
       /* Mask out upper bits of the shift amount, since we're doing a
          reg. */
-      assign( t_bitno1, binop(Iop_And64, 
-                              mkexpr(t_bitno0), 
+      assign( t_bitno1, binop(Iop_And64,
+                              mkexpr(t_bitno0),
                               mkU64(sz == 8 ? 63 : sz == 4 ? 31 : 15)) );
 
    } else {
@@ -8021,22 +8021,22 @@ ULong dis_bt_G_E ( VexAbiInfo* vbi,
       delta += len;
       assign( t_bitno1, mkexpr(t_bitno0) );
    }
-  
+
    /* At this point: t_addr0 is the address being operated on.  If it
       was a reg, we will have pushed it onto the client's stack.
       t_bitno1 is the bit number, suitably masked in the case of a
       reg.  */
-  
+
    /* Now the main sequence. */
-   assign( t_addr1, 
-           binop(Iop_Add64, 
-                 mkexpr(t_addr0), 
+   assign( t_addr1,
+           binop(Iop_Add64,
+                 mkexpr(t_addr0),
                  binop(Iop_Sar64, mkexpr(t_bitno1), mkU8(3))) );
 
    /* t_addr1 now holds effective address */
 
-   assign( t_bitno2, 
-           unop(Iop_64to8, 
+   assign( t_bitno2,
+           unop(Iop_64to8,
                 binop(Iop_And64, mkexpr(t_bitno1), mkU64(7))) );
 
    /* t_bitno2 contains offset of bit within byte */
@@ -8062,10 +8062,10 @@ ULong dis_bt_G_E ( VexAbiInfo* vbi,
             break;
          case BtOpReset:
             assign( t_new,
-                    binop(Iop_And8, mkexpr(t_fetched), 
+                    binop(Iop_And8, mkexpr(t_fetched),
                                     unop(Iop_Not8, mkexpr(t_mask))) );
             break;
-         default: 
+         default:
             vpanic("dis_bt_G_E(amd64)");
       }
       if ((haveLOCK(pfx)) && !epartIsReg(modrm)) {
@@ -8076,15 +8076,15 @@ ULong dis_bt_G_E ( VexAbiInfo* vbi,
          storeLE( mkexpr(t_addr1), mkexpr(t_new) );
       }
    }
-  
+
    /* Side effect done; now get selected bit into Carry flag */
    /* Flags: C=selected bit, O,S,Z,A,P undefined, so are set to zero. */
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
    stmt( IRStmt_Put( OFFB_CC_DEP2, mkU64(0) ));
-   stmt( IRStmt_Put( 
+   stmt( IRStmt_Put(
             OFFB_CC_DEP1,
             binop(Iop_And64,
-                  binop(Iop_Shr64, 
+                  binop(Iop_Shr64,
                         unop(Iop_8Uto64, mkexpr(t_fetched)),
                         mkexpr(t_bitno2)),
                   mkU64(1)))
@@ -8105,9 +8105,9 @@ ULong dis_bt_G_E ( VexAbiInfo* vbi,
    }
 
    DIP("bt%s%c %s, %s\n",
-       nameBtOp(op), nameISize(sz), nameIRegG(sz, pfx, modrm), 
+       nameBtOp(op), nameISize(sz), nameIRegG(sz, pfx, modrm),
        ( epartIsReg(modrm) ? nameIRegE(sz, pfx, modrm) : dis_buf ) );
- 
+
    return delta;
 }
 
@@ -8144,8 +8144,8 @@ ULong dis_bs_E_G ( VexAbiInfo* vbi,
    }
 
    DIP("bs%c%c %s, %s\n",
-       fwds ? 'f' : 'r', nameISize(sz), 
-       ( isReg ? nameIRegE(sz, pfx, modrm) : dis_buf ), 
+       fwds ? 'f' : 'r', nameISize(sz),
+       ( isReg ? nameIRegE(sz, pfx, modrm) : dis_buf ),
        nameIRegG(sz, pfx, modrm));
 
    /* First, widen src to 64 bits if it is not already. */
@@ -8159,11 +8159,11 @@ ULong dis_bs_E_G ( VexAbiInfo* vbi,
       careful handling. */
    assign( srcB, binop(Iop_ExpCmpNE64, mkexpr(src64), mkU64(0)) );
 
-   /* Flags: Z is 1 iff source value is zero.  All others 
+   /* Flags: Z is 1 iff source value is zero.  All others
       are undefined -- we force them to zero. */
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
    stmt( IRStmt_Put( OFFB_CC_DEP2, mkU64(0) ));
-   stmt( IRStmt_Put( 
+   stmt( IRStmt_Put(
             OFFB_CC_DEP1,
             IRExpr_ITE( mkexpr(srcB),
                         /* src!=0 */
@@ -8183,33 +8183,33 @@ ULong dis_bs_E_G ( VexAbiInfo* vbi,
 
    /* Bleh.  What we compute:
 
-          bsf64:  if src == 0 then {dst is unchanged} 
+          bsf64:  if src == 0 then {dst is unchanged}
                               else Ctz64(src)
 
-          bsr64:  if src == 0 then {dst is unchanged} 
+          bsr64:  if src == 0 then {dst is unchanged}
                               else 63 - Clz64(src)
 
-          bsf32:  if src == 0 then {dst is unchanged} 
+          bsf32:  if src == 0 then {dst is unchanged}
                               else Ctz64(32Uto64(src))
 
           bsr32:  if src == 0 then {dst is unchanged}
                               else 63 - Clz64(32Uto64(src))
 
-          bsf16:  if src == 0 then {dst is unchanged} 
+          bsf16:  if src == 0 then {dst is unchanged}
                               else Ctz64(32Uto64(16Uto32(src)))
 
-          bsr16:  if src == 0 then {dst is unchanged} 
+          bsr16:  if src == 0 then {dst is unchanged}
                               else 63 - Clz64(32Uto64(16Uto32(src)))
    */
 
    /* The main computation, guarding against zero. */
    assign( dst64,
-           IRExpr_ITE( 
+           IRExpr_ITE(
               mkexpr(srcB),
               /* src != 0 */
               fwds ? unop(Iop_Ctz64, mkexpr(src64))
-                   : binop(Iop_Sub64, 
-                           mkU64(63), 
+                   : binop(Iop_Sub64,
+                           mkU64(63),
                            unop(Iop_Clz64, mkexpr(src64))),
               /* src == 0 -- leave dst unchanged */
               widenUto64( getIRegG( sz, pfx, modrm ) )
@@ -8232,7 +8232,7 @@ ULong dis_bs_E_G ( VexAbiInfo* vbi,
 
 
 /* swap rAX with the reg specified by reg and REX.B */
-static 
+static
 void codegen_xchg_rAX_Reg ( Prefix pfx, Int sz, UInt regLo3 )
 {
    IRType ty = szToITy(sz);
@@ -8256,17 +8256,17 @@ void codegen_xchg_rAX_Reg ( Prefix pfx, Int sz, UInt regLo3 )
       putIReg16( R_RAX, mkexpr(t2) );
       putIRegRexB(2, pfx, regLo3, mkexpr(t1) );
    }
-   DIP("xchg%c %s, %s\n", 
-       nameISize(sz), nameIRegRAX(sz), 
+   DIP("xchg%c %s, %s\n",
+       nameISize(sz), nameIRegRAX(sz),
                       nameIRegRexB(sz,pfx, regLo3));
 }
 
 
-static 
+static
 void codegen_SAHF ( void )
 {
    /* Set the flags to:
-      (amd64g_calculate_flags_all() & AMD64G_CC_MASK_O) 
+      (amd64g_calculate_flags_all() & AMD64G_CC_MASK_O)
                                     -- retain the old O flag
       | (%AH & (AMD64G_CC_MASK_S|AMD64G_CC_MASK_Z|AMD64G_CC_MASK_A
                 |AMD64G_CC_MASK_P|AMD64G_CC_MASK_C)
@@ -8281,7 +8281,7 @@ void codegen_SAHF ( void )
    stmt( IRStmt_Put( OFFB_CC_DEP1,
          binop(Iop_Or64,
                binop(Iop_And64, mkexpr(oldflags), mkU64(AMD64G_CC_MASK_O)),
-               binop(Iop_And64, 
+               binop(Iop_And64,
                      binop(Iop_Shr64, getIReg64(R_RAX), mkU8(8)),
                      mkU64(mask_SZACP))
               )
@@ -8289,7 +8289,7 @@ void codegen_SAHF ( void )
 }
 
 
-static 
+static
 void codegen_LAHF ( void  )
 {
    /* AH <- EFLAGS(SF:ZF:0:AF:0:PF:1:CF) */
@@ -8302,12 +8302,12 @@ void codegen_LAHF ( void  )
    IRTemp  flags = newTemp(Ity_I64);
    assign( flags, mk_amd64g_calculate_rflags_all() );
 
-   rax_with_hole 
+   rax_with_hole
       = binop(Iop_And64, getIReg64(R_RAX), mkU64(~0xFF00ULL));
-   new_byte 
+   new_byte
       = binop(Iop_Or64, binop(Iop_And64, mkexpr(flags), mkU64(mask_SZACP)),
                         mkU64(1<<1));
-   new_rax 
+   new_rax
       = binop(Iop_Or64, rax_with_hole,
                         binop(Iop_Shl64, new_byte, mkU8(8)));
    putIReg64(R_RAX, new_rax);
@@ -8318,7 +8318,7 @@ static
 ULong dis_cmpxchg_G_E ( /*OUT*/Bool* ok,
                         VexAbiInfo*  vbi,
                         Prefix       pfx,
-                        Int          size, 
+                        Int          size,
                         Long         delta0 )
 {
    HChar dis_buf[50];
@@ -8377,7 +8377,7 @@ ULong dis_cmpxchg_G_E ( /*OUT*/Bool* ok,
       DIP("cmpxchg%c %s,%s\n", nameISize(size),
                                nameIRegG(size,pfx,rm),
                                nameIRegE(size,pfx,rm) );
-   } 
+   }
    else if (!epartIsReg(rm) && !haveLOCK(pfx)) {
       /* case 2 */
       addr = disAMode ( &len, vbi, pfx, delta0, dis_buf, 0 );
@@ -8391,7 +8391,7 @@ ULong dis_cmpxchg_G_E ( /*OUT*/Bool* ok,
       assign( acc2,  IRExpr_ITE(mkexpr(cond), mkexpr(acc), mkexpr(dest)) );
       putIRegRAX(size, mkexpr(acc2));
       storeLE( mkexpr(addr), mkexpr(dest2) );
-      DIP("cmpxchg%c %s,%s\n", nameISize(size), 
+      DIP("cmpxchg%c %s,%s\n", nameISize(size),
                                nameIRegG(size,pfx,rm), dis_buf);
    }
    else if (!epartIsReg(rm) && haveLOCK(pfx)) {
@@ -8404,15 +8404,15 @@ ULong dis_cmpxchg_G_E ( /*OUT*/Bool* ok,
       delta0 += len;
       assign( src, getIRegG(size, pfx, rm) );
       assign( acc, getIRegRAX(size) );
-      stmt( IRStmt_CAS( 
-         mkIRCAS( IRTemp_INVALID, dest, Iend_LE, mkexpr(addr), 
+      stmt( IRStmt_CAS(
+         mkIRCAS( IRTemp_INVALID, dest, Iend_LE, mkexpr(addr),
                   NULL, mkexpr(acc), NULL, mkexpr(src) )
       ));
       setFlags_DEP1_DEP2(Iop_Sub8, acc, dest, ty);
       assign( cond, mk_amd64g_calculate_condition(AMD64CondZ) );
       assign( acc2,  IRExpr_ITE(mkexpr(cond), mkexpr(acc), mkexpr(dest)) );
       putIRegRAX(size, mkexpr(acc2));
-      DIP("cmpxchg%c %s,%s\n", nameISize(size), 
+      DIP("cmpxchg%c %s,%s\n", nameISize(size),
                                nameIRegG(size,pfx,rm), dis_buf);
    }
    else vassert(0);
@@ -8432,7 +8432,7 @@ ULong dis_cmpxchg_G_E ( /*OUT*/Bool* ok,
                        GET %G, tmpd
                        CMOVcc tmps, tmpd
                        PUT tmpd, %G
- 
+
    If E is mem  -->    (getAddr E) -> tmpa
                        LD (tmpa), tmps
                        GET %G, tmpd
@@ -8442,7 +8442,7 @@ ULong dis_cmpxchg_G_E ( /*OUT*/Bool* ok,
 static
 ULong dis_cmov_E_G ( VexAbiInfo* vbi,
                      Prefix        pfx,
-                     Int           sz, 
+                     Int           sz,
                      AMD64Condcode cond,
                      Long          delta0 )
 {
@@ -8469,7 +8469,7 @@ ULong dis_cmov_E_G ( VexAbiInfo* vbi,
       return 1+delta0;
    }
 
-   /* E refers to memory */    
+   /* E refers to memory */
    {
       IRTemp addr = disAMode ( &len, vbi, pfx, delta0, dis_buf, 0 );
       assign( tmps, loadLE(ty, mkexpr(addr)) );
@@ -8548,7 +8548,7 @@ ULong dis_xadd_G_E ( /*OUT*/Bool* decode_ok,
       IRTemp addr = disAMode ( &len, vbi, pfx, delta0, dis_buf, 0 );
       assign( tmpd,  loadLE(ty, mkexpr(addr)) );
       assign( tmpt0, getIRegG(sz, pfx, rm) );
-      assign( tmpt1, binop(mkSizedOp(ty,Iop_Add8), 
+      assign( tmpt1, binop(mkSizedOp(ty,Iop_Add8),
                            mkexpr(tmpd), mkexpr(tmpt0)) );
       casLE( mkexpr(addr), mkexpr(tmpd)/*expVal*/,
                            mkexpr(tmpt1)/*newVal*/, guest_RIP_curr_instr );
@@ -8564,7 +8564,7 @@ ULong dis_xadd_G_E ( /*OUT*/Bool* decode_ok,
 }
 
 //.. /* Move 16 bits from Ew (ireg or mem) to G (a segment register). */
-//.. 
+//..
 //.. static
 //.. UInt dis_mov_Ew_Sw ( UChar sorb, Long delta0 )
 //.. {
@@ -8572,7 +8572,7 @@ ULong dis_xadd_G_E ( /*OUT*/Bool* decode_ok,
 //..    IRTemp addr;
 //..    UChar  rm  = getUChar(delta0);
 //..    HChar  dis_buf[50];
-//.. 
+//..
 //..    if (epartIsReg(rm)) {
 //..       putSReg( gregOfRM(rm), getIReg(2, eregOfRM(rm)) );
 //..       DIP("movw %s,%s\n", nameIReg(2,eregOfRM(rm)), nameSReg(gregOfRM(rm)));
@@ -8584,10 +8584,10 @@ ULong dis_xadd_G_E ( /*OUT*/Bool* decode_ok,
 //..       return len+delta0;
 //..    }
 //.. }
-//.. 
+//..
 //.. /* Move 16 bits from G (a segment register) to Ew (ireg or mem).  If
 //..    dst is ireg and sz==4, zero out top half of it.  */
-//.. 
+//..
 //.. static
 //.. UInt dis_mov_Sw_Ew ( UChar sorb,
 //..                      Int   sz,
@@ -8597,15 +8597,15 @@ ULong dis_xadd_G_E ( /*OUT*/Bool* decode_ok,
 //..    IRTemp addr;
 //..    UChar  rm  = getUChar(delta0);
 //..    HChar  dis_buf[50];
-//.. 
+//..
 //..    vassert(sz == 2 || sz == 4);
-//.. 
+//..
 //..    if (epartIsReg(rm)) {
 //..       if (sz == 4)
 //..          putIReg(4, eregOfRM(rm), unop(Iop_16Uto32, getSReg(gregOfRM(rm))));
 //..       else
 //..          putIReg(2, eregOfRM(rm), getSReg(gregOfRM(rm)));
-//.. 
+//..
 //..       DIP("mov %s,%s\n", nameSReg(gregOfRM(rm)), nameIReg(sz,eregOfRM(rm)));
 //..       return 1+delta0;
 //..    } else {
@@ -8615,33 +8615,33 @@ ULong dis_xadd_G_E ( /*OUT*/Bool* decode_ok,
 //..       return len+delta0;
 //..    }
 //.. }
-//.. 
-//.. 
-//.. static 
+//..
+//..
+//.. static
 //.. void dis_push_segreg ( UInt sreg, Int sz )
 //.. {
 //..     IRTemp t1 = newTemp(Ity_I16);
 //..     IRTemp ta = newTemp(Ity_I32);
 //..     vassert(sz == 2 || sz == 4);
-//.. 
+//..
 //..     assign( t1, getSReg(sreg) );
 //..     assign( ta, binop(Iop_Sub32, getIReg(4, R_ESP), mkU32(sz)) );
 //..     putIReg(4, R_ESP, mkexpr(ta));
 //..     storeLE( mkexpr(ta), mkexpr(t1) );
-//.. 
+//..
 //..     DIP("pushw %s\n", nameSReg(sreg));
 //.. }
-//.. 
+//..
 //.. static
 //.. void dis_pop_segreg ( UInt sreg, Int sz )
 //.. {
 //..     IRTemp t1 = newTemp(Ity_I16);
 //..     IRTemp ta = newTemp(Ity_I32);
 //..     vassert(sz == 2 || sz == 4);
-//.. 
+//..
 //..     assign( ta, getIReg(4, R_ESP) );
 //..     assign( t1, loadLE(Ity_I16, mkexpr(ta)) );
-//.. 
+//..
 //..     putIReg(4, R_ESP, binop(Iop_Add32, mkexpr(ta), mkU32(sz)) );
 //..     putSReg( sreg, mkexpr(t1) );
 //..     DIP("pop %s\n", nameSReg(sreg));
@@ -8650,7 +8650,7 @@ ULong dis_xadd_G_E ( /*OUT*/Bool* decode_ok,
 static
 void dis_ret ( /*MOD*/DisResult* dres, VexAbiInfo* vbi, ULong d64 )
 {
-   IRTemp t1 = newTemp(Ity_I64); 
+   IRTemp t1 = newTemp(Ity_I64);
    IRTemp t2 = newTemp(Ity_I64);
    IRTemp t3 = newTemp(Ity_I64);
    assign(t1, getIReg64(R_RSP));
@@ -8693,13 +8693,13 @@ static Bool requiresRMode ( IROp op )
 }
 
 
-/* Worker function; do not call directly. 
+/* Worker function; do not call directly.
    Handles full width G = G `op` E   and   G = (not G) `op` E.
 */
 
-static ULong dis_SSE_E_to_G_all_wrk ( 
+static ULong dis_SSE_E_to_G_all_wrk (
                 VexAbiInfo* vbi,
-                Prefix pfx, Long delta, 
+                Prefix pfx, Long delta,
                 const HChar* opname, IROp op,
                 Bool   invertG
              )
@@ -8729,7 +8729,7 @@ static ULong dis_SSE_E_to_G_all_wrk (
    } else {
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
       putXMMReg(
-         gregOfRexRM(pfx,rm), 
+         gregOfRexRM(pfx,rm),
          needsRMode
             ? triop(op, get_FAKE_roundingmode(), /* XXXROUNDINGFIXME */
                         gpart,
@@ -8749,7 +8749,7 @@ static ULong dis_SSE_E_to_G_all_wrk (
 
 static
 ULong dis_SSE_E_to_G_all ( VexAbiInfo* vbi,
-                           Prefix pfx, Long delta, 
+                           Prefix pfx, Long delta,
                            const HChar* opname, IROp op )
 {
    return dis_SSE_E_to_G_all_wrk( vbi, pfx, delta, opname, op, False );
@@ -8759,7 +8759,7 @@ ULong dis_SSE_E_to_G_all ( VexAbiInfo* vbi,
 
 static
 ULong dis_SSE_E_to_G_all_invG ( VexAbiInfo* vbi,
-                                Prefix pfx, Long delta, 
+                                Prefix pfx, Long delta,
                                 const HChar* opname, IROp op )
 {
    return dis_SSE_E_to_G_all_wrk( vbi, pfx, delta, opname, op, True );
@@ -8769,7 +8769,7 @@ ULong dis_SSE_E_to_G_all_invG ( VexAbiInfo* vbi,
 /* Lowest 32-bit lane only SSE binary operation, G = G `op` E. */
 
 static ULong dis_SSE_E_to_G_lo32 ( VexAbiInfo* vbi,
-                                   Prefix pfx, Long delta, 
+                                   Prefix pfx, Long delta,
                                    const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -8778,7 +8778,7 @@ static ULong dis_SSE_E_to_G_lo32 ( VexAbiInfo* vbi,
    UChar   rm = getUChar(delta);
    IRExpr* gpart = getXMMReg(gregOfRexRM(pfx,rm));
    if (epartIsReg(rm)) {
-      putXMMReg( gregOfRexRM(pfx,rm), 
+      putXMMReg( gregOfRexRM(pfx,rm),
                  binop(op, gpart,
                            getXMMReg(eregOfRexRM(pfx,rm))) );
       DIP("%s %s,%s\n", opname,
@@ -8792,7 +8792,7 @@ static ULong dis_SSE_E_to_G_lo32 ( VexAbiInfo* vbi,
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
       assign( epart, unop( Iop_32UtoV128,
                            loadLE(Ity_I32, mkexpr(addr))) );
-      putXMMReg( gregOfRexRM(pfx,rm), 
+      putXMMReg( gregOfRexRM(pfx,rm),
                  binop(op, gpart, mkexpr(epart)) );
       DIP("%s %s,%s\n", opname,
                         dis_buf,
@@ -8805,7 +8805,7 @@ static ULong dis_SSE_E_to_G_lo32 ( VexAbiInfo* vbi,
 /* Lower 64-bit lane only SSE binary operation, G = G `op` E. */
 
 static ULong dis_SSE_E_to_G_lo64 ( VexAbiInfo* vbi,
-                                   Prefix pfx, Long delta, 
+                                   Prefix pfx, Long delta,
                                    const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -8814,7 +8814,7 @@ static ULong dis_SSE_E_to_G_lo64 ( VexAbiInfo* vbi,
    UChar   rm = getUChar(delta);
    IRExpr* gpart = getXMMReg(gregOfRexRM(pfx,rm));
    if (epartIsReg(rm)) {
-      putXMMReg( gregOfRexRM(pfx,rm), 
+      putXMMReg( gregOfRexRM(pfx,rm),
                  binop(op, gpart,
                            getXMMReg(eregOfRexRM(pfx,rm))) );
       DIP("%s %s,%s\n", opname,
@@ -8828,7 +8828,7 @@ static ULong dis_SSE_E_to_G_lo64 ( VexAbiInfo* vbi,
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
       assign( epart, unop( Iop_64UtoV128,
                            loadLE(Ity_I64, mkexpr(addr))) );
-      putXMMReg( gregOfRexRM(pfx,rm), 
+      putXMMReg( gregOfRexRM(pfx,rm),
                  binop(op, gpart, mkexpr(epart)) );
       DIP("%s %s,%s\n", opname,
                         dis_buf,
@@ -8840,9 +8840,9 @@ static ULong dis_SSE_E_to_G_lo64 ( VexAbiInfo* vbi,
 
 /* All lanes unary SSE operation, G = op(E). */
 
-static ULong dis_SSE_E_to_G_unary_all ( 
+static ULong dis_SSE_E_to_G_unary_all (
                 VexAbiInfo* vbi,
-                Prefix pfx, Long delta, 
+                Prefix pfx, Long delta,
                 const HChar* opname, IROp op
              )
 {
@@ -8851,7 +8851,7 @@ static ULong dis_SSE_E_to_G_unary_all (
    IRTemp  addr;
    UChar   rm = getUChar(delta);
    if (epartIsReg(rm)) {
-      putXMMReg( gregOfRexRM(pfx,rm), 
+      putXMMReg( gregOfRexRM(pfx,rm),
                  unop(op, getXMMReg(eregOfRexRM(pfx,rm))) );
       DIP("%s %s,%s\n", opname,
                         nameXMMReg(eregOfRexRM(pfx,rm)),
@@ -8859,7 +8859,7 @@ static ULong dis_SSE_E_to_G_unary_all (
       return delta+1;
    } else {
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
-      putXMMReg( gregOfRexRM(pfx,rm), 
+      putXMMReg( gregOfRexRM(pfx,rm),
                  unop(op, loadLE(Ity_V128, mkexpr(addr))) );
       DIP("%s %s,%s\n", opname,
                         dis_buf,
@@ -8871,9 +8871,9 @@ static ULong dis_SSE_E_to_G_unary_all (
 
 /* Lowest 32-bit lane only unary SSE operation, G = op(E). */
 
-static ULong dis_SSE_E_to_G_unary_lo32 ( 
+static ULong dis_SSE_E_to_G_unary_lo32 (
                 VexAbiInfo* vbi,
-                Prefix pfx, Long delta, 
+                Prefix pfx, Long delta,
                 const HChar* opname, IROp op
              )
 {
@@ -8889,7 +8889,7 @@ static ULong dis_SSE_E_to_G_unary_lo32 (
    assign( oldG0, getXMMReg(gregOfRexRM(pfx,rm)) );
 
    if (epartIsReg(rm)) {
-      assign( oldG1, 
+      assign( oldG1,
               binop( Iop_SetV128lo32,
                      mkexpr(oldG0),
                      getXMMRegLane32(eregOfRexRM(pfx,rm), 0)) );
@@ -8900,7 +8900,7 @@ static ULong dis_SSE_E_to_G_unary_lo32 (
       return delta+1;
    } else {
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
-      assign( oldG1, 
+      assign( oldG1,
               binop( Iop_SetV128lo32,
                      mkexpr(oldG0),
                      loadLE(Ity_I32, mkexpr(addr)) ));
@@ -8915,9 +8915,9 @@ static ULong dis_SSE_E_to_G_unary_lo32 (
 
 /* Lowest 64-bit lane only unary SSE operation, G = op(E). */
 
-static ULong dis_SSE_E_to_G_unary_lo64 ( 
+static ULong dis_SSE_E_to_G_unary_lo64 (
                 VexAbiInfo* vbi,
-                Prefix pfx, Long delta, 
+                Prefix pfx, Long delta,
                 const HChar* opname, IROp op
              )
 {
@@ -8933,7 +8933,7 @@ static ULong dis_SSE_E_to_G_unary_lo64 (
    assign( oldG0, getXMMReg(gregOfRexRM(pfx,rm)) );
 
    if (epartIsReg(rm)) {
-      assign( oldG1, 
+      assign( oldG1,
               binop( Iop_SetV128lo64,
                      mkexpr(oldG0),
                      getXMMRegLane64(eregOfRexRM(pfx,rm), 0)) );
@@ -8944,7 +8944,7 @@ static ULong dis_SSE_E_to_G_unary_lo64 (
       return delta+1;
    } else {
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
-      assign( oldG1, 
+      assign( oldG1,
               binop( Iop_SetV128lo64,
                      mkexpr(oldG0),
                      loadLE(Ity_I64, mkexpr(addr)) ));
@@ -8961,9 +8961,9 @@ static ULong dis_SSE_E_to_G_unary_lo64 (
       G = G `op` E   (eLeft == False)
       G = E `op` G   (eLeft == True)
 */
-static ULong dis_SSEint_E_to_G( 
+static ULong dis_SSEint_E_to_G(
                 VexAbiInfo* vbi,
-                Prefix pfx, Long delta, 
+                Prefix pfx, Long delta,
                 const HChar* opname, IROp op,
                 Bool   eLeft
              )
@@ -8988,7 +8988,7 @@ static ULong dis_SSEint_E_to_G(
                         nameXMMReg(gregOfRexRM(pfx,rm)) );
       delta += alen;
    }
-   putXMMReg( gregOfRexRM(pfx,rm), 
+   putXMMReg( gregOfRexRM(pfx,rm),
               eLeft ? binop(op, epart, gpart)
                     : binop(op, gpart, epart) );
    return delta;
@@ -9118,7 +9118,7 @@ static Bool findSSECmpOp ( /*OUT*/Bool* preSwapP,
    returns the original delta to indicate failure. */
 
 static Long dis_SSE_cmp_E_to_G ( VexAbiInfo* vbi,
-                                 Prefix pfx, Long delta, 
+                                 Prefix pfx, Long delta,
                                  const HChar* opname, Bool all_lanes, Int sz )
 {
    Long    delta0 = delta;
@@ -9139,7 +9139,7 @@ static Long dis_SSE_cmp_E_to_G ( VexAbiInfo* vbi,
       Bool ok = findSSECmpOp(&preSwap, &op, &postNot, imm8, all_lanes, sz);
       if (!ok) return delta0; /* FAIL */
       vassert(!preSwap); /* never needed for imm8 < 8 */
-      assign( plain, binop(op, getXMMReg(gregOfRexRM(pfx,rm)), 
+      assign( plain, binop(op, getXMMReg(gregOfRexRM(pfx,rm)),
                                getXMMReg(eregOfRexRM(pfx,rm))) );
       delta += 2;
       DIP("%s $%d,%s,%s\n", opname,
@@ -9153,17 +9153,17 @@ static Long dis_SSE_cmp_E_to_G ( VexAbiInfo* vbi,
       Bool ok = findSSECmpOp(&preSwap, &op, &postNot, imm8, all_lanes, sz);
       if (!ok) return delta0; /* FAIL */
       vassert(!preSwap); /* never needed for imm8 < 8 */
-      assign( plain, 
+      assign( plain,
               binop(
                  op,
-                 getXMMReg(gregOfRexRM(pfx,rm)), 
-                   all_lanes 
+                 getXMMReg(gregOfRexRM(pfx,rm)),
+                   all_lanes
                       ? loadLE(Ity_V128, mkexpr(addr))
                    : sz == 8
                       ? unop( Iop_64UtoV128, loadLE(Ity_I64, mkexpr(addr)))
                    : /*sz==4*/
                       unop( Iop_32UtoV128, loadLE(Ity_I32, mkexpr(addr)))
-              ) 
+              )
       );
       delta += alen+1;
       DIP("%s $%d,%s,%s\n", opname,
@@ -9173,13 +9173,13 @@ static Long dis_SSE_cmp_E_to_G ( VexAbiInfo* vbi,
    }
 
    if (postNot && all_lanes) {
-      putXMMReg( gregOfRexRM(pfx,rm), 
+      putXMMReg( gregOfRexRM(pfx,rm),
                  unop(Iop_NotV128, mkexpr(plain)) );
    }
    else
    if (postNot && !all_lanes) {
       mask = toUShort(sz==4 ? 0x000F : 0x00FF);
-      putXMMReg( gregOfRexRM(pfx,rm), 
+      putXMMReg( gregOfRexRM(pfx,rm),
                  binop(Iop_XorV128, mkexpr(plain), mkV128(mask)) );
    }
    else {
@@ -9194,7 +9194,7 @@ static Long dis_SSE_cmp_E_to_G ( VexAbiInfo* vbi,
    of E. */
 
 static ULong dis_SSE_shiftG_byE ( VexAbiInfo* vbi,
-                                  Prefix pfx, Long delta, 
+                                  Prefix pfx, Long delta,
                                   const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -9238,7 +9238,7 @@ static ULong dis_SSE_shiftG_byE ( VexAbiInfo* vbi,
    }
 
    if (shl || shr) {
-     assign( 
+     assign(
         g1,
         IRExpr_ITE(
            binop(Iop_CmpLT64U, mkexpr(amt), mkU64(size)),
@@ -9246,9 +9246,9 @@ static ULong dis_SSE_shiftG_byE ( VexAbiInfo* vbi,
            mkV128(0x0000)
         )
      );
-   } else 
+   } else
    if (sar) {
-     assign( 
+     assign(
         g1,
         IRExpr_ITE(
            binop(Iop_CmpLT64U, mkexpr(amt), mkU64(size)),
@@ -9267,8 +9267,8 @@ static ULong dis_SSE_shiftG_byE ( VexAbiInfo* vbi,
 
 /* Vector by scalar shift of E by an immediate byte. */
 
-static 
-ULong dis_SSE_shiftE_imm ( Prefix pfx, 
+static
+ULong dis_SSE_shiftE_imm ( Prefix pfx,
                            Long delta, const HChar* opname, IROp op )
 {
    Bool    shl, shr, sar;
@@ -9277,7 +9277,7 @@ ULong dis_SSE_shiftE_imm ( Prefix pfx,
    IRTemp  e1   = newTemp(Ity_V128);
    UChar   amt, size;
    vassert(epartIsReg(rm));
-   vassert(gregLO3ofRM(rm) == 2 
+   vassert(gregLO3ofRM(rm) == 2
            || gregLO3ofRM(rm) == 4 || gregLO3ofRM(rm) == 6);
    amt = getUChar(delta+1);
    delta += 2;
@@ -9301,13 +9301,13 @@ ULong dis_SSE_shiftE_imm ( Prefix pfx,
    }
 
    if (shl || shr) {
-     assign( e1, amt >= size 
+     assign( e1, amt >= size
                     ? mkV128(0x0000)
                     : binop(op, mkexpr(e0), mkU8(amt))
      );
-   } else 
+   } else
    if (sar) {
-     assign( e1, amt >= size 
+     assign( e1, amt >= size
                     ? binop(op, mkexpr(e0), mkU8(size-1))
                     : binop(op, mkexpr(e0), mkU8(amt))
      );
@@ -9324,17 +9324,17 @@ ULong dis_SSE_shiftE_imm ( Prefix pfx,
 
 static IRExpr* /* :: Ity_I32 */ get_sse_roundingmode ( void )
 {
-   return 
-      unop( Iop_64to32, 
-            binop( Iop_And64, 
-                   IRExpr_Get( OFFB_SSEROUND, Ity_I64 ), 
+   return
+      unop( Iop_64to32,
+            binop( Iop_And64,
+                   IRExpr_Get( OFFB_SSEROUND, Ity_I64 ),
                    mkU64(3) ));
 }
 
 static void put_sse_roundingmode ( IRExpr* sseround )
 {
    vassert(typeOfIRExpr(irsb->tyenv, sseround) == Ity_I32);
-   stmt( IRStmt_Put( OFFB_SSEROUND, 
+   stmt( IRStmt_Put( OFFB_SSEROUND,
                      unop(Iop_32Uto64,sseround) ) );
 }
 
@@ -9422,7 +9422,7 @@ static void breakupV256to64s ( IRTemp t256,
                                /*OUTs*/
                                IRTemp* t3, IRTemp* t2,
                                IRTemp* t1, IRTemp* t0 )
-{ 
+{
    vassert(t0 && *t0 == IRTemp_INVALID);
    vassert(t1 && *t1 == IRTemp_INVALID);
    vassert(t2 && *t2 == IRTemp_INVALID);
@@ -9442,7 +9442,7 @@ static void breakupV256to64s ( IRTemp t256,
 static void breakupV256toV128s ( IRTemp t256,
                                  /*OUTs*/
                                  IRTemp* t1, IRTemp* t0 )
-{ 
+{
    vassert(t0 && *t0 == IRTemp_INVALID);
    vassert(t1 && *t1 == IRTemp_INVALID);
    *t0 = newTemp(Ity_V128);
@@ -9551,7 +9551,7 @@ static IRExpr* dis_PMULHRSW_helper ( IRExpr* aax, IRExpr* bbx )
       binop(
          Iop_ShrN32x2,
          binop(
-            Iop_Add32x2, 
+            Iop_Add32x2,
             binop(
                Iop_ShrN32x2,
                binop(Iop_Mul32x2, mkexpr(aahi32s), mkexpr(bbhi32s)),
@@ -9567,7 +9567,7 @@ static IRExpr* dis_PMULHRSW_helper ( IRExpr* aax, IRExpr* bbx )
       binop(
          Iop_ShrN32x2,
          binop(
-            Iop_Add32x2, 
+            Iop_Add32x2,
             binop(
                Iop_ShrN32x2,
                binop(Iop_Mul32x2, mkexpr(aalo32s), mkexpr(bblo32s)),
@@ -9723,7 +9723,7 @@ static IRExpr* dis_PALIGNR_XMM_helper ( IRTemp hi64,
       );
 }
 
-static IRTemp math_PALIGNR_XMM ( IRTemp sV, IRTemp dV, UInt imm8 ) 
+static IRTemp math_PALIGNR_XMM ( IRTemp sV, IRTemp dV, UInt imm8 )
 {
    IRTemp res = newTemp(Ity_V128);
    IRTemp sHi = newTemp(Ity_I64);
@@ -9908,7 +9908,7 @@ static Bool can_be_used_with_LOCK_prefix ( UChar* opc )
                if (!epartIsReg(opc[2]))
                   return True;
                break;
-            case 0xBA: 
+            case 0xBA:
                if (gregLO3ofRM(opc[2]) >= 5 && gregLO3ofRM(opc[2]) <= 7
                    && !epartIsReg(opc[2]))
                   return True;
@@ -9917,7 +9917,7 @@ static Bool can_be_used_with_LOCK_prefix ( UChar* opc )
                if (!epartIsReg(opc[2]))
                   return True;
                break;
-            case 0xC7: 
+            case 0xC7:
                if (gregLO3ofRM(opc[2]) == 1 && !epartIsReg(opc[2]) )
                   return True;
                break;
@@ -9956,7 +9956,7 @@ static Long dis_COMISD ( VexAbiInfo* vbi, Prefix pfx,
    UChar  modrm = getUChar(delta);
    IRTemp addr  = IRTemp_INVALID;
    if (epartIsReg(modrm)) {
-      assign( argR, getXMMRegLane64F( eregOfRexRM(pfx,modrm), 
+      assign( argR, getXMMRegLane64F( eregOfRexRM(pfx,modrm),
                                       0/*lowest lane*/ ) );
       delta += 1;
       DIP("%s%scomisd %s,%s\n", isAvx ? "v" : "",
@@ -9972,15 +9972,15 @@ static Long dis_COMISD ( VexAbiInfo* vbi, Prefix pfx,
                                 dis_buf,
                                 nameXMMReg(gregOfRexRM(pfx,modrm)) );
    }
-   assign( argL, getXMMRegLane64F( gregOfRexRM(pfx,modrm), 
+   assign( argL, getXMMRegLane64F( gregOfRexRM(pfx,modrm),
                                    0/*lowest lane*/ ) );
 
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
    stmt( IRStmt_Put( OFFB_CC_DEP2, mkU64(0) ));
-   stmt( IRStmt_Put( 
+   stmt( IRStmt_Put(
             OFFB_CC_DEP1,
             binop( Iop_And64,
-                   unop( Iop_32Uto64, 
+                   unop( Iop_32Uto64,
                          binop(Iop_CmpF64, mkexpr(argL), mkexpr(argR)) ),
                    mkU64(0x45)
        )));
@@ -9999,7 +9999,7 @@ static Long dis_COMISS ( VexAbiInfo* vbi, Prefix pfx,
    UChar  modrm = getUChar(delta);
    IRTemp addr  = IRTemp_INVALID;
    if (epartIsReg(modrm)) {
-      assign( argR, getXMMRegLane32F( eregOfRexRM(pfx,modrm), 
+      assign( argR, getXMMRegLane32F( eregOfRexRM(pfx,modrm),
                                       0/*lowest lane*/ ) );
       delta += 1;
       DIP("%s%scomiss %s,%s\n", isAvx ? "v" : "",
@@ -10015,16 +10015,16 @@ static Long dis_COMISS ( VexAbiInfo* vbi, Prefix pfx,
                                 dis_buf,
                                 nameXMMReg(gregOfRexRM(pfx,modrm)) );
    }
-   assign( argL, getXMMRegLane32F( gregOfRexRM(pfx,modrm), 
+   assign( argL, getXMMRegLane32F( gregOfRexRM(pfx,modrm),
                                    0/*lowest lane*/ ) );
 
    stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
    stmt( IRStmt_Put( OFFB_CC_DEP2, mkU64(0) ));
-   stmt( IRStmt_Put( 
+   stmt( IRStmt_Put(
             OFFB_CC_DEP1,
             binop( Iop_And64,
-                   unop( Iop_32Uto64, 
-                         binop(Iop_CmpF64, 
+                   unop( Iop_32Uto64,
+                         binop(Iop_CmpF64,
                                unop(Iop_F32toF64,mkexpr(argL)),
                                unop(Iop_F32toF64,mkexpr(argR)))),
                    mkU64(0x45)
@@ -10047,16 +10047,16 @@ static Long dis_PSHUFD_32x4 ( VexAbiInfo* vbi, Prefix pfx,
       assign( sV, getXMMReg(eregOfRexRM(pfx,modrm)) );
       order = (Int)getUChar(delta+1);
       delta += 1+1;
-      DIP("%spshufd $%d,%s,%s\n", strV, order, 
+      DIP("%spshufd $%d,%s,%s\n", strV, order,
                                   nameXMMReg(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
    } else {
-      addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 
+      addr = disAMode ( &alen, vbi, pfx, delta, dis_buf,
                         1/*byte after the amode*/ );
       assign( sV, loadLE(Ity_V128, mkexpr(addr)) );
       order = (Int)getUChar(delta+alen);
       delta += alen+1;
-      DIP("%spshufd $%d,%s,%s\n", strV, order, 
+      DIP("%spshufd $%d,%s,%s\n", strV, order,
                                  dis_buf,
                                  nameXMMReg(gregOfRexRM(pfx,modrm)));
    }
@@ -10146,22 +10146,22 @@ static IRTemp math_PSRLDQ ( IRTemp sV, Int imm )
       assign( hi64r, mkU64(0) );
       assign( lo64r, mkexpr(hi64) );
    }
-   else 
+   else
    if (imm > 8) {
       assign( hi64r, mkU64(0) );
       assign( lo64r, binop( Iop_Shr64, mkexpr(hi64), mkU8( 8*(imm-8) ) ));
    } else {
       assign( hi64r, binop( Iop_Shr64, mkexpr(hi64), mkU8(8 * imm) ));
-      assign( lo64r, 
+      assign( lo64r,
               binop( Iop_Or64,
-                     binop(Iop_Shr64, mkexpr(lo64), 
+                     binop(Iop_Shr64, mkexpr(lo64),
                            mkU8(8 * imm)),
                      binop(Iop_Shl64, mkexpr(hi64),
                            mkU8(8 * (8 - imm)) )
                      )
               );
    }
-   
+
    assign( dV, binop(Iop_64HLtoV128, mkexpr(hi64r), mkexpr(lo64r)) );
    return dV;
 }
@@ -10183,7 +10183,7 @@ static IRTemp math_PSLLDQ ( IRTemp sV, Int imm )
 
    assign( hi64, unop(Iop_V128HIto64, mkexpr(sV)) );
    assign( lo64, unop(Iop_V128to64, mkexpr(sV)) );
-   
+
    if (imm == 0) {
       assign( lo64r, mkexpr(lo64) );
       assign( hi64r, mkexpr(hi64) );
@@ -10199,9 +10199,9 @@ static IRTemp math_PSLLDQ ( IRTemp sV, Int imm )
       assign( hi64r, binop( Iop_Shl64, mkexpr(lo64), mkU8( 8*(imm-8) ) ));
    } else {
       assign( lo64r, binop( Iop_Shl64, mkexpr(lo64), mkU8(8 * imm) ));
-      assign( hi64r, 
+      assign( hi64r,
               binop( Iop_Or64,
-                     binop(Iop_Shl64, mkexpr(hi64), 
+                     binop(Iop_Shl64, mkexpr(hi64),
                            mkU8(8 * imm)),
                      binop(Iop_Shr64, mkexpr(lo64),
                            mkU8(8 * (8 - imm)) )
@@ -10279,7 +10279,7 @@ static Long dis_CVTxSS2SI ( VexAbiInfo* vbi, Prefix pfx,
       assign(f32lo, getXMMRegLane32F(eregOfRexRM(pfx,modrm), 0));
       DIP("%scvt%sss2si %s,%s\n", isAvx ? "v" : "", r2zero ? "t" : "",
                                   nameXMMReg(eregOfRexRM(pfx,modrm)),
-                                  nameIReg(sz, gregOfRexRM(pfx,modrm), 
+                                  nameIReg(sz, gregOfRexRM(pfx,modrm),
                                            False));
    } else {
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
@@ -10299,17 +10299,17 @@ static Long dis_CVTxSS2SI ( VexAbiInfo* vbi, Prefix pfx,
 
    if (sz == 4) {
       putIReg32( gregOfRexRM(pfx,modrm),
-                 binop( Iop_F64toI32S, 
-                        mkexpr(rmode), 
+                 binop( Iop_F64toI32S,
+                        mkexpr(rmode),
                         unop(Iop_F32toF64, mkexpr(f32lo))) );
    } else {
       vassert(sz == 8);
       putIReg64( gregOfRexRM(pfx,modrm),
-                 binop( Iop_F64toI64S, 
-                        mkexpr(rmode), 
+                 binop( Iop_F64toI64S,
+                        mkexpr(rmode),
                         unop(Iop_F32toF64, mkexpr(f32lo))) );
    }
-   
+
    return delta;
 }
 
@@ -10334,7 +10334,7 @@ static Long dis_CVTPS2PD_128 ( VexAbiInfo* vbi, Prefix pfx,
    } else {
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
       assign( f32lo, loadLE(Ity_F32, mkexpr(addr)) );
-      assign( f32hi, loadLE(Ity_F32, 
+      assign( f32hi, loadLE(Ity_F32,
                             binop(Iop_Add64,mkexpr(addr),mkU64(4))) );
       delta += alen;
       DIP("%scvtps2pd %s,%s\n",
@@ -10372,11 +10372,11 @@ static Long dis_CVTPS2PD_256 ( VexAbiInfo* vbi, Prefix pfx,
    } else {
       addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
       assign( f32_0, loadLE(Ity_F32, mkexpr(addr)) );
-      assign( f32_1, loadLE(Ity_F32, 
+      assign( f32_1, loadLE(Ity_F32,
                             binop(Iop_Add64,mkexpr(addr),mkU64(4))) );
-      assign( f32_2, loadLE(Ity_F32, 
+      assign( f32_2, loadLE(Ity_F32,
                             binop(Iop_Add64,mkexpr(addr),mkU64(8))) );
-      assign( f32_3, loadLE(Ity_F32, 
+      assign( f32_3, loadLE(Ity_F32,
                             binop(Iop_Add64,mkexpr(addr),mkU64(12))) );
       delta += alen;
       DIP("vcvtps2pd %s,%s\n", dis_buf, nameYMMReg(rG));
@@ -10413,15 +10413,15 @@ static Long dis_CVTPD2PS_128 ( VexAbiInfo* vbi, Prefix pfx,
       DIP("%scvtpd2ps %s,%s\n", isAvx ? "v" : "",
           dis_buf, nameXMMReg(rG) );
    }
-         
+
    assign( rmode, get_sse_roundingmode() );
    IRTemp t0 = newTemp(Ity_F64);
    IRTemp t1 = newTemp(Ity_F64);
-   assign( t0, unop(Iop_ReinterpI64asF64, 
+   assign( t0, unop(Iop_ReinterpI64asF64,
                     unop(Iop_V128to64, mkexpr(argV))) );
-   assign( t1, unop(Iop_ReinterpI64asF64, 
+   assign( t1, unop(Iop_ReinterpI64asF64,
                     unop(Iop_V128HIto64, mkexpr(argV))) );
-      
+
 #  define CVT(_t)  binop( Iop_F64toF32, mkexpr(rmode), mkexpr(_t) )
    putXMMRegLane32(  rG, 3, mkU32(0) );
    putXMMRegLane32(  rG, 2, mkU32(0) );
@@ -10472,7 +10472,7 @@ static Long dis_CVTxPS2DQ_128 ( VexAbiInfo* vbi, Prefix pfx,
              mkexpr(rmode),                   \
              unop( Iop_F32toF64,              \
                    unop( Iop_ReinterpI32asF32, mkexpr(_t))) )
-      
+
    putXMMRegLane32( rG, 3, CVT(t3) );
    putXMMRegLane32( rG, 2, CVT(t2) );
    putXMMRegLane32( rG, 1, CVT(t1) );
@@ -10522,7 +10522,7 @@ static Long dis_CVTxPS2DQ_256 ( VexAbiInfo* vbi, Prefix pfx,
              mkexpr(rmode),                   \
              unop( Iop_F32toF64,              \
                    unop( Iop_ReinterpI32asF32, mkexpr(_t))) )
-      
+
    putYMMRegLane32( rG, 7, CVT(t7) );
    putYMMRegLane32( rG, 6, CVT(t6) );
    putYMMRegLane32( rG, 5, CVT(t5) );
@@ -10571,9 +10571,9 @@ static Long dis_CVTxPD2DQ_128 ( VexAbiInfo* vbi, Prefix pfx,
 
    t0 = newTemp(Ity_F64);
    t1 = newTemp(Ity_F64);
-   assign( t0, unop(Iop_ReinterpI64asF64, 
+   assign( t0, unop(Iop_ReinterpI64asF64,
                     unop(Iop_V128to64, mkexpr(argV))) );
-   assign( t1, unop(Iop_ReinterpI64asF64, 
+   assign( t1, unop(Iop_ReinterpI64asF64,
                     unop(Iop_V128HIto64, mkexpr(argV))) );
 
 #  define CVT(_t)  binop( Iop_F64toI32S,                   \
@@ -10682,7 +10682,7 @@ static Long dis_CVTDQ2PS_128 ( VexAbiInfo* vbi, Prefix pfx,
 #  define CVT(_t)  binop( Iop_F64toF32,                    \
                           mkexpr(rmode),                   \
                           unop(Iop_I32StoF64,mkexpr(_t)))
-      
+
    putXMMRegLane32F( rG, 3, CVT(t3) );
    putXMMRegLane32F( rG, 2, CVT(t2) );
    putXMMRegLane32F( rG, 1, CVT(t1) );
@@ -10732,7 +10732,7 @@ static Long dis_CVTDQ2PS_256 ( VexAbiInfo* vbi, Prefix pfx,
 #  define CVT(_t)  binop( Iop_F64toF32,                    \
                           mkexpr(rmode),                   \
                           unop(Iop_I32StoF64,mkexpr(_t)))
-      
+
    putYMMRegLane32F( rG, 7, CVT(t7) );
    putYMMRegLane32F( rG, 6, CVT(t6) );
    putYMMRegLane32F( rG, 5, CVT(t5) );
@@ -10875,8 +10875,8 @@ static IRTemp math_SHUFPS_128 ( IRTemp sV, IRTemp dV, UInt imm8 )
 #  define SELD(n) ((n)==0 ? d0 : ((n)==1 ? d1 : ((n)==2 ? d2 : d3)))
 #  define SELS(n) ((n)==0 ? s0 : ((n)==1 ? s1 : ((n)==2 ? s2 : s3)))
    IRTemp res = newTemp(Ity_V128);
-   assign(res, 
-          mkV128from32s( SELS((imm8>>6)&3), SELS((imm8>>4)&3), 
+   assign(res,
+          mkV128from32s( SELS((imm8>>6)&3), SELS((imm8>>4)&3),
                          SELD((imm8>>2)&3), SELD((imm8>>0)&3) ) );
 #  undef SELD
 #  undef SELS
@@ -10955,10 +10955,10 @@ static IRTemp math_BLENDPD_128 ( IRTemp sV, IRTemp dV, UInt imm8 )
    assign( imm8_mask, mkV128( imm8_mask_16 ) );
 
    IRTemp res = newTemp(Ity_V128);
-   assign ( res, binop( Iop_OrV128, 
+   assign ( res, binop( Iop_OrV128,
                         binop( Iop_AndV128, mkexpr(sV),
-                                            mkexpr(imm8_mask) ), 
-                        binop( Iop_AndV128, mkexpr(dV), 
+                                            mkexpr(imm8_mask) ),
+                        binop( Iop_AndV128, mkexpr(dV),
                                unop( Iop_NotV128, mkexpr(imm8_mask) ) ) ) );
    return res;
 }
@@ -10989,7 +10989,7 @@ static IRTemp math_BLENDPS_128 ( IRTemp sV, IRTemp dV, UInt imm8 )
 
    IRTemp res = newTemp(Ity_V128);
    assign ( res, binop( Iop_OrV128,
-                        binop( Iop_AndV128, mkexpr(sV), 
+                        binop( Iop_AndV128, mkexpr(sV),
                                             mkexpr(imm8_mask) ),
                         binop( Iop_AndV128, mkexpr(dV),
                                unop( Iop_NotV128, mkexpr(imm8_mask) ) ) ) );
@@ -11026,7 +11026,7 @@ static IRTemp math_PBLENDW_128 ( IRTemp sV, IRTemp dV, UInt imm8 )
 
    IRTemp res = newTemp(Ity_V128);
    assign ( res, binop( Iop_OrV128,
-                        binop( Iop_AndV128, mkexpr(sV), 
+                        binop( Iop_AndV128, mkexpr(sV),
                                             mkexpr(imm16_mask) ),
                         binop( Iop_AndV128, mkexpr(dV),
                                unop( Iop_NotV128, mkexpr(imm16_mask) ) ) ) );
@@ -11107,11 +11107,11 @@ static IRTemp math_PMADDWD_128 ( IRTemp dV, IRTemp sV )
    breakupV128to64s( sV, &sVhi, &sVlo );
    breakupV128to64s( dV, &dVhi, &dVlo );
    assign( resHi, mkIRExprCCall(Ity_I64, 0/*regparms*/,
-                                "amd64g_calculate_mmx_pmaddwd", 
+                                "amd64g_calculate_mmx_pmaddwd",
                                 &amd64g_calculate_mmx_pmaddwd,
                                 mkIRExprVec_2( mkexpr(sVhi), mkexpr(dVhi))));
    assign( resLo, mkIRExprCCall(Ity_I64, 0/*regparms*/,
-                                "amd64g_calculate_mmx_pmaddwd", 
+                                "amd64g_calculate_mmx_pmaddwd",
                                 &amd64g_calculate_mmx_pmaddwd,
                                 mkIRExprVec_2( mkexpr(sVlo), mkexpr(dVlo))));
    IRTemp res = newTemp(Ity_V128);
@@ -11360,7 +11360,7 @@ static Long dis_PEXTRW_128_EregOnly_toG ( VexAbiInfo* vbi, Prefix pfx,
    putIReg32(rG, unop(Iop_16Uto32, mkexpr(d16)));
    return delta;
 }
- 
+
 
 static Long dis_CVTDQ2PD_128 ( VexAbiInfo* vbi, Prefix pfx,
                                Long delta, Bool isAvx )
@@ -11383,12 +11383,12 @@ static Long dis_CVTDQ2PD_128 ( VexAbiInfo* vbi, Prefix pfx,
       delta += alen;
       DIP("%scvtdq2pd %s,%s\n", mbV, dis_buf, nameXMMReg(rG) );
    }
-   putXMMRegLane64F( 
+   putXMMRegLane64F(
       rG, 0,
       unop(Iop_I32StoF64, unop(Iop_64to32, mkexpr(arg64)))
    );
    putXMMRegLane64F(
-      rG, 1, 
+      rG, 1,
       unop(Iop_I32StoF64, unop(Iop_64HIto32, mkexpr(arg64)))
    );
    if (isAvx)
@@ -11415,14 +11415,14 @@ static Long dis_STMXCSR ( VexAbiInfo* vbi, Prefix pfx,
    */
    /* ULong amd64h_create_mxcsr ( ULong sseround ) */
    DIP("%sstmxcsr %s\n",  isAvx ? "v" : "", dis_buf);
-   storeLE( 
-      mkexpr(addr), 
-      unop(Iop_64to32,      
+   storeLE(
+      mkexpr(addr),
+      unop(Iop_64to32,
            mkIRExprCCall(
               Ity_I64, 0/*regp*/,
-              "amd64g_create_mxcsr", &amd64g_create_mxcsr, 
-              mkIRExprVec_1( unop(Iop_32Uto64,get_sse_roundingmode()) ) 
-           ) 
+              "amd64g_create_mxcsr", &amd64g_create_mxcsr,
+              mkIRExprVec_1( unop(Iop_32Uto64,get_sse_roundingmode()) )
+           )
       )
    );
    return delta;
@@ -11451,14 +11451,14 @@ static Long dis_LDMXCSR ( VexAbiInfo* vbi, Prefix pfx,
       word) to a clean helper, getting back a 64-bit value, the
       lower half of which is the SSEROUND value to store, and the
       upper half of which is the emulation-warning token which may
-      be generated.  
+      be generated.
    */
    /* ULong amd64h_check_ldmxcsr ( ULong ); */
    assign( t64, mkIRExprCCall(
-                   Ity_I64, 0/*regparms*/, 
+                   Ity_I64, 0/*regparms*/,
                    "amd64g_check_ldmxcsr",
-                   &amd64g_check_ldmxcsr, 
-                   mkIRExprVec_1( 
+                   &amd64g_check_ldmxcsr,
+                   mkIRExprVec_1(
                       unop(Iop_32Uto64,
                            loadLE(Ity_I32, mkexpr(addr))
                       )
@@ -11472,7 +11472,7 @@ static Long dis_LDMXCSR ( VexAbiInfo* vbi, Prefix pfx,
    /* Finally, if an emulation warning was reported, side-exit to
       the next insn, reporting the warning, so that Valgrind's
       dispatcher sees the warning. */
-   stmt( 
+   stmt(
       IRStmt_Exit(
          binop(Iop_CmpNE64, unop(Iop_32Uto64,mkexpr(ew)), mkU64(0)),
          Ijk_EmWarn,
@@ -11517,16 +11517,16 @@ static IRTemp math_PSADBW_128 ( IRTemp dV, IRTemp sV )
 
    breakupV128to64s( sV, &s1, &s0 );
    breakupV128to64s( dV, &d1, &d0 );
-   
+
    IRTemp res = newTemp(Ity_V128);
    assign( res,
            binop(Iop_64HLtoV128,
                  mkIRExprCCall(Ity_I64, 0/*regparms*/,
-                               "amd64g_calculate_mmx_psadbw", 
+                               "amd64g_calculate_mmx_psadbw",
                                &amd64g_calculate_mmx_psadbw,
                                mkIRExprVec_2( mkexpr(s1), mkexpr(d1))),
                  mkIRExprCCall(Ity_I64, 0/*regparms*/,
-                               "amd64g_calculate_mmx_psadbw", 
+                               "amd64g_calculate_mmx_psadbw",
                                &amd64g_calculate_mmx_psadbw,
                                mkIRExprVec_2( mkexpr(s0), mkexpr(d0)))) );
    return res;
@@ -11565,20 +11565,20 @@ static Long dis_MASKMOVDQU ( VexAbiInfo* vbi, Prefix pfx,
    /* Unfortunately can't do the obvious thing with SarN8x16
       here since that can't be re-emitted as SSE2 code - no such
       insn. */
-   assign( mask, 
+   assign( mask,
            binop(Iop_64HLtoV128,
-                 binop(Iop_SarN8x8, 
-                       getXMMRegLane64( eregOfRexRM(pfx,modrm), 1 ), 
+                 binop(Iop_SarN8x8,
+                       getXMMRegLane64( eregOfRexRM(pfx,modrm), 1 ),
                        mkU8(7) ),
-                 binop(Iop_SarN8x8, 
-                       getXMMRegLane64( eregOfRexRM(pfx,modrm), 0 ), 
+                 binop(Iop_SarN8x8,
+                       getXMMRegLane64( eregOfRexRM(pfx,modrm), 0 ),
                        mkU8(7) ) ));
    assign( olddata, loadLE( Ity_V128, mkexpr(addr) ));
-   assign( newdata, binop(Iop_OrV128, 
-                          binop(Iop_AndV128, 
-                                mkexpr(regD), 
+   assign( newdata, binop(Iop_OrV128,
+                          binop(Iop_AndV128,
+                                mkexpr(regD),
                                 mkexpr(mask) ),
-                          binop(Iop_AndV128, 
+                          binop(Iop_AndV128,
                                 mkexpr(olddata),
                                 unop(Iop_NotV128, mkexpr(mask)))) );
    storeLE( mkexpr(addr), mkexpr(newdata) );
@@ -11752,19 +11752,19 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    switch (opc) {
 
    case 0x10:
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          /* 66 0F 10 = MOVUPD -- move from E (mem or xmm) to G (xmm). */
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        getXMMReg( eregOfRexRM(pfx,modrm) ));
             DIP("movupd %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
             delta += 1;
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        loadLE(Ity_V128, mkexpr(addr)) );
             DIP("movupd %s,%s\n", dis_buf,
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -11775,7 +11775,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* F2 0F 10 = MOVSD -- move 64 bits from E (mem or lo half xmm) to
          G (lo half xmm).  If E is mem, upper half of G is zeroed out.
          If E is reg, upper half of G is unchanged. */
-      if (haveF2no66noF3(pfx) 
+      if (haveF2no66noF3(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8) ) {
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
@@ -11797,7 +11797,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       }
       /* F3 0F 10 = MOVSS -- move 32 bits from E (mem or lo 1/4 xmm) to G
          (lo 1/4 xmm).  If E is mem, upper 3/4 of G is zeroed out. */
-      if (haveF3no66noF2(pfx) 
+      if (haveF3no66noF2(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
@@ -11818,18 +11818,18 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          goto decode_success;
       }
       /* 0F 10 = MOVUPS -- move from E (mem or xmm) to G (xmm). */
-      if (haveNo66noF2noF3(pfx) 
+      if (haveNo66noF2noF3(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        getXMMReg( eregOfRexRM(pfx,modrm) ));
             DIP("movups %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
             delta += 1;
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        loadLE(Ity_V128, mkexpr(addr)) );
             DIP("movups %s,%s\n", dis_buf,
                                      nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -11842,7 +11842,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0x11:
       /* F2 0F 11 = MOVSD -- move 64 bits from G (lo half xmm) to E (mem
          or lo half xmm). */
-      if (haveF2no66noF3(pfx) 
+      if (haveF2no66noF3(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
@@ -11927,7 +11927,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             putXMMRegLane64( gregOfRexRM(pfx,modrm),
                              0/*lower lane*/,
                              loadLE(Ity_I64, mkexpr(addr)) );
-            DIP("movlpd %s, %s\n", 
+            DIP("movlpd %s, %s\n",
                 dis_buf, nameXMMReg( gregOfRexRM(pfx,modrm) ));
             goto decode_success;
          }
@@ -11939,17 +11939,17 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
             delta += 1;
-            putXMMRegLane64( gregOfRexRM(pfx,modrm),  
+            putXMMRegLane64( gregOfRexRM(pfx,modrm),
                              0/*lower lane*/,
                              getXMMRegLane64( eregOfRexRM(pfx,modrm), 1 ));
-            DIP("movhlps %s, %s\n", nameXMMReg(eregOfRexRM(pfx,modrm)), 
+            DIP("movhlps %s, %s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                     nameXMMReg(gregOfRexRM(pfx,modrm)));
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             delta += alen;
             putXMMRegLane64( gregOfRexRM(pfx,modrm),  0/*lower lane*/,
                              loadLE(Ity_I64, mkexpr(addr)) );
-            DIP("movlps %s, %s\n", 
+            DIP("movlps %s, %s\n",
                 dis_buf, nameXMMReg( gregOfRexRM(pfx,modrm) ));
          }
          goto decode_success;
@@ -11964,8 +11964,8 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          if (!epartIsReg(modrm)) {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             delta += alen;
-            storeLE( mkexpr(addr), 
-                     getXMMRegLane64( gregOfRexRM(pfx,modrm), 
+            storeLE( mkexpr(addr),
+                     getXMMRegLane64( gregOfRexRM(pfx,modrm),
                                       0/*lower lane*/ ) );
             DIP("movlps %s, %s\n", nameXMMReg( gregOfRexRM(pfx,modrm) ),
                                    dis_buf);
@@ -11981,8 +11981,8 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          if (!epartIsReg(modrm)) {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             delta += alen;
-            storeLE( mkexpr(addr), 
-                     getXMMRegLane64( gregOfRexRM(pfx,modrm), 
+            storeLE( mkexpr(addr),
+                     getXMMRegLane64( gregOfRexRM(pfx,modrm),
                                       0/*lower lane*/ ) );
             DIP("movlpd %s, %s\n", nameXMMReg( gregOfRexRM(pfx,modrm) ),
                                    dis_buf);
@@ -12024,7 +12024,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 66 0F 15 = UNPCKHPD -- unpack and interleave high part F64s */
       /* 66 0F 14 = UNPCKLPD -- unpack and interleave low part F64s */
       /* These just appear to be special cases of SHUFPS */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && sz == 2 /* could be 8 if rex also present */) {
          Bool   hi = toBool(opc == 0x15);
          IRTemp sV = newTemp(Ity_V128);
@@ -12065,7 +12065,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             delta += alen;
             putXMMRegLane64( gregOfRexRM(pfx,modrm), 1/*upper lane*/,
                              loadLE(Ity_I64, mkexpr(addr)) );
-            DIP("movhpd %s,%s\n", dis_buf, 
+            DIP("movhpd %s,%s\n", dis_buf,
                                   nameXMMReg( gregOfRexRM(pfx,modrm) ));
             goto decode_success;
          }
@@ -12079,14 +12079,14 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             delta += 1;
             putXMMRegLane64( gregOfRexRM(pfx,modrm), 1/*upper lane*/,
                              getXMMRegLane64( eregOfRexRM(pfx,modrm), 0 ) );
-            DIP("movhps %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)), 
+            DIP("movhps %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             delta += alen;
             putXMMRegLane64( gregOfRexRM(pfx,modrm), 1/*upper lane*/,
                              loadLE(Ity_I64, mkexpr(addr)) );
-            DIP("movhps %s,%s\n", dis_buf, 
+            DIP("movhps %s,%s\n", dis_buf,
                                   nameXMMReg( gregOfRexRM(pfx,modrm) ));
          }
          goto decode_success;
@@ -12101,7 +12101,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          if (!epartIsReg(modrm)) {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             delta += alen;
-            storeLE( mkexpr(addr), 
+            storeLE( mkexpr(addr),
                      getXMMRegLane64( gregOfRexRM(pfx,modrm),
                                       1/*upper lane*/ ) );
             DIP("movhps %s,%s\n", nameXMMReg( gregOfRexRM(pfx,modrm) ),
@@ -12118,7 +12118,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          if (!epartIsReg(modrm)) {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             delta += alen;
-            storeLE( mkexpr(addr), 
+            storeLE( mkexpr(addr),
                      getXMMRegLane64( gregOfRexRM(pfx,modrm),
                                       1/*upper lane*/ ) );
             DIP("movhpd %s,%s\n", nameXMMReg( gregOfRexRM(pfx,modrm) ),
@@ -12135,7 +12135,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F 18 /2 = PREFETCH1 */
       /* 0F 18 /3 = PREFETCH2 */
       if (haveNo66noF2noF3(pfx)
-          && !epartIsReg(getUChar(delta)) 
+          && !epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) >= 0
           && gregLO3ofRM(getUChar(delta)) <= 3) {
          const HChar* hintstr = "??";
@@ -12161,11 +12161,11 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
 
    case 0x28:
       /* 66 0F 28 = MOVAPD -- move from E (mem or xmm) to G (xmm). */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        getXMMReg( eregOfRexRM(pfx,modrm) ));
             DIP("movapd %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -12173,7 +12173,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             gen_SEGV_if_not_16_aligned( addr );
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        loadLE(Ity_V128, mkexpr(addr)) );
             DIP("movapd %s,%s\n", dis_buf,
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -12182,11 +12182,11 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          goto decode_success;
       }
       /* 0F 28 = MOVAPS -- move from E (mem or xmm) to G (xmm). */
-      if (haveNo66noF2noF3(pfx) 
+      if (haveNo66noF2noF3(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        getXMMReg( eregOfRexRM(pfx,modrm) ));
             DIP("movaps %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -12194,7 +12194,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             gen_SEGV_if_not_16_aligned( addr );
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        loadLE(Ity_V128, mkexpr(addr)) );
             DIP("movaps %s,%s\n", dis_buf,
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -12271,23 +12271,23 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
 
          assign( rmode, get_sse_roundingmode() );
 
-         putXMMRegLane32F( 
+         putXMMRegLane32F(
             gregOfRexRM(pfx,modrm), 0,
-            binop(Iop_F64toF32, 
+            binop(Iop_F64toF32,
                   mkexpr(rmode),
-                  unop(Iop_I32StoF64, 
+                  unop(Iop_I32StoF64,
                        unop(Iop_64to32, mkexpr(arg64)) )) );
 
          putXMMRegLane32F(
-            gregOfRexRM(pfx,modrm), 1, 
-            binop(Iop_F64toF32, 
+            gregOfRexRM(pfx,modrm), 1,
+            binop(Iop_F64toF32,
                   mkexpr(rmode),
                   unop(Iop_I32StoF64,
                        unop(Iop_64HIto32, mkexpr(arg64)) )) );
 
          goto decode_success;
       }
-      /* F3 0F 2A = CVTSI2SS 
+      /* F3 0F 2A = CVTSI2SS
          -- sz==4: convert I32 in mem/ireg to F32 in low quarter xmm
          -- sz==8: convert I64 in mem/ireg to F32 in low quarter xmm */
       if (haveF3no66noF2(pfx) && (sz == 4 || sz == 8)) {
@@ -12308,7 +12308,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
                DIP("cvtsi2ss %s,%s\n", dis_buf,
                                        nameXMMReg(gregOfRexRM(pfx,modrm)) );
             }
-            putXMMRegLane32F( 
+            putXMMRegLane32F(
                gregOfRexRM(pfx,modrm), 0,
                binop(Iop_F64toF32,
                      mkexpr(rmode),
@@ -12328,7 +12328,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
                DIP("cvtsi2ssq %s,%s\n", dis_buf,
                                         nameXMMReg(gregOfRexRM(pfx,modrm)) );
             }
-            putXMMRegLane32F( 
+            putXMMRegLane32F(
                gregOfRexRM(pfx,modrm), 0,
                binop(Iop_F64toF32,
                      mkexpr(rmode),
@@ -12336,7 +12336,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          }
          goto decode_success;
       }
-      /* F2 0F 2A = CVTSI2SD 
+      /* F2 0F 2A = CVTSI2SD
          when sz==4 -- convert I32 in mem/ireg to F64 in low half xmm
          when sz==8 -- convert I64 in mem/ireg to F64 in low half xmm
       */
@@ -12357,7 +12357,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
                                         nameXMMReg(gregOfRexRM(pfx,modrm)) );
             }
             putXMMRegLane64F( gregOfRexRM(pfx,modrm), 0,
-                              unop(Iop_I32StoF64, mkexpr(arg32)) 
+                              unop(Iop_I32StoF64, mkexpr(arg32))
             );
          } else {
             /* sz == 8 */
@@ -12374,13 +12374,13 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
                DIP("cvtsi2sdq %s,%s\n", dis_buf,
                                         nameXMMReg(gregOfRexRM(pfx,modrm)) );
             }
-            putXMMRegLane64F( 
-               gregOfRexRM(pfx,modrm), 
+            putXMMRegLane64F(
+               gregOfRexRM(pfx,modrm),
                0,
                binop( Iop_I64StoF64,
                       get_sse_roundingmode(),
                       mkexpr(arg64)
-               ) 
+               )
             );
          }
          goto decode_success;
@@ -12411,12 +12411,12 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
                                     nameXMMReg(gregOfRexRM(pfx,modrm)) );
          }
 
-         putXMMRegLane64F( 
+         putXMMRegLane64F(
             gregOfRexRM(pfx,modrm), 0,
             unop(Iop_I32StoF64, unop(Iop_64to32, mkexpr(arg64)) )
          );
 
-         putXMMRegLane64F( 
+         putXMMRegLane64F(
             gregOfRexRM(pfx,modrm), 1,
             unop(Iop_I32StoF64, unop(Iop_64HIto32, mkexpr(arg64)) )
          );
@@ -12471,8 +12471,8 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             assign(f32lo, loadLE(Ity_F32, mkexpr(addr)));
-            assign(f32hi, loadLE(Ity_F32, binop( Iop_Add64, 
-                                                 mkexpr(addr), 
+            assign(f32hi, loadLE(Ity_F32, binop( Iop_Add64,
+                                                 mkexpr(addr),
                                                  mkU64(4) )));
             delta += alen;
             DIP("cvt%sps2pi %s,%s\n", r2zero ? "t" : "",
@@ -12486,14 +12486,14 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             assign( rmode, get_sse_roundingmode() );
          }
 
-         assign( 
+         assign(
             dst64,
             binop( Iop_32HLto64,
-                   binop( Iop_F64toI32S, 
-                          mkexpr(rmode), 
+                   binop( Iop_F64toI32S,
+                          mkexpr(rmode),
                           unop( Iop_F32toF64, mkexpr(f32hi) ) ),
-                   binop( Iop_F64toI32S, 
-                          mkexpr(rmode), 
+                   binop( Iop_F64toI32S,
+                          mkexpr(rmode),
                           unop( Iop_F32toF64, mkexpr(f32lo) ) )
                  )
          );
@@ -12501,33 +12501,33 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          putMMXReg(gregLO3ofRM(modrm), mkexpr(dst64));
          goto decode_success;
       }
-      /* F3 0F 2D = CVTSS2SI 
-         when sz==4 -- convert F32 in mem/low quarter xmm to I32 in ireg, 
+      /* F3 0F 2D = CVTSS2SI
+         when sz==4 -- convert F32 in mem/low quarter xmm to I32 in ireg,
                        according to prevailing SSE rounding mode
-         when sz==8 -- convert F32 in mem/low quarter xmm to I64 in ireg, 
+         when sz==8 -- convert F32 in mem/low quarter xmm to I64 in ireg,
                        according to prevailing SSE rounding mode
       */
-      /* F3 0F 2C = CVTTSS2SI 
-         when sz==4 -- convert F32 in mem/low quarter xmm to I32 in ireg, 
+      /* F3 0F 2C = CVTTSS2SI
+         when sz==4 -- convert F32 in mem/low quarter xmm to I32 in ireg,
                        truncating towards zero
-         when sz==8 -- convert F32 in mem/low quarter xmm to I64 in ireg, 
-                       truncating towards zero 
+         when sz==8 -- convert F32 in mem/low quarter xmm to I64 in ireg,
+                       truncating towards zero
       */
       if (haveF3no66noF2(pfx) && (sz == 4 || sz == 8)) {
          delta = dis_CVTxSS2SI( vbi, pfx, delta, False/*!isAvx*/, opc, sz);
          goto decode_success;
       }
-      /* F2 0F 2D = CVTSD2SI 
-         when sz==4 -- convert F64 in mem/low half xmm to I32 in ireg, 
+      /* F2 0F 2D = CVTSD2SI
+         when sz==4 -- convert F64 in mem/low half xmm to I32 in ireg,
                        according to prevailing SSE rounding mode
-         when sz==8 -- convert F64 in mem/low half xmm to I64 in ireg, 
+         when sz==8 -- convert F64 in mem/low half xmm to I64 in ireg,
                        according to prevailing SSE rounding mode
       */
-      /* F2 0F 2C = CVTTSD2SI 
-         when sz==4 -- convert F64 in mem/low half xmm to I32 in ireg, 
+      /* F2 0F 2C = CVTTSD2SI
+         when sz==4 -- convert F64 in mem/low half xmm to I32 in ireg,
                        truncating towards zero
-         when sz==8 -- convert F64 in mem/low half xmm to I64 in ireg, 
-                       truncating towards zero 
+         when sz==8 -- convert F64 in mem/low half xmm to I64 in ireg,
+                       truncating towards zero
       */
       if (haveF2no66noF3(pfx) && (sz == 4 || sz == 8)) {
          delta = dis_CVTxSD2SI( vbi, pfx, delta, False/*!isAvx*/, opc, sz);
@@ -12557,8 +12557,8 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             assign(f64lo, loadLE(Ity_F64, mkexpr(addr)));
-            assign(f64hi, loadLE(Ity_F64, binop( Iop_Add64, 
-                                                 mkexpr(addr), 
+            assign(f64hi, loadLE(Ity_F64, binop( Iop_Add64,
+                                                 mkexpr(addr),
                                                  mkU64(8) )));
             delta += alen;
             DIP("cvt%spf2pi %s,%s\n", r2zero ? "t" : "",
@@ -12572,7 +12572,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             assign( rmode, get_sse_roundingmode() );
          }
 
-         assign( 
+         assign(
             dst64,
             binop( Iop_32HLto64,
                    binop( Iop_F64toI32S, mkexpr(rmode), mkexpr(f64hi) ),
@@ -12643,25 +12643,25 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0x51:
       /* F3 0F 51 = SQRTSS -- approx sqrt 32F0x4 from R/M to R */
       if (haveF3no66noF2(pfx) && sz == 4) {
-         delta = dis_SSE_E_to_G_unary_lo32( vbi, pfx, delta, 
+         delta = dis_SSE_E_to_G_unary_lo32( vbi, pfx, delta,
                                             "sqrtss", Iop_Sqrt32F0x4 );
          goto decode_success;
       }
       /* 0F 51 = SQRTPS -- approx sqrt 32Fx4 from R/M to R */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
-         delta = dis_SSE_E_to_G_unary_all( vbi, pfx, delta, 
+         delta = dis_SSE_E_to_G_unary_all( vbi, pfx, delta,
                                            "sqrtps", Iop_Sqrt32Fx4 );
          goto decode_success;
       }
       /* F2 0F 51 = SQRTSD -- approx sqrt 64F0x2 from R/M to R */
       if (haveF2no66noF3(pfx) && sz == 4) {
-         delta = dis_SSE_E_to_G_unary_lo64( vbi, pfx, delta, 
+         delta = dis_SSE_E_to_G_unary_lo64( vbi, pfx, delta,
                                             "sqrtsd", Iop_Sqrt64F0x2 );
          goto decode_success;
       }
       /* 66 0F 51 = SQRTPD -- approx sqrt 64Fx2 from R/M to R */
       if (have66noF2noF3(pfx) && sz == 2) {
-         delta = dis_SSE_E_to_G_unary_all( vbi, pfx, delta, 
+         delta = dis_SSE_E_to_G_unary_all( vbi, pfx, delta,
                                            "sqrtpd", Iop_Sqrt64Fx2 );
          goto decode_success;
       }
@@ -12670,13 +12670,13 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0x52:
       /* F3 0F 52 = RSQRTSS -- approx reciprocal sqrt 32F0x4 from R/M to R */
       if (haveF3no66noF2(pfx) && sz == 4) {
-         delta = dis_SSE_E_to_G_unary_lo32( vbi, pfx, delta, 
+         delta = dis_SSE_E_to_G_unary_lo32( vbi, pfx, delta,
                                             "rsqrtss", Iop_RSqrtEst32F0x4 );
          goto decode_success;
       }
       /* 0F 52 = RSQRTPS -- approx reciprocal sqrt 32Fx4 from R/M to R */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
-         delta = dis_SSE_E_to_G_unary_all( vbi, pfx, delta, 
+         delta = dis_SSE_E_to_G_unary_all( vbi, pfx, delta,
                                            "rsqrtps", Iop_RSqrtEst32Fx4 );
          goto decode_success;
       }
@@ -12763,13 +12763,13 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          goto decode_success;
       }
       /* F2 0F 58 = ADDSD -- add 64F0x2 from R/M to R */
-      if (haveF2no66noF3(pfx) 
+      if (haveF2no66noF3(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          delta = dis_SSE_E_to_G_lo64( vbi, pfx, delta, "addsd", Iop_Add64F0x2 );
          goto decode_success;
       }
       /* 66 0F 58 = ADDPD -- add 32Fx4 from R/M to R */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          delta = dis_SSE_E_to_G_all( vbi, pfx, delta, "addpd", Iop_Add64Fx2 );
          goto decode_success;
@@ -12778,7 +12778,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
 
    case 0x59:
       /* F2 0F 59 = MULSD -- mul 64F0x2 from R/M to R */
-      if (haveF2no66noF3(pfx) 
+      if (haveF2no66noF3(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          delta = dis_SSE_E_to_G_lo64( vbi, pfx, delta, "mulsd", Iop_Mul64F0x2 );
          goto decode_success;
@@ -12794,7 +12794,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          goto decode_success;
       }
       /* 66 0F 59 = MULPD -- mul 64Fx2 from R/M to R */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          delta = dis_SSE_E_to_G_all( vbi, pfx, delta, "mulpd", Iop_Mul64Fx2 );
          goto decode_success;
@@ -12827,7 +12827,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
                                     nameXMMReg(gregOfRexRM(pfx,modrm)));
          }
 
-         putXMMRegLane64F( gregOfRexRM(pfx,modrm), 0, 
+         putXMMRegLane64F( gregOfRexRM(pfx,modrm), 0,
                            unop( Iop_F32toF64, mkexpr(f32lo) ) );
 
          goto decode_success;
@@ -12853,8 +12853,8 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          }
 
          assign( rmode, get_sse_roundingmode() );
-         putXMMRegLane32F( 
-            gregOfRexRM(pfx,modrm), 0, 
+         putXMMRegLane32F(
+            gregOfRexRM(pfx,modrm), 0,
             binop( Iop_F64toF32, mkexpr(rmode), mkexpr(f64lo) )
          );
 
@@ -12897,7 +12897,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          goto decode_success;
       }
       /* F2 0F 5C = SUBSD -- sub 64F0x2 from R/M to R */
-      if (haveF2no66noF3(pfx) 
+      if (haveF2no66noF3(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          delta = dis_SSE_E_to_G_lo64( vbi, pfx, delta, "subsd", Iop_Sub64F0x2 );
          goto decode_success;
@@ -13026,7 +13026,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0x64:
       /* 66 0F 64 = PCMPGTB */
       if (have66noF2noF3(pfx) && sz == 2) {
-         delta = dis_SSEint_E_to_G( vbi, pfx, delta, 
+         delta = dis_SSEint_E_to_G( vbi, pfx, delta,
                                     "pcmpgtb", Iop_CmpGT8Sx16, False );
          goto decode_success;
       }
@@ -13083,7 +13083,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0x6A:
       /* 66 0F 6A = PUNPCKHDQ */
       if (have66noF2noF3(pfx) && sz == 2) {
-         delta = dis_SSEint_E_to_G( vbi, pfx, delta, 
+         delta = dis_SSEint_E_to_G( vbi, pfx, delta,
                                     "punpckhdq",
                                     Iop_InterleaveHI32x4, True );
          goto decode_success;
@@ -13134,16 +13134,16 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             if (sz == 4) {
                putXMMReg(
                   gregOfRexRM(pfx,modrm),
-                  unop( Iop_32UtoV128, getIReg32(eregOfRexRM(pfx,modrm)) ) 
+                  unop( Iop_32UtoV128, getIReg32(eregOfRexRM(pfx,modrm)) )
                );
-               DIP("movd %s, %s\n", nameIReg32(eregOfRexRM(pfx,modrm)), 
+               DIP("movd %s, %s\n", nameIReg32(eregOfRexRM(pfx,modrm)),
                                     nameXMMReg(gregOfRexRM(pfx,modrm)));
             } else {
                putXMMReg(
                   gregOfRexRM(pfx,modrm),
-                  unop( Iop_64UtoV128, getIReg64(eregOfRexRM(pfx,modrm)) ) 
+                  unop( Iop_64UtoV128, getIReg64(eregOfRexRM(pfx,modrm)) )
                );
-               DIP("movq %s, %s\n", nameIReg64(eregOfRexRM(pfx,modrm)), 
+               DIP("movq %s, %s\n", nameIReg64(eregOfRexRM(pfx,modrm)),
                                     nameXMMReg(gregOfRexRM(pfx,modrm)));
             }
          } else {
@@ -13151,11 +13151,11 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             delta += alen;
             putXMMReg(
                gregOfRexRM(pfx,modrm),
-               sz == 4 
-                  ?  unop( Iop_32UtoV128,loadLE(Ity_I32, mkexpr(addr)) ) 
+               sz == 4
+                  ?  unop( Iop_32UtoV128,loadLE(Ity_I32, mkexpr(addr)) )
                   :  unop( Iop_64UtoV128,loadLE(Ity_I64, mkexpr(addr)) )
             );
-            DIP("mov%c %s, %s\n", sz == 4 ? 'd' : 'q', dis_buf, 
+            DIP("mov%c %s, %s\n", sz == 4 ? 'd' : 'q', dis_buf,
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
          }
          goto decode_success;
@@ -13163,12 +13163,12 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       break;
 
    case 0x6F:
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          /* 66 0F 6F = MOVDQA -- move from E (mem or xmm) to G (xmm). */
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        getXMMReg( eregOfRexRM(pfx,modrm) ));
             DIP("movdqa %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -13176,7 +13176,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             gen_SEGV_if_not_16_aligned( addr );
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        loadLE(Ity_V128, mkexpr(addr)) );
             DIP("movdqa %s,%s\n", dis_buf,
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -13188,14 +13188,14 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          /* F3 0F 6F = MOVDQU -- move from E (mem or xmm) to G (xmm). */
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        getXMMReg( eregOfRexRM(pfx,modrm) ));
             DIP("movdqu %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
             delta += 1;
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        loadLE(Ity_V128, mkexpr(addr)) );
             DIP("movdqu %s,%s\n", dis_buf,
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -13225,7 +13225,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             assign( sV, getMMXReg(eregLO3ofRM(modrm)) );
             order = (Int)getUChar(delta+1);
             delta += 1+1;
-            DIP("pshufw $%d,%s,%s\n", order, 
+            DIP("pshufw $%d,%s,%s\n", order,
                                       nameMMXReg(eregLO3ofRM(modrm)),
                                       nameMMXReg(gregLO3ofRM(modrm)));
          } else {
@@ -13234,7 +13234,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             assign( sV, loadLE(Ity_I64, mkexpr(addr)) );
             order = (Int)getUChar(delta+alen);
             delta += 1+alen;
-            DIP("pshufw $%d,%s,%s\n", order, 
+            DIP("pshufw $%d,%s,%s\n", order,
                                       dis_buf,
                                       nameMMXReg(gregLO3ofRM(modrm)));
          }
@@ -13274,14 +13274,14 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          goto decode_success;
       }
       /* 66 0F 71 /4 ib = PSRAW by immediate */
-      if (have66noF2noF3(pfx) && sz == 2 
+      if (have66noF2noF3(pfx) && sz == 2
           && epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) == 4) {
          delta = dis_SSE_shiftE_imm( pfx, delta, "psraw", Iop_SarN16x8 );
          goto decode_success;
       }
       /* 66 0F 71 /6 ib = PSLLW by immediate */
-      if (have66noF2noF3(pfx) && sz == 2 
+      if (have66noF2noF3(pfx) && sz == 2
           && epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) == 6) {
          delta = dis_SSE_shiftE_imm( pfx, delta, "psllw", Iop_ShlN16x8 );
@@ -13291,21 +13291,21 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
 
    case 0x72:
       /* 66 0F 72 /2 ib = PSRLD by immediate */
-      if (have66noF2noF3(pfx) && sz == 2 
+      if (have66noF2noF3(pfx) && sz == 2
           && epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) == 2) {
          delta = dis_SSE_shiftE_imm( pfx, delta, "psrld", Iop_ShrN32x4 );
          goto decode_success;
       }
       /* 66 0F 72 /4 ib = PSRAD by immediate */
-      if (have66noF2noF3(pfx) && sz == 2 
+      if (have66noF2noF3(pfx) && sz == 2
           && epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) == 4) {
          delta = dis_SSE_shiftE_imm( pfx, delta, "psrad", Iop_SarN32x4 );
          goto decode_success;
       }
       /* 66 0F 72 /6 ib = PSLLD by immediate */
-      if (have66noF2noF3(pfx) && sz == 2 
+      if (have66noF2noF3(pfx) && sz == 2
           && epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) == 6) {
          delta = dis_SSE_shiftE_imm( pfx, delta, "pslld", Iop_ShlN32x4 );
@@ -13316,7 +13316,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0x73:
       /* 66 0F 73 /3 ib = PSRLDQ by immediate */
       /* note, if mem case ever filled in, 1 byte after amode */
-      if (have66noF2noF3(pfx) && sz == 2 
+      if (have66noF2noF3(pfx) && sz == 2
           && epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) == 3) {
          Int imm = (Int)getUChar(delta+1);
@@ -13330,7 +13330,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       }
       /* 66 0F 73 /7 ib = PSLLDQ by immediate */
       /* note, if mem case ever filled in, 1 byte after amode */
-      if (have66noF2noF3(pfx) && sz == 2 
+      if (have66noF2noF3(pfx) && sz == 2
           && epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) == 7) {
          Int imm = (Int)getUChar(delta+1);
@@ -13351,7 +13351,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          goto decode_success;
       }
       /* 66 0F 73 /6 ib = PSLLQ by immediate */
-      if (have66noF2noF3(pfx) && sz == 2 
+      if (have66noF2noF3(pfx) && sz == 2
           && epartIsReg(getUChar(delta))
           && gregLO3ofRM(getUChar(delta)) == 6) {
          delta = dis_SSE_shiftE_imm( pfx, delta, "psllq", Iop_ShlN64x2 );
@@ -13389,7 +13389,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0x7E:
       /* F3 0F 7E = MOVQ -- move 64 bits from E (mem or lo half xmm) to
          G (lo half xmm).  Upper half of G is zeroed out. */
-      if (haveF3no66noF2(pfx) 
+      if (haveF3no66noF2(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
@@ -13421,12 +13421,12 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             if (sz == 4) {
                putIReg32( eregOfRexRM(pfx,modrm),
                           getXMMRegLane32(gregOfRexRM(pfx,modrm), 0) );
-               DIP("movd %s, %s\n", nameXMMReg(gregOfRexRM(pfx,modrm)), 
+               DIP("movd %s, %s\n", nameXMMReg(gregOfRexRM(pfx,modrm)),
                                     nameIReg32(eregOfRexRM(pfx,modrm)));
             } else {
                putIReg64( eregOfRexRM(pfx,modrm),
                           getXMMRegLane64(gregOfRexRM(pfx,modrm), 0) );
-               DIP("movq %s, %s\n", nameXMMReg(gregOfRexRM(pfx,modrm)), 
+               DIP("movq %s, %s\n", nameXMMReg(gregOfRexRM(pfx,modrm)),
                                     nameIReg64(eregOfRexRM(pfx,modrm)));
             }
          } else {
@@ -13452,7 +13452,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             delta += 1;
             putXMMReg( eregOfRexRM(pfx,modrm),
                        getXMMReg(gregOfRexRM(pfx,modrm)) );
-            DIP("movdqu %s, %s\n", nameXMMReg(gregOfRexRM(pfx,modrm)), 
+            DIP("movdqu %s, %s\n", nameXMMReg(gregOfRexRM(pfx,modrm)),
                                    nameXMMReg(eregOfRexRM(pfx,modrm)));
          } else {
             addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
@@ -13469,7 +13469,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             delta += 1;
             putXMMReg( eregOfRexRM(pfx,modrm),
                        getXMMReg(gregOfRexRM(pfx,modrm)) );
-            DIP("movdqa %s, %s\n", nameXMMReg(gregOfRexRM(pfx,modrm)), 
+            DIP("movdqa %s, %s\n", nameXMMReg(gregOfRexRM(pfx,modrm)),
                                    nameXMMReg(eregOfRexRM(pfx,modrm)));
          } else {
             addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
@@ -13484,32 +13484,39 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
 
    case 0xAE:
       /* 0F AE /7 = SFENCE -- flush pending operations to memory */
-      if (haveNo66noF2noF3(pfx) 
+      if (haveNo66noF2noF3(pfx)
           && epartIsReg(getUChar(delta)) && gregLO3ofRM(getUChar(delta)) == 7
           && sz == 4) {
          delta += 1;
          /* Insert a memory fence.  It's sometimes important that these
             are carried through to the generated code. */
-         stmt( IRStmt_MBE(Imbe_Fence) );
+         stmt( IRStmt_MBE(Imbe_SFence) );
          DIP("sfence\n");
          goto decode_success;
       }
 
-      /* XXX - Imbe_SFence, Imbe_LFence */
-
       /* mindless duplication follows .. */
       /* 0F AE /5 = LFENCE -- flush pending operations to memory */
+      if (haveNo66noF2noF3(pfx)
+          && epartIsReg(getUChar(delta)) && gregLO3ofRM(getUChar(delta)) == 5
+          && sz == 4) {
+         delta += 1;
+         /* Insert a memory fence.  It's sometimes important that these
+            are carried through to the generated code. */
+         stmt( IRStmt_MBE(Imbe_LFence) );
+         DIP("lfence\n");
+         goto decode_success;
+      }
+
       /* 0F AE /6 = MFENCE -- flush pending operations to memory */
       if (haveNo66noF2noF3(pfx)
-          && epartIsReg(getUChar(delta))
-          && (gregLO3ofRM(getUChar(delta)) == 5
-              || gregLO3ofRM(getUChar(delta)) == 6)
+          && epartIsReg(getUChar(delta)) && gregLO3ofRM(getUChar(delta)) == 6
           && sz == 4) {
          delta += 1;
          /* Insert a memory fence.  It's sometimes important that these
             are carried through to the generated code. */
          stmt( IRStmt_MBE(Imbe_Fence) );
-         DIP("%sfence\n", gregLO3ofRM(getUChar(delta-1))==5 ? "l" : "m");
+         DIP("fence\n");
          goto decode_success;
       }
 
@@ -13541,10 +13548,12 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
          delta += alen;
 
-         stmt( IRStmt_Flush(mkexpr(addr)) );
+
 
          if (!have66(pfx))
-             stmt( IRStmt_MBE(Imbe_Fence) );
+             stmt( IRStmt_Flush(mkexpr(addr), Ifk_flush) );
+         else
+             stmt( IRStmt_Flush(mkexpr(addr), Ifk_flushopt) );
 
          /* Round addr down to the start of the containing block. */
          stmt( IRStmt_Put(
@@ -13576,13 +13585,13 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
          delta += alen;
 
-         stmt( IRStmt_Flush(mkexpr(addr)) );
+         stmt( IRStmt_Flush(mkexpr(addr), Ifk_clwb) );
 
          /* Round addr down to the start of the containing block. */
          stmt( IRStmt_Put(
                   OFFB_CMSTART,
-                  binop( Iop_And64, 
-                         mkexpr(addr), 
+                  binop( Iop_And64,
+                         mkexpr(addr),
                          mkU64( ~(lineszB-1) ))) );
 
          stmt( IRStmt_Put(OFFB_CMLEN, mkU64(lineszB) ) );
@@ -13628,11 +13637,11 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
 
          DIP("%sfxsave %s\n", sz==8 ? "rex64/" : "", dis_buf);
 
-         /* Uses dirty helper: 
+         /* Uses dirty helper:
               void amd64g_do_FXSAVE_ALL_EXCEPT_XMM ( VexGuestAMD64State*,
                                                      ULong ) */
-         d = unsafeIRDirty_0_N ( 
-                0/*regparms*/, 
+         d = unsafeIRDirty_0_N (
+                0/*regparms*/,
                 "amd64g_dirtyhelper_FXSAVE_ALL_EXCEPT_XMM",
                 &amd64g_dirtyhelper_FXSAVE_ALL_EXCEPT_XMM,
                 mkIRExprVec_2( IRExpr_BBPTR(), mkexpr(addr) )
@@ -13705,15 +13714,15 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
 
          DIP("%sfxrstor %s\n", sz==8 ? "rex64/" : "", dis_buf);
 
-         /* Uses dirty helper: 
+         /* Uses dirty helper:
               VexEmNote amd64g_do_FXRSTOR_ALL_EXCEPT_XMM ( VexGuestAMD64State*,
                                                            ULong )
             NOTE:
               the VexEmNote value is simply ignored
          */
-         d = unsafeIRDirty_0_N ( 
-                0/*regparms*/, 
-                "amd64g_dirtyhelper_FXRSTOR_ALL_EXCEPT_XMM", 
+         d = unsafeIRDirty_0_N (
+                0/*regparms*/,
+                "amd64g_dirtyhelper_FXRSTOR_ALL_EXCEPT_XMM",
                 &amd64g_dirtyhelper_FXRSTOR_ALL_EXCEPT_XMM,
                 mkIRExprVec_2( IRExpr_BBPTR(), mkexpr(addr) )
              );
@@ -13838,7 +13847,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             assign(t4, getIReg16(eregOfRexRM(pfx,modrm)));
             delta += 1+1;
             lane = getUChar(delta-1);
-            DIP("pinsrw $%d,%s,%s\n", (Int)lane, 
+            DIP("pinsrw $%d,%s,%s\n", (Int)lane,
                                       nameIReg16(eregOfRexRM(pfx,modrm)),
                                       nameMMXReg(gregLO3ofRM(modrm)));
          } else {
@@ -13863,7 +13872,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       }
       /* 66 0F C4 = PINSRW -- get 16 bits from E(mem or low half ireg) and
          put it into the specified lane of xmm(G). */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          Int lane;
          t4 = newTemp(Ity_I16);
@@ -13877,7 +13886,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             DIP("pinsrw $%d,%s,%s\n",
                 (Int)lane, nameIReg16(rE), nameXMMReg(rG));
          } else {
-            addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode ( &alen, vbi, pfx, delta, dis_buf,
                               1/*byte after the amode*/ );
             delta += 1+alen;
             lane = getUChar(delta-1);
@@ -13895,7 +13904,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
 
    case 0xC5:
       /* ***--- this is an MMX class insn introduced in SSE1 ---*** */
-      /* 0F C5 = PEXTRW -- extract 16-bit field from mmx(E) and put 
+      /* 0F C5 = PEXTRW -- extract 16-bit field from mmx(E) and put
          zero-extend of it in ireg(G). */
       if (haveNo66noF2noF3(pfx) && (sz == 4 || sz == 8)) {
          modrm = getUChar(delta);
@@ -13924,15 +13933,15 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             );
             delta += 2;
             goto decode_success;
-         } 
+         }
          /* else fall through */
          /* note, for anyone filling in the mem case: this insn has one
             byte after the amode and therefore you must pass 1 as the
             last arg to disAMode */
       }
-      /* 66 0F C5 = PEXTRW -- extract 16-bit field from xmm(E) and put 
+      /* 66 0F C5 = PEXTRW -- extract 16-bit field from xmm(E) and put
          zero-extend of it in ireg(G). */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          Long delta0 = delta;
          delta = dis_PEXTRW_128_EregOnly_toG( vbi, pfx, delta,
@@ -13981,7 +13990,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             assign( sV, getXMMReg(eregOfRexRM(pfx,modrm)) );
             select = (Int)getUChar(delta+1);
             delta += 1+1;
-            DIP("shufpd $%d,%s,%s\n", select, 
+            DIP("shufpd $%d,%s,%s\n", select,
                                       nameXMMReg(eregOfRexRM(pfx,modrm)),
                                       nameXMMReg(gregOfRexRM(pfx,modrm)));
          } else {
@@ -13989,7 +13998,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             assign( sV, loadLE(Ity_V128, mkexpr(addr)) );
             select = getUChar(delta+alen);
             delta += 1+alen;
-            DIP("shufpd $%d,%s,%s\n", select, 
+            DIP("shufpd $%d,%s,%s\n", select,
                                       dis_buf,
                                       nameXMMReg(gregOfRexRM(pfx,modrm)));
          }
@@ -14035,7 +14044,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F D4 = PADDQ -- add 64x1 */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                    vbi, pfx, delta, opc, "paddq", False );
          goto decode_success;
       }
@@ -14044,7 +14053,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0xD5:
       /* 66 0F D5 = PMULLW -- 16x8 multiply */
       if (have66noF2noF3(pfx) && sz == 2) {
-         delta = dis_SSEint_E_to_G( vbi, pfx, delta, 
+         delta = dis_SSEint_E_to_G( vbi, pfx, delta,
                                     "pmullw", Iop_Mul16x8, False );
          goto decode_success;
       }
@@ -14057,7 +14066,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
             do_MMX_preamble();
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        unop(Iop_64UtoV128, getMMXReg( eregLO3ofRM(modrm) )) );
             DIP("movq2dq %s,%s\n", nameMMXReg(eregLO3ofRM(modrm)),
                                    nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -14068,7 +14077,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       }
       /* 66 0F D6 = MOVQ -- move 64 bits from G (lo half xmm) to E (mem
          or lo half xmm).  */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
@@ -14076,7 +14085,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
             /* dst: lo half copied, hi half zeroed */
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
-            storeLE( mkexpr(addr), 
+            storeLE( mkexpr(addr),
                      getXMMRegLane64( gregOfRexRM(pfx,modrm), 0 ));
             DIP("movq %s,%s\n", nameXMMReg(gregOfRexRM(pfx,modrm)), dis_buf );
             delta += alen;
@@ -14088,7 +14097,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
             do_MMX_preamble();
-            putMMXReg( gregLO3ofRM(modrm), 
+            putMMXReg( gregLO3ofRM(modrm),
                        getXMMRegLane64( eregOfRexRM(pfx,modrm), 0 ));
             DIP("movdq2q %s,%s\n", nameXMMReg(eregOfRexRM(pfx,modrm)),
                                    nameMMXReg(gregLO3ofRM(modrm)));
@@ -14104,7 +14113,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          lanes in xmm(E), turn them into a byte, and put
          zero-extend of it in ireg(G).  Doing this directly is just
          too cumbersome; give up therefore and call a helper. */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)
           && epartIsReg(getUChar(delta))) { /* no memory case, it seems */
          delta = dis_PMOVMSKB_128( vbi, pfx, delta, False/*!isAvx*/ );
@@ -14128,7 +14137,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
                                     nameIReg32(gregOfRexRM(pfx,modrm)));
             delta += 1;
             goto decode_success;
-         } 
+         }
          /* else fall through */
       }
       break;
@@ -14156,7 +14165,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F DA = PMINUB -- 8x8 unsigned min */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                     vbi, pfx, delta, opc, "pminub", False );
          goto decode_success;
       }
@@ -14199,7 +14208,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F DE = PMAXUB -- 8x8 unsigned max */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                     vbi, pfx, delta, opc, "pmaxub", False );
          goto decode_success;
       }
@@ -14224,7 +14233,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F E0 = PAVGB -- 8x8 unsigned Packed Average, with rounding */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                     vbi, pfx, delta, opc, "pavgb", False );
          goto decode_success;
       }
@@ -14257,7 +14266,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F E3 = PAVGW -- 16x4 unsigned Packed Average, with rounding */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                     vbi, pfx, delta, opc, "pavgw", False );
          goto decode_success;
       }
@@ -14274,7 +14283,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F E4 = PMULUH -- 16x4 hi-half of unsigned widening multiply */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                     vbi, pfx, delta, opc, "pmuluh", False );
          goto decode_success;
       }
@@ -14320,7 +14329,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F E7 = MOVNTQ -- for us, just a plain MMX store.  Note, the
          Intel manual does not say anything about the usual business of
          the FP reg tags getting trashed whenever an MMX insn happens.
-         So we just leave them alone. 
+         So we just leave them alone.
       */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          modrm = getUChar(delta);
@@ -14374,7 +14383,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F EA = PMINSW -- 16x4 signed min */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                     vbi, pfx, delta, opc, "pminsw", False );
          goto decode_success;
       }
@@ -14417,7 +14426,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F EE = PMAXSW -- 16x4 signed max */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                     vbi, pfx, delta, opc, "pmaxsw", False );
          goto decode_success;
       }
@@ -14549,7 +14558,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F F6 = PSADBW -- sum of 8Ux8 absolute differences */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                     vbi, pfx, delta, opc, "psadbw", False );
          goto decode_success;
       }
@@ -14596,7 +14605,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
    case 0xF8:
       /* 66 0F F8 = PSUBB */
       if (have66noF2noF3(pfx) && sz == 2) {
-         delta = dis_SSEint_E_to_G( vbi, pfx, delta, 
+         delta = dis_SSEint_E_to_G( vbi, pfx, delta,
                                     "psubb", Iop_Sub8x16, False );
          goto decode_success;
       }
@@ -14631,7 +14640,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
       /* 0F FB = PSUBQ -- sub 64x1 */
       if (haveNo66noF2noF3(pfx) && sz == 4) {
          do_MMX_preamble();
-         delta = dis_MMXop_regmem_to_reg ( 
+         delta = dis_MMXop_regmem_to_reg (
                    vbi, pfx, delta, opc, "psubq", False );
          goto decode_success;
       }
@@ -14846,7 +14855,7 @@ static IRTemp math_HADDPD_128 ( IRTemp dV, IRTemp sV, Bool isAdd )
 
    breakupV128to64s( sV, &s1, &s0 );
    breakupV128to64s( dV, &d1, &d0 );
-   
+
    assign( leftV,  binop(Iop_64HLtoV128, mkexpr(s0), mkexpr(d0)) );
    assign( rightV, binop(Iop_64HLtoV128, mkexpr(s1), mkexpr(d1)) );
 
@@ -14886,7 +14895,7 @@ Long dis_ESC_0F__SSE3 ( Bool* decode_OK,
       }
       /* F2 0F 12 = MOVDDUP -- move from E (mem or xmm) to G (xmm),
          duplicating some lanes (0:1:0:1). */
-      if (haveF2no66noF3(pfx) 
+      if (haveF2no66noF3(pfx)
           && (sz == 4 || /* ignore redundant REX.W */ sz == 8)) {
          delta = dis_MOVDDUP_128( vbi, pfx, delta, False/*!isAvx*/ );
          goto decode_success;
@@ -15014,7 +15023,7 @@ Long dis_ESC_0F__SSE3 ( Bool* decode_OK,
             goto decode_failure;
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
-            putXMMReg( gregOfRexRM(pfx,modrm), 
+            putXMMReg( gregOfRexRM(pfx,modrm),
                        loadLE(Ity_V128, mkexpr(addr)) );
             DIP("lddqu %s,%s\n", dis_buf,
                                  nameXMMReg(gregOfRexRM(pfx,modrm)));
@@ -15211,9 +15220,9 @@ static Long dis_PHADD_128 ( VexAbiInfo* vbi, Prefix pfx, Long delta,
    /* This isn't a particularly efficient way to compute the
       result, but at least it avoids a proliferation of IROps,
       hence avoids complication all the backends. */
-   
+
    (isAvx ? putYMMRegLoAndZU : putXMMReg)
-      ( rG, 
+      ( rG,
         binop(Iop_64HLtoV128,
               binop(opV64,
                     binop(opCatE,mkexpr(sHi),mkexpr(sLo)),
@@ -15305,7 +15314,7 @@ static IRTemp math_PMADDUBSW_128 ( IRTemp dV, IRTemp sV )
    IRTemp dVevensZX = newTemp(Ity_V128);
    /* compute dV unsigned x sV signed */
    assign( sVoddsSX, binop(Iop_SarN16x8, mkexpr(sV), mkU8(8)) );
-   assign( sVevensSX, binop(Iop_SarN16x8, 
+   assign( sVevensSX, binop(Iop_SarN16x8,
                             binop(Iop_ShlN16x8, mkexpr(sV), mkU8(8)),
                             mkU8(8)) );
    assign( dVoddsZX, binop(Iop_ShrN16x8, mkexpr(dV), mkU8(8)) );
@@ -15358,7 +15367,7 @@ Long dis_ESC_0F38__SupSSE3 ( Bool* decode_OK,
 
    case 0x00:
       /* 66 0F 38 00 = PSHUFB -- Packed Shuffle Bytes 8x16 (XMM) */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /*redundant REX.W*/ sz == 8)) {
          IRTemp sV = newTemp(Ity_V128);
          IRTemp dV = newTemp(Ity_V128);
@@ -15442,7 +15451,7 @@ Long dis_ESC_0F38__SupSSE3 ( Bool* decode_OK,
          G to G (xmm). */
       /* 66 0F 38 07 = PHSUBSW -- 16x8 signed qsub across from E (mem or
          xmm) and G to G (xmm). */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /*redundant REX.W*/ sz == 8)) {
          delta = dis_PHADD_128( vbi, pfx, delta, False/*isAvx*/, opc );
          goto decode_success;
@@ -15514,7 +15523,7 @@ Long dis_ESC_0F38__SupSSE3 ( Bool* decode_OK,
    case 0x04:
       /* 66 0F 38 04 = PMADDUBSW -- Multiply and Add Packed Signed and
          Unsigned Bytes (XMM) */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /*redundant REX.W*/ sz == 8)) {
          IRTemp sV = newTemp(Ity_V128);
          IRTemp dV = newTemp(Ity_V128);
@@ -15570,8 +15579,8 @@ Long dis_ESC_0F38__SupSSE3 ( Bool* decode_OK,
          assign( sVoddsSX,
                  binop(Iop_SarN16x4, mkexpr(sV), mkU8(8)) );
          assign( sVevensSX,
-                 binop(Iop_SarN16x4, 
-                       binop(Iop_ShlN16x4, mkexpr(sV), mkU8(8)), 
+                 binop(Iop_SarN16x4,
+                       binop(Iop_ShlN16x4, mkexpr(sV), mkU8(8)),
                        mkU8(8)) );
          assign( dVoddsZX,
                  binop(Iop_ShrN16x4, mkexpr(dV), mkU8(8)) );
@@ -15597,7 +15606,7 @@ Long dis_ESC_0F38__SupSSE3 ( Bool* decode_OK,
       /* 66 0F 38 08 = PSIGNB -- Packed Sign 8x16 (XMM) */
       /* 66 0F 38 09 = PSIGNW -- Packed Sign 16x8 (XMM) */
       /* 66 0F 38 0A = PSIGND -- Packed Sign 32x4 (XMM) */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /*redundant REX.W*/ sz == 8)) {
          IRTemp sV      = newTemp(Ity_V128);
          IRTemp dV      = newTemp(Ity_V128);
@@ -15767,7 +15776,7 @@ Long dis_ESC_0F38__SupSSE3 ( Bool* decode_OK,
       /* 66 0F 38 1C = PABSB -- Packed Absolute Value 8x16 (XMM) */
       /* 66 0F 38 1D = PABSW -- Packed Absolute Value 16x8 (XMM) */
       /* 66 0F 38 1E = PABSD -- Packed Absolute Value 32x4 (XMM) */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /*redundant REX.W*/ sz == 8)) {
          IRTemp sV  = newTemp(Ity_V128);
          const HChar* str = "???";
@@ -15878,7 +15887,7 @@ Long dis_ESC_0F3A__SupSSE3 ( Bool* decode_OK,
 
    case 0x0F:
       /* 66 0F 3A 0F = PALIGNR -- Packed Align Right (XMM) */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /*redundant REX.W*/ sz == 8)) {
          IRTemp sV  = newTemp(Ity_V128);
          IRTemp dV  = newTemp(Ity_V128);
@@ -15922,7 +15931,7 @@ Long dis_ESC_0F3A__SupSSE3 ( Bool* decode_OK,
             assign( sV, getMMXReg(eregLO3ofRM(modrm)) );
             d64 = (Long)getUChar(delta+1);
             delta += 1+1;
-            DIP("palignr $%d,%s,%s\n",  (Int)d64, 
+            DIP("palignr $%d,%s,%s\n",  (Int)d64,
                                         nameMMXReg(eregLO3ofRM(modrm)),
                                         nameMMXReg(gregLO3ofRM(modrm)));
          } else {
@@ -15939,7 +15948,7 @@ Long dis_ESC_0F3A__SupSSE3 ( Bool* decode_OK,
             assign( res, mkexpr(sV) );
          }
          else if (d64 >= 1 && d64 <= 7) {
-            assign(res, 
+            assign(res,
                    binop(Iop_Or64,
                          binop(Iop_Shr64, mkexpr(sV), mkU8(8*d64)),
                          binop(Iop_Shl64, mkexpr(dV), mkU8(8*(8-d64))
@@ -16113,7 +16122,7 @@ Long dis_ESC_0F__SSE4 ( Bool* decode_OK,
          differently.  Bizarrely, my Sandy Bridge also accepts these
          instructions but produces different results. */
       if (haveF3noF2(pfx) /* so both 66 and 48 are possibilities */
-          && (sz == 2 || sz == 4 || sz == 8) 
+          && (sz == 2 || sz == 4 || sz == 8)
           && 0 != (archinfo->hwcaps & VEX_HWCAPS_AMD64_LZCNT)) {
          /*IRType*/ ty  = szToITy(sz);
          IRTemp     src = newTemp(ty);
@@ -16332,7 +16341,7 @@ static void finish_xTESTy ( IRTemp andV, IRTemp andnV, Int sign )
       InterleaveLO64x2([a,b],[c,d]) == [b,d]    hence
 
       InterleaveLO64x2([a,b],[a,b]) == [b,b]    and similarly
-      InterleaveHI64x2([a,b],[a,b]) == [a,a] 
+      InterleaveHI64x2([a,b],[a,b]) == [a,a]
 
       and so the OR of the above 2 exprs produces
       [a OR b, a OR b], from which we simply take the lower half.
@@ -16404,7 +16413,7 @@ static void finish_xTESTy ( IRTemp andV, IRTemp andnV, Int sign )
    /* And finally, slice out the Z and C flags and set the flags
       thunk to COPY for them.  OSAP are set to zero. */
    IRTemp newOSZACP = newTemp(Ity_I64);
-   assign(newOSZACP, 
+   assign(newOSZACP,
           binop(Iop_Or64,
                 binop(Iop_And64, mkexpr(z64), mkU64(AMD64G_CC_MASK_Z)),
                 binop(Iop_And64, mkexpr(c64), mkU64(AMD64G_CC_MASK_C))));
@@ -16547,18 +16556,18 @@ static Long dis_PMOVxXBW_128 ( VexAbiInfo* vbi, Prefix pfx,
       DIP( "%spmov%cxbw %s,%s\n", mbV, how, nameXMMReg(rE), nameXMMReg(rG) );
    } else {
       addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
-      assign( srcVec, 
+      assign( srcVec,
               unop( Iop_64UtoV128, loadLE( Ity_I64, mkexpr(addr) ) ) );
       delta += alen;
       DIP( "%spmov%cxbw %s,%s\n", mbV, how, dis_buf, nameXMMReg(rG) );
    }
 
-   IRExpr* res 
+   IRExpr* res
       = xIsZ /* do math for either zero or sign extend */
-        ? binop( Iop_InterleaveLO8x16, 
+        ? binop( Iop_InterleaveLO8x16,
                  IRExpr_Const( IRConst_V128(0) ), mkexpr(srcVec) )
-        : binop( Iop_SarN16x8, 
-                 binop( Iop_ShlN16x8, 
+        : binop( Iop_SarN16x8,
+                 binop( Iop_ShlN16x8,
                         binop( Iop_InterleaveLO8x16,
                                IRExpr_Const( IRConst_V128(0) ),
                                mkexpr(srcVec) ),
@@ -16631,17 +16640,17 @@ static Long dis_PMOVxXWD_128 ( VexAbiInfo* vbi, Prefix pfx,
       DIP( "%spmov%cxwd %s,%s\n", mbV, how, nameXMMReg(rE), nameXMMReg(rG) );
    } else {
       addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
-      assign( srcVec, 
+      assign( srcVec,
               unop( Iop_64UtoV128, loadLE( Ity_I64, mkexpr(addr) ) ) );
       delta += alen;
       DIP( "%spmov%cxwd %s,%s\n", mbV, how, dis_buf, nameXMMReg(rG) );
    }
 
    IRExpr* res
-      = binop( Iop_InterleaveLO16x8,  
+      = binop( Iop_InterleaveLO16x8,
                IRExpr_Const( IRConst_V128(0) ), mkexpr(srcVec) );
    if (!xIsZ)
-      res = binop(Iop_SarN32x4, 
+      res = binop(Iop_SarN32x4,
                   binop(Iop_ShlN32x4, res, mkU8(16)), mkU8(16));
 
    (isAvx ? putYMMRegLoAndZU : putXMMReg)
@@ -16714,10 +16723,10 @@ static Long dis_PMOVSXWQ_128 ( VexAbiInfo* vbi, Prefix pfx,
    }
 
    (isAvx ? putYMMRegLoAndZU : putXMMReg)
-      ( rG, binop( Iop_64HLtoV128, 
+      ( rG, binop( Iop_64HLtoV128,
                    unop( Iop_16Sto64,
                          unop( Iop_32HIto16, mkexpr(srcBytes) ) ),
-                   unop( Iop_16Sto64, 
+                   unop( Iop_16Sto64,
                          unop( Iop_32to16, mkexpr(srcBytes) ) ) ) );
    return delta;
 }
@@ -16776,7 +16785,7 @@ static Long dis_PMOVZXWQ_128 ( VexAbiInfo* vbi, Prefix pfx,
       DIP( "%spmovzxwq %s,%s\n", mbV, nameXMMReg(rE), nameXMMReg(rG) );
    } else {
       addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
-      assign( srcVec, 
+      assign( srcVec,
               unop( Iop_32UtoV128, loadLE( Ity_I32, mkexpr(addr) ) ) );
       delta += alen;
       DIP( "%spmovzxwq %s,%s\n", mbV, dis_buf, nameXMMReg(rG) );
@@ -16786,9 +16795,9 @@ static Long dis_PMOVZXWQ_128 ( VexAbiInfo* vbi, Prefix pfx,
    assign( zeroVec, IRExpr_Const( IRConst_V128(0) ) );
 
    (isAvx ? putYMMRegLoAndZU : putXMMReg)
-      ( rG, binop( Iop_InterleaveLO16x8, 
-                   mkexpr(zeroVec), 
-                   binop( Iop_InterleaveLO16x8, 
+      ( rG, binop( Iop_InterleaveLO16x8,
+                   mkexpr(zeroVec),
+                   binop( Iop_InterleaveLO16x8,
                           mkexpr(zeroVec), mkexpr(srcVec) ) ) );
    return delta;
 }
@@ -16864,14 +16873,14 @@ static Long dis_PMOVxXDQ_128 ( VexAbiInfo* vbi, Prefix pfx,
       DIP( "%spmov%cxdq %s,%s\n", mbV, how, dis_buf, nameXMMReg(rG) );
    }
 
-   IRExpr* res 
+   IRExpr* res
       = xIsZ /* do math for either zero or sign extend */
-        ? binop( Iop_InterleaveLO32x4, 
+        ? binop( Iop_InterleaveLO32x4,
                  IRExpr_Const( IRConst_V128(0) ), mkexpr(srcVec) )
-        : binop( Iop_64HLtoV128, 
-                 unop( Iop_32Sto64, 
-                       unop( Iop_64HIto32, mkexpr(srcI64) ) ), 
-                 unop( Iop_32Sto64, 
+        : binop( Iop_64HLtoV128,
+                 unop( Iop_32Sto64,
+                       unop( Iop_64HIto32, mkexpr(srcI64) ) ),
+                 unop( Iop_32Sto64,
                        unop( Iop_64to32, mkexpr(srcI64) ) ) );
 
    (isAvx ? putYMMRegLoAndZU : putXMMReg) ( rG, res );
@@ -16952,7 +16961,7 @@ static Long dis_PMOVxXBD_128 ( VexAbiInfo* vbi, Prefix pfx,
       DIP( "%spmov%cxbd %s,%s\n", mbV, how, nameXMMReg(rE), nameXMMReg(rG) );
    } else {
       addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
-      assign( srcVec, 
+      assign( srcVec,
               unop( Iop_32UtoV128, loadLE( Ity_I32, mkexpr(addr) ) ) );
       delta += alen;
       DIP( "%spmov%cxbd %s,%s\n", mbV, how, dis_buf, nameXMMReg(rG) );
@@ -16964,10 +16973,10 @@ static Long dis_PMOVxXBD_128 ( VexAbiInfo* vbi, Prefix pfx,
    IRExpr* res
       = binop(Iop_InterleaveLO8x16,
               mkexpr(zeroVec),
-              binop(Iop_InterleaveLO8x16, 
+              binop(Iop_InterleaveLO8x16,
                     mkexpr(zeroVec), mkexpr(srcVec)));
    if (!xIsZ)
-      res = binop(Iop_SarN32x4, 
+      res = binop(Iop_SarN32x4,
                   binop(Iop_ShlN32x4, res, mkU8(24)), mkU8(24));
 
    (isAvx ? putYMMRegLoAndZU : putXMMReg) ( rG, res );
@@ -17120,8 +17129,8 @@ static Long dis_PMOVZXBQ_128 ( VexAbiInfo* vbi, Prefix pfx,
       DIP( "%spmovzxbq %s,%s\n", mbV, nameXMMReg(rE), nameXMMReg(rG) );
    } else {
       addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
-      assign( srcVec, 
-              unop( Iop_32UtoV128, 
+      assign( srcVec,
+              unop( Iop_32UtoV128,
                     unop( Iop_16Uto32, loadLE( Ity_I16, mkexpr(addr) ))));
       delta += alen;
       DIP( "%spmovzxbq %s,%s\n", mbV, dis_buf, nameXMMReg(rG) );
@@ -17131,11 +17140,11 @@ static Long dis_PMOVZXBQ_128 ( VexAbiInfo* vbi, Prefix pfx,
    assign( zeroVec, IRExpr_Const( IRConst_V128(0) ) );
 
    (isAvx ? putYMMRegLoAndZU : putXMMReg)
-      ( rG, binop( Iop_InterleaveLO8x16, 
-                   mkexpr(zeroVec), 
-                   binop( Iop_InterleaveLO8x16, 
-                          mkexpr(zeroVec), 
-                          binop( Iop_InterleaveLO8x16, 
+      ( rG, binop( Iop_InterleaveLO8x16,
+                   mkexpr(zeroVec),
+                   binop( Iop_InterleaveLO8x16,
+                          mkexpr(zeroVec),
+                          binop( Iop_InterleaveLO8x16,
                                  mkexpr(zeroVec), mkexpr(srcVec) ) ) ) );
    return delta;
 }
@@ -17216,7 +17225,7 @@ static Long dis_PHMINPOSUW_128 ( VexAbiInfo* vbi, Prefix pfx,
    assign( sLo, unop(Iop_V128to64,   mkexpr(sV)) );
    assign( dLo, mkIRExprCCall(
                    Ity_I64, 0/*regparms*/,
-                   "amd64g_calculate_sse_phminposuw", 
+                   "amd64g_calculate_sse_phminposuw",
                    &amd64g_calculate_sse_phminposuw,
                    mkIRExprVec_2( mkexpr(sLo), mkexpr(sHi) )
          ));
@@ -17292,7 +17301,7 @@ static Long dis_AESx ( VexAbiInfo* vbi, Prefix pfx,
       d->fxState[1].fx     = Ifx_Read;
       d->nFxState++;
       d->fxState[2].fx     = Ifx_Write;
-      d->fxState[2].offset = gstOffD; 
+      d->fxState[2].offset = gstOffD;
       d->fxState[2].size   = sizeof(U128);
    }
 
@@ -17307,7 +17316,7 @@ static Long dis_AESx ( VexAbiInfo* vbi, Prefix pfx,
          case 0xDB: opsuf = "imc"; break;
          default: vassert(0);
       }
-      DIP("%saes%s %s,%s%s%s\n", isAvx ? "v" : "", opsuf, 
+      DIP("%saes%s %s,%s%s%s\n", isAvx ? "v" : "", opsuf,
           (regNoL == 16 ? dis_buf : nameXMMReg(regNoL)),
           nameXMMReg(regNoR),
           (isAvx && opc != 0xDB) ? "," : "",
@@ -17469,7 +17478,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       break;
 
    case 0x20:
-      /* 66 0F 38 20 /r = PMOVSXBW xmm1, xmm2/m64 
+      /* 66 0F 38 20 /r = PMOVSXBW xmm1, xmm2/m64
          Packed Move with Sign Extend from Byte to Word (XMM) */
       if (have66noF2noF3(pfx) && sz == 2) {
          delta = dis_PMOVxXBW_128( vbi, pfx, delta,
@@ -17479,7 +17488,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       break;
 
    case 0x21:
-      /* 66 0F 38 21 /r = PMOVSXBD xmm1, xmm2/m32 
+      /* 66 0F 38 21 /r = PMOVSXBD xmm1, xmm2/m32
          Packed Move with Sign Extend from Byte to DWord (XMM) */
       if (have66noF2noF3(pfx) && sz == 2) {
          delta = dis_PMOVxXBD_128( vbi, pfx, delta,
@@ -17498,7 +17507,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       break;
 
    case 0x23:
-      /* 66 0F 38 23 /r = PMOVSXWD xmm1, xmm2/m64 
+      /* 66 0F 38 23 /r = PMOVSXWD xmm1, xmm2/m64
          Packed Move with Sign Extend from Word to DWord (XMM) */
       if (have66noF2noF3(pfx) && sz == 2) {
          delta = dis_PMOVxXWD_128(vbi, pfx, delta,
@@ -17558,9 +17567,9 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
    case 0x29:
       /* 66 0F 38 29 = PCMPEQQ
          64x2 equality comparison */
-      if (have66noF2noF3(pfx) && sz == 2) { 
+      if (have66noF2noF3(pfx) && sz == 2) {
          /* FIXME: this needs an alignment check */
-         delta = dis_SSEint_E_to_G( vbi, pfx, delta, 
+         delta = dis_SSEint_E_to_G( vbi, pfx, delta,
                                     "pcmpeqq", Iop_CmpEQ64x2, False );
          goto decode_success;
       }
@@ -17589,7 +17598,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       /* 66 0f 38 2B /r = PACKUSDW xmm1, xmm2/m128
          2x 32x4 S->U saturating narrow from xmm2/m128 to xmm1 */
       if (have66noF2noF3(pfx) && sz == 2) {
-  
+
          modrm = getUChar(delta);
 
          IRTemp argL = newTemp(Ity_V128);
@@ -17612,7 +17621,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
 
          assign(argR, getXMMReg( gregOfRexRM(pfx, modrm) ));
 
-         putXMMReg( gregOfRexRM(pfx, modrm), 
+         putXMMReg( gregOfRexRM(pfx, modrm),
                     binop( Iop_QNarrowBin32Sto16Ux8,
                            mkexpr(argL), mkexpr(argR)) );
 
@@ -17621,7 +17630,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       break;
 
    case 0x30:
-      /* 66 0F 38 30 /r = PMOVZXBW xmm1, xmm2/m64 
+      /* 66 0F 38 30 /r = PMOVZXBW xmm1, xmm2/m64
          Packed Move with Zero Extend from Byte to Word (XMM) */
       if (have66noF2noF3(pfx) && sz == 2) {
          delta = dis_PMOVxXBW_128( vbi, pfx, delta,
@@ -17631,7 +17640,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       break;
 
    case 0x31:
-      /* 66 0F 38 31 /r = PMOVZXBD xmm1, xmm2/m32 
+      /* 66 0F 38 31 /r = PMOVZXBD xmm1, xmm2/m32
          Packed Move with Zero Extend from Byte to DWord (XMM) */
       if (have66noF2noF3(pfx) && sz == 2) {
          delta = dis_PMOVxXBD_128( vbi, pfx, delta,
@@ -17650,7 +17659,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       break;
 
    case 0x33:
-      /* 66 0F 38 33 /r = PMOVZXWD xmm1, xmm2/m64 
+      /* 66 0F 38 33 /r = PMOVZXWD xmm1, xmm2/m64
          Packed Move with Zero Extend from Word to DWord (XMM) */
       if (have66noF2noF3(pfx) && sz == 2) {
          delta = dis_PMOVxXWD_128( vbi, pfx, delta,
@@ -17699,7 +17708,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
          /* FIXME: this needs an alignment check */
          Bool isMAX = opc == 0x3C;
          delta = dis_SSEint_E_to_G(
-                    vbi, pfx, delta, 
+                    vbi, pfx, delta,
                     isMAX ? "pmaxsb" : "pminsb",
                     isMAX ? Iop_Max8Sx16 : Iop_Min8Sx16,
                     False
@@ -17713,13 +17722,13 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       /* 66 0F 38 39 /r = PMINSD xmm1, xmm2/m128
          Minimum of Packed Signed Double Word Integers (XMM)
          66 0F 38 3D /r = PMAXSD xmm1, xmm2/m128
-         Maximum of Packed Signed Double Word Integers (XMM) 
+         Maximum of Packed Signed Double Word Integers (XMM)
       */
       if (have66noF2noF3(pfx) && sz == 2) {
          /* FIXME: this needs an alignment check */
          Bool isMAX = opc == 0x3D;
          delta = dis_SSEint_E_to_G(
-                    vbi, pfx, delta, 
+                    vbi, pfx, delta,
                     isMAX ? "pmaxsd" : "pminsd",
                     isMAX ? Iop_Max32Sx4 : Iop_Min32Sx4,
                     False
@@ -17739,7 +17748,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
          /* FIXME: this needs an alignment check */
          Bool isMAX = opc == 0x3E;
          delta = dis_SSEint_E_to_G(
-                    vbi, pfx, delta, 
+                    vbi, pfx, delta,
                     isMAX ? "pmaxuw" : "pminuw",
                     isMAX ? Iop_Max16Ux8 : Iop_Min16Ux8,
                     False
@@ -17759,7 +17768,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
          /* FIXME: this needs an alignment check */
          Bool isMAX = opc == 0x3F;
          delta = dis_SSEint_E_to_G(
-                    vbi, pfx, delta, 
+                    vbi, pfx, delta,
                     isMAX ? "pmaxud" : "pminud",
                     isMAX ? Iop_Max32Ux4 : Iop_Min32Ux4,
                     False
@@ -17772,7 +17781,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       /* 66 0F 38 40 /r = PMULLD xmm1, xmm2/m128
          32x4 integer multiply from xmm2/m128 to xmm1 */
       if (have66noF2noF3(pfx) && sz == 2) {
-  
+
          modrm = getUChar(delta);
 
          IRTemp argL = newTemp(Ity_V128);
@@ -17795,7 +17804,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
 
          assign(argR, getXMMReg( gregOfRexRM(pfx, modrm) ));
 
-         putXMMReg( gregOfRexRM(pfx, modrm), 
+         putXMMReg( gregOfRexRM(pfx, modrm),
                     binop( Iop_Mul32x4, mkexpr(argL), mkexpr(argR)) );
 
          goto decode_success;
@@ -17808,7 +17817,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
       if (have66noF2noF3(pfx) && sz == 2) {
          delta = dis_PHMINPOSUW_128( vbi, pfx, delta, False/*!isAvx*/ );
          goto decode_success;
-      } 
+      }
       break;
 
    case 0xDC:
@@ -17838,7 +17847,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
           && (opc == 0xF1 || (opc == 0xF0 && !have66(pfx)))) {
          modrm = getUChar(delta);
 
-         if (opc == 0xF0) 
+         if (opc == 0xF0)
             sz = 1;
          else
             vassert(sz == 2 || sz == 4 || sz == 8);
@@ -17882,7 +17891,7 @@ Long dis_ESC_0F38__SSE4 ( Bool* decode_OK,
          vassert(nm && fn);
          IRTemp valG1 = newTemp(Ity_I64);
          assign(valG1,
-                mkIRExprCCall(Ity_I64, 0/*regparm*/, nm, fn, 
+                mkIRExprCCall(Ity_I64, 0/*regparm*/, nm, fn,
                               mkIRExprVec_2(mkexpr(valG0),
                                             widenUto64(mkexpr(valE)))));
 
@@ -17935,7 +17944,7 @@ static Long dis_PEXTRW ( VexAbiInfo* vbi, Prefix pfx,
 
    if ( epartIsReg( modrm ) ) {
       imm8_20 = (Int)(getUChar(delta+1) & 7);
-   } else { 
+   } else {
       addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 1 );
       imm8_20 = (Int)(getUChar(delta+alen) & 7);
    }
@@ -17991,7 +18000,7 @@ static Long dis_PEXTRD ( VexAbiInfo* vbi, Prefix pfx,
 
    if ( epartIsReg( modrm ) ) {
       imm8_10 = (Int)(getUChar(delta+1) & 3);
-   } else { 
+   } else {
       addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 1 );
       imm8_10 = (Int)(getUChar(delta+alen) & 3);
    }
@@ -18405,8 +18414,8 @@ static IRTemp math_PINSRQ_128 ( IRTemp v128, IRTemp u64, UInt imm8 )
       OR into a suitably masked-out v128.*/
    IRTemp withZs = newTemp(Ity_V128);
    UShort mask = 0;
-   if (imm8 == 0) { 
-      mask = 0xFF00; 
+   if (imm8 == 0) {
+      mask = 0xFF00;
       assign(withZs, binop(Iop_64HLtoV128, mkU64(0), mkexpr(u64)));
    } else {
       vassert(imm8 == 1);
@@ -18435,10 +18444,10 @@ static IRTemp math_INSERTPS ( IRTemp dstV, IRTemp toInsertD, UInt imm8 )
    IRTemp zero_32 = newTemp(Ity_I32);
    assign( zero_32, mkU32(0) );
    IRTemp resV = newTemp(Ity_V128);
-   assign( resV, mkV128from32s( 
-                    ((imm8_zmask & 8) == 8) ? zero_32 : dstDs[3], 
-                    ((imm8_zmask & 4) == 4) ? zero_32 : dstDs[2], 
-                    ((imm8_zmask & 2) == 2) ? zero_32 : dstDs[1], 
+   assign( resV, mkV128from32s(
+                    ((imm8_zmask & 8) == 8) ? zero_32 : dstDs[3],
+                    ((imm8_zmask & 4) == 4) ? zero_32 : dstDs[2],
+                    ((imm8_zmask & 2) == 2) ? zero_32 : dstDs[1],
                     ((imm8_zmask & 1) == 1) ? zero_32 : dstDs[0]) );
    return resV;
 }
@@ -18474,16 +18483,16 @@ static Long dis_PEXTRB_128_GtoE ( VexAbiInfo* vbi, Prefix pfx,
       case 3:  assign( sel_lane, mkexpr(t3) ); break;
       default: vassert(0);
    }
-   assign( shr_lane, 
+   assign( shr_lane,
            binop( Iop_Shr32, mkexpr(sel_lane), mkU8(((imm8 & 3)*8)) ) );
 
    if ( epartIsReg( modrm ) ) {
-      putIReg64( eregOfRexRM(pfx,modrm), 
-                 unop( Iop_32Uto64, 
+      putIReg64( eregOfRexRM(pfx,modrm),
+                 unop( Iop_32Uto64,
                        binop(Iop_And32, mkexpr(shr_lane), mkU32(255)) ) );
       delta += 1+1;
-      DIP( "%spextrb $%d, %s,%s\n", mbV, imm8, 
-           nameXMMReg( gregOfRexRM(pfx, modrm) ), 
+      DIP( "%spextrb $%d, %s,%s\n", mbV, imm8,
+           nameXMMReg( gregOfRexRM(pfx, modrm) ),
            nameIReg64( eregOfRexRM(pfx, modrm) ) );
    } else {
       storeLE( mkexpr(addr), unop(Iop_32to8, mkexpr(shr_lane) ) );
@@ -18491,7 +18500,7 @@ static Long dis_PEXTRB_128_GtoE ( VexAbiInfo* vbi, Prefix pfx,
       DIP( "%spextrb $%d,%s,%s\n", mbV,
            imm8, nameXMMReg( gregOfRexRM(pfx, modrm) ), dis_buf );
    }
-   
+
    return delta;
 }
 
@@ -18533,35 +18542,35 @@ static IRTemp math_DPPS_128 ( IRTemp src_vec, IRTemp dst_vec, UInt imm8 )
    IRTemp rm           = newTemp(Ity_I32);
    IRTemp v3, v2, v1, v0;
    v3 = v2 = v1 = v0   = IRTemp_INVALID;
-   UShort imm8_perms[16] = { 0x0000, 0x000F, 0x00F0, 0x00FF, 0x0F00, 
+   UShort imm8_perms[16] = { 0x0000, 0x000F, 0x00F0, 0x00FF, 0x0F00,
                              0x0F0F, 0x0FF0, 0x0FFF, 0xF000, 0xF00F,
                              0xF0F0, 0xF0FF, 0xFF00, 0xFF0F, 0xFFF0,
                              0xFFFF };
 
    assign( rm, get_FAKE_roundingmode() ); /* XXXROUNDINGFIXME */
-   assign( tmp_prod_vec, 
-           binop( Iop_AndV128, 
+   assign( tmp_prod_vec,
+           binop( Iop_AndV128,
                   triop( Iop_Mul32Fx4,
-                         mkexpr(rm), mkexpr(dst_vec), mkexpr(src_vec) ), 
+                         mkexpr(rm), mkexpr(dst_vec), mkexpr(src_vec) ),
                   mkV128( imm8_perms[((imm8 >> 4)& 15)] ) ) );
    breakupV128to32s( tmp_prod_vec, &v3, &v2, &v1, &v0 );
    assign( prod_vec, mkV128from32s( v3, v1, v2, v0 ) );
 
    assign( sum_vec, triop( Iop_Add32Fx4,
                            mkexpr(rm),
-                           binop( Iop_InterleaveHI32x4, 
-                                  mkexpr(prod_vec), mkexpr(prod_vec) ), 
-                           binop( Iop_InterleaveLO32x4, 
+                           binop( Iop_InterleaveHI32x4,
+                                  mkexpr(prod_vec), mkexpr(prod_vec) ),
+                           binop( Iop_InterleaveLO32x4,
                                   mkexpr(prod_vec), mkexpr(prod_vec) ) ) );
 
    IRTemp res = newTemp(Ity_V128);
-   assign( res, binop( Iop_AndV128, 
+   assign( res, binop( Iop_AndV128,
                        triop( Iop_Add32Fx4,
                               mkexpr(rm),
                               binop( Iop_InterleaveHI32x4,
-                                     mkexpr(sum_vec), mkexpr(sum_vec) ), 
+                                     mkexpr(sum_vec), mkexpr(sum_vec) ),
                               binop( Iop_InterleaveLO32x4,
-                                     mkexpr(sum_vec), mkexpr(sum_vec) ) ), 
+                                     mkexpr(sum_vec), mkexpr(sum_vec) ) ),
                        mkV128( imm8_perms[ (imm8 & 15) ] ) ) );
    return res;
 }
@@ -18639,7 +18648,7 @@ static Long dis_EXTRACTPS ( VexAbiInfo* vbi, Prefix pfx,
 
    if ( epartIsReg( modrm ) ) {
       imm8_10 = (Int)(getUChar(delta+1) & 3);
-   } else { 
+   } else {
       addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 1 );
       imm8_10 = (Int)(getUChar(delta+alen) & 3);
    }
@@ -18673,7 +18682,7 @@ static IRTemp math_PCLMULQDQ( IRTemp dV, IRTemp sV, UInt imm8 )
 {
    IRTemp t0 = newTemp(Ity_I64);
    IRTemp t1 = newTemp(Ity_I64);
-   assign(t0, unop((imm8&1)? Iop_V128HIto64 : Iop_V128to64, 
+   assign(t0, unop((imm8&1)? Iop_V128HIto64 : Iop_V128to64,
               mkexpr(dV)));
    assign(t1, unop((imm8&16) ? Iop_V128HIto64 : Iop_V128to64,
               mkexpr(sV)));
@@ -18732,13 +18741,13 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
          modrm = getUChar(delta);
 
          if (epartIsReg(modrm)) {
-            assign( src0, 
+            assign( src0,
                     getXMMRegLane32F( eregOfRexRM(pfx, modrm), 0 ) );
-            assign( src1, 
+            assign( src1,
                     getXMMRegLane32F( eregOfRexRM(pfx, modrm), 1 ) );
-            assign( src2, 
+            assign( src2,
                     getXMMRegLane32F( eregOfRexRM(pfx, modrm), 2 ) );
-            assign( src3, 
+            assign( src3,
                     getXMMRegLane32F( eregOfRexRM(pfx, modrm), 3 ) );
             imm = getUChar(delta+1);
             if (imm & ~15) goto decode_failure;
@@ -18798,9 +18807,9 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
          modrm = getUChar(delta);
 
          if (epartIsReg(modrm)) {
-            assign( src0, 
+            assign( src0,
                     getXMMRegLane64F( eregOfRexRM(pfx, modrm), 0 ) );
-            assign( src1, 
+            assign( src1,
                     getXMMRegLane64F( eregOfRexRM(pfx, modrm), 1 ) );
             imm = getUChar(delta+1);
             if (imm & ~15) goto decode_failure;
@@ -18853,7 +18862,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
          modrm = getUChar(delta);
 
          if (epartIsReg(modrm)) {
-            assign( src, 
+            assign( src,
                     isD ? getXMMRegLane64F( eregOfRexRM(pfx, modrm), 0 )
                         : getXMMRegLane32F( eregOfRexRM(pfx, modrm), 0 ) );
             imm = getUChar(delta+1);
@@ -18879,7 +18888,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             we can use that value directly in the IR as a rounding
             mode. */
          assign(res, binop(isD ? Iop_RoundF64toInt : Iop_RoundF32toInt,
-                           (imm & 4) ? get_sse_roundingmode() 
+                           (imm & 4) ? get_sse_roundingmode()
                                      : mkU32(imm & 3),
                            mkexpr(src)) );
 
@@ -18911,19 +18920,19 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             delta += 1+1;
             DIP( "blendps $%d, %s,%s\n", imm8,
                  nameXMMReg( eregOfRexRM(pfx, modrm) ),
-                 nameXMMReg( gregOfRexRM(pfx, modrm) ) );    
+                 nameXMMReg( gregOfRexRM(pfx, modrm) ) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             gen_SEGV_if_not_16_aligned( addr );
             assign( src_vec, loadLE( Ity_V128, mkexpr(addr) ) );
             imm8 = (Int)getUChar(delta+alen);
             delta += alen+1;
-            DIP( "blendpd $%d, %s,%s\n", 
+            DIP( "blendpd $%d, %s,%s\n",
                  imm8, dis_buf, nameXMMReg( gregOfRexRM(pfx, modrm) ) );
          }
 
-         putXMMReg( gregOfRexRM(pfx, modrm), 
+         putXMMReg( gregOfRexRM(pfx, modrm),
                     mkexpr( math_BLENDPS_128( src_vec, dst_vec, imm8) ) );
          goto decode_success;
       }
@@ -18949,17 +18958,17 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
                  nameXMMReg( eregOfRexRM(pfx, modrm) ),
                  nameXMMReg( gregOfRexRM(pfx, modrm) ) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             gen_SEGV_if_not_16_aligned( addr );
             assign( src_vec, loadLE( Ity_V128, mkexpr(addr) ) );
             imm8 = (Int)getUChar(delta+alen);
             delta += alen+1;
-            DIP( "blendpd $%d, %s,%s\n", 
+            DIP( "blendpd $%d, %s,%s\n",
                  imm8, dis_buf, nameXMMReg( gregOfRexRM(pfx, modrm) ) );
          }
 
-         putXMMReg( gregOfRexRM(pfx, modrm), 
+         putXMMReg( gregOfRexRM(pfx, modrm),
                     mkexpr( math_BLENDPD_128( src_vec, dst_vec, imm8) ) );
          goto decode_success;
       }
@@ -18984,19 +18993,19 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             delta += 1+1;
             DIP( "pblendw $%d, %s,%s\n", imm8,
                  nameXMMReg( eregOfRexRM(pfx, modrm) ),
-                 nameXMMReg( gregOfRexRM(pfx, modrm) ) );    
+                 nameXMMReg( gregOfRexRM(pfx, modrm) ) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             gen_SEGV_if_not_16_aligned( addr );
             assign( src_vec, loadLE( Ity_V128, mkexpr(addr) ) );
             imm8 = (Int)getUChar(delta+alen);
             delta += alen+1;
-            DIP( "pblendw $%d, %s,%s\n", 
+            DIP( "pblendw $%d, %s,%s\n",
                  imm8, dis_buf, nameXMMReg( gregOfRexRM(pfx, modrm) ) );
          }
 
-         putXMMReg( gregOfRexRM(pfx, modrm), 
+         putXMMReg( gregOfRexRM(pfx, modrm),
                     mkexpr( math_PBLENDW_128( src_vec, dst_vec, imm8) ) );
          goto decode_success;
       }
@@ -19024,19 +19033,19 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
 
    case 0x16:
       /* 66 no-REX.W 0F 3A 16 /r ib = PEXTRD reg/mem32, xmm2, imm8
-         Extract Doubleword int from xmm reg and store in gen.reg or mem. (XMM) 
-         Note that this insn has the same opcodes as PEXTRQ, but 
+         Extract Doubleword int from xmm reg and store in gen.reg or mem. (XMM)
+         Note that this insn has the same opcodes as PEXTRQ, but
          here the REX.W bit is _not_ present */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && sz == 2 /* REX.W is _not_ present */) {
          delta = dis_PEXTRD( vbi, pfx, delta, False/*!isAvx*/ );
          goto decode_success;
       }
       /* 66 REX.W 0F 3A 16 /r ib = PEXTRQ reg/mem64, xmm2, imm8
-         Extract Quadword int from xmm reg and store in gen.reg or mem. (XMM) 
-         Note that this insn has the same opcodes as PEXTRD, but 
+         Extract Quadword int from xmm reg and store in gen.reg or mem. (XMM)
+         Note that this insn has the same opcodes as PEXTRD, but
          here the REX.W bit is present */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && sz == 8 /* REX.W is present */) {
          delta = dis_PEXTRQ( vbi, pfx, delta, False/*!isAvx*/);
          goto decode_success;
@@ -19048,7 +19057,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
          float from xmm reg and store in gen.reg or mem.  This is
          identical to PEXTRD, except that REX.W appears to be ignored.
       */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && (sz == 2 || /* ignore redundant REX.W */ sz == 8)) {
          delta = dis_EXTRACTPS( vbi, pfx, delta, False/*!isAvx*/ );
          goto decode_success;
@@ -19075,7 +19084,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             imm8 = (Int)(getUChar(delta+alen) & 0xF);
             assign( new8, loadLE( Ity_I8, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "pinsrb $%d,%s,%s\n", 
+            DIP( "pinsrb $%d,%s,%s\n",
                  imm8, dis_buf, nameXMMReg(rG) );
          }
          IRTemp src_vec = newTemp(Ity_V128);
@@ -19113,7 +19122,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             assign( d2ins, loadLE( Ity_I32, mkexpr(addr) ) );
             imm8 = getUChar(delta+alen);
             delta += alen+1;
-            DIP( "insertps $%u, %s,%s\n", 
+            DIP( "insertps $%u, %s,%s\n",
                  imm8, dis_buf, nameXMMReg(rG) );
          }
 
@@ -19128,7 +19137,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
    case 0x22:
       /* 66 no-REX.W 0F 3A 22 /r ib = PINSRD xmm1, r/m32, imm8
          Extract Doubleword int from gen.reg/mem32 and insert into xmm1 */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && sz == 2 /* REX.W is NOT present */) {
          Int    imm8_10;
          IRTemp src_u32 = newTemp(Ity_I32);
@@ -19147,7 +19156,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             imm8_10 = (Int)(getUChar(delta+alen) & 3);
             assign( src_u32, loadLE( Ity_I32, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "pinsrd $%d, %s,%s\n", 
+            DIP( "pinsrd $%d, %s,%s\n",
                  imm8_10, dis_buf, nameXMMReg(rG) );
          }
 
@@ -19159,7 +19168,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
       }
       /* 66 REX.W 0F 3A 22 /r ib = PINSRQ xmm1, r/m64, imm8
          Extract Quadword int from gen.reg/mem64 and insert into xmm1 */
-      if (have66noF2noF3(pfx) 
+      if (have66noF2noF3(pfx)
           && sz == 8 /* REX.W is present */) {
          Int imm8_0;
          IRTemp src_u64 = newTemp(Ity_I64);
@@ -19178,7 +19187,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             imm8_0 = (Int)(getUChar(delta+alen) & 1);
             assign( src_u64, loadLE( Ity_I64, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "pinsrq $%d, %s,%s\n", 
+            DIP( "pinsrq $%d, %s,%s\n",
                  imm8_0, dis_buf, nameXMMReg(rG) );
          }
 
@@ -19206,15 +19215,15 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             assign( src_vec, getXMMReg(rE) );
             delta += 1+1;
             DIP( "dpps $%d, %s,%s\n",
-                 imm8, nameXMMReg(rE), nameXMMReg(rG) );    
+                 imm8, nameXMMReg(rE), nameXMMReg(rG) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             gen_SEGV_if_not_16_aligned( addr );
             assign( src_vec, loadLE( Ity_V128, mkexpr(addr) ) );
             imm8 = (Int)getUChar(delta+alen);
             delta += alen+1;
-            DIP( "dpps $%d, %s,%s\n", 
+            DIP( "dpps $%d, %s,%s\n",
                  imm8, dis_buf, nameXMMReg(rG) );
          }
          IRTemp res = math_DPPS_128( src_vec, dst_vec, imm8 );
@@ -19239,15 +19248,15 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             assign( src_vec, getXMMReg(rE) );
             delta += 1+1;
             DIP( "dppd $%d, %s,%s\n",
-                 imm8, nameXMMReg(rE), nameXMMReg(rG) );    
+                 imm8, nameXMMReg(rE), nameXMMReg(rG) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             gen_SEGV_if_not_16_aligned( addr );
             assign( src_vec, loadLE( Ity_V128, mkexpr(addr) ) );
             imm8 = (Int)getUChar(delta+alen);
             delta += alen+1;
-            DIP( "dppd $%d, %s,%s\n", 
+            DIP( "dppd $%d, %s,%s\n",
                  imm8, dis_buf, nameXMMReg(rG) );
          }
          IRTemp res = math_DPPD_128( src_vec, dst_vec, imm8 );
@@ -19267,7 +19276,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
          UInt   rG      = gregOfRexRM(pfx, modrm);
 
          assign( dst_vec, getXMMReg(rG) );
-  
+
          if ( epartIsReg( modrm ) ) {
             UInt rE = eregOfRexRM(pfx, modrm);
 
@@ -19277,7 +19286,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
             DIP( "mpsadbw $%d, %s,%s\n", imm8,
                  nameXMMReg(rE), nameXMMReg(rG) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             gen_SEGV_if_not_16_aligned( addr );
             assign( src_vec, loadLE( Ity_V128, mkexpr(addr) ) );
@@ -19297,7 +19306,7 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
        * registers (a.k.a multiplication of polynomials over GF(2))
        */
       if (have66noF2noF3(pfx) && sz == 2) {
-  
+
          Int imm8;
          IRTemp svec = newTemp(Ity_V128);
          IRTemp dvec = newTemp(Ity_V128);
@@ -19305,22 +19314,22 @@ Long dis_ESC_0F3A__SSE4 ( Bool* decode_OK,
          UInt   rG   = gregOfRexRM(pfx, modrm);
 
          assign( dvec, getXMMReg(rG) );
-  
+
          if ( epartIsReg( modrm ) ) {
             UInt rE = eregOfRexRM(pfx, modrm);
             imm8 = (Int)getUChar(delta+1);
             assign( svec, getXMMReg(rE) );
             delta += 1+1;
             DIP( "pclmulqdq $%d, %s,%s\n", imm8,
-                 nameXMMReg(rE), nameXMMReg(rG) );    
+                 nameXMMReg(rE), nameXMMReg(rG) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             gen_SEGV_if_not_16_aligned( addr );
             assign( svec, loadLE( Ity_V128, mkexpr(addr) ) );
             imm8 = (Int)getUChar(delta+alen);
             delta += alen+1;
-            DIP( "pclmulqdq $%d, %s,%s\n", 
+            DIP( "pclmulqdq $%d, %s,%s\n",
                  imm8, dis_buf, nameXMMReg(rG) );
          }
 
@@ -19387,7 +19396,7 @@ Long dis_ESC_NONE (
         void*        callback_opaque,
         VexArchInfo* archinfo,
         VexAbiInfo*  vbi,
-        Prefix pfx, Int sz, Long deltaIN 
+        Prefix pfx, Int sz, Long deltaIN
      )
 {
    Long   d64   = 0;
@@ -19674,7 +19683,7 @@ Long dis_ESC_NONE (
       if (sz == 4)
          sz = 8; /* there is no encoding for 32-bit push in 64-bit mode */
       ty = sz==2 ? Ity_I16 : Ity_I64;
-      t1 = newTemp(ty); 
+      t1 = newTemp(ty);
       t2 = newTemp(Ity_I64);
       assign(t1, getIRegRexB(sz, pfx, opc-0x50));
       assign(t2, binop(Iop_Sub64, getIReg64(R_RSP), mkU64(sz)));
@@ -19695,7 +19704,7 @@ Long dis_ESC_NONE (
       vassert(sz == 2 || sz == 4 || sz == 8);
       if (sz == 4)
          sz = 8; /* there is no encoding for 32-bit pop in 64-bit mode */
-      t1 = newTemp(szToITy(sz)); 
+      t1 = newTemp(szToITy(sz));
       t2 = newTemp(Ity_I64);
       assign(t2, getIReg64(R_RSP));
       assign(t1, loadLE(szToITy(sz),mkexpr(t2)));
@@ -19712,8 +19721,8 @@ Long dis_ESC_NONE (
          modrm = getUChar(delta);
          if (epartIsReg(modrm)) {
             delta++;
-            putIRegG(8, pfx, modrm, 
-                             unop(Iop_32Sto64, 
+            putIRegG(8, pfx, modrm,
+                             unop(Iop_32Sto64,
                                   getIRegE(4, pfx, modrm)));
             DIP("movslq %s,%s\n",
                 nameIRegE(4, pfx, modrm),
@@ -19722,10 +19731,10 @@ Long dis_ESC_NONE (
          } else {
             addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
             delta += alen;
-            putIRegG(8, pfx, modrm, 
-                             unop(Iop_32Sto64, 
+            putIRegG(8, pfx, modrm,
+                             unop(Iop_32Sto64,
                                   loadLE(Ity_I32, mkexpr(addr))));
-            DIP("movslq %s,%s\n", dis_buf, 
+            DIP("movslq %s,%s\n", dis_buf,
                 nameIRegG(8, pfx, modrm));
             return delta;
          }
@@ -19737,7 +19746,7 @@ Long dis_ESC_NONE (
       if (haveF2orF3(pfx)) goto decode_failure;
       /* Note, sz==4 is not possible in 64-bit mode.  Hence ... */
       if (sz == 4) sz = 8;
-      d64 = getSDisp(imin(4,sz),delta); 
+      d64 = getSDisp(imin(4,sz),delta);
       delta += imin(4,sz);
       goto do_push_I;
 
@@ -19805,7 +19814,7 @@ Long dis_ESC_NONE (
             branch target address (d64).  If we wind up back at the
             first instruction of the trace, just stop; it's better to
             let the IR loop unroller handle that case. */
-         stmt( IRStmt_Exit( 
+         stmt( IRStmt_Exit(
                   mk_amd64g_calculate_condition(
                      (AMD64Condcode)(1 ^ (opc - 0x70))),
                   Ijk_Boring,
@@ -19825,7 +19834,7 @@ Long dis_ESC_NONE (
             we need to emit a side-exit to d64 (the dest) and continue
             disassembling at the insn immediately following this
             one. */
-         stmt( IRStmt_Exit( 
+         stmt( IRStmt_Exit(
                   mk_amd64g_calculate_condition((AMD64Condcode)(opc - 0x70)),
                   Ijk_Boring,
                   IRConst_U64(d64),
@@ -19911,7 +19920,7 @@ Long dis_ESC_NONE (
          presence of LOCK in this case -- XCHG is unusual in this
          respect. */
       if (haveF2orF3(pfx)) {
-         if (epartIsReg(modrm)) { 
+         if (epartIsReg(modrm)) {
             goto decode_failure;
          } else {
             if (haveF2andF3(pfx))
@@ -19926,8 +19935,8 @@ Long dis_ESC_NONE (
          putIRegG(sz, pfx, modrm, mkexpr(t1));
          putIRegE(sz, pfx, modrm, mkexpr(t2));
          delta++;
-         DIP("xchg%c %s, %s\n", 
-             nameISize(sz), nameIRegG(sz, pfx, modrm), 
+         DIP("xchg%c %s, %s\n",
+             nameISize(sz), nameIRegG(sz, pfx, modrm),
                             nameIRegE(sz, pfx, modrm));
       } else {
          *expect_CAS = True;
@@ -19938,7 +19947,7 @@ Long dis_ESC_NONE (
                 mkexpr(t1), mkexpr(t2), guest_RIP_curr_instr );
          putIRegG( sz, pfx, modrm, mkexpr(t1) );
          delta += alen;
-         DIP("xchg%c %s, %s\n", nameISize(sz), 
+         DIP("xchg%c %s, %s\n", nameISize(sz),
                                 nameIRegG(sz, pfx, modrm), dis_buf);
       }
       return delta;
@@ -19974,7 +19983,7 @@ Long dis_ESC_NONE (
       if (sz != 4 && sz != 8)
          goto decode_failure;
       modrm = getUChar(delta);
-      if (epartIsReg(modrm)) 
+      if (epartIsReg(modrm))
          goto decode_failure;
       /* NOTE!  this is the one place where a segment override prefix
          has no effect on the address calculation.  Therefore we clear
@@ -19984,12 +19993,12 @@ Long dis_ESC_NONE (
       /* This is a hack.  But it isn't clear that really doing the
          calculation at 32 bits is really worth it.  Hence for leal,
          do the full 64-bit calculation and then truncate it. */
-      putIRegG( sz, pfx, modrm, 
+      putIRegG( sz, pfx, modrm,
                          sz == 4
                             ? unop(Iop_64to32, mkexpr(addr))
                             : mkexpr(addr)
               );
-      DIP("lea%c %s, %s\n", nameISize(sz), dis_buf, 
+      DIP("lea%c %s, %s\n", nameISize(sz), dis_buf,
                             nameIRegG(sz,pfx,modrm));
       return delta;
 
@@ -20010,13 +20019,13 @@ Long dis_ESC_NONE (
       if (epartIsReg(rm) || gregLO3ofRM(rm) != 0)
          goto decode_failure;
       /* and has correct size */
-      vassert(sz == 8);      
-       
+      vassert(sz == 8);
+
       t1 = newTemp(Ity_I64);
       t3 = newTemp(Ity_I64);
       assign( t1, getIReg64(R_RSP) );
       assign( t3, loadLE(Ity_I64, mkexpr(t1)) );
-       
+
       /* Increase RSP; must be done before the STORE.  Intel manual
          says: If the RSP register is used as a base register for
          addressing a destination operand in memory, the POP
@@ -20087,12 +20096,12 @@ Long dis_ESC_NONE (
       if (haveF2orF3(pfx)) goto decode_failure;
       vassert(sz == 2 || sz == 4 || sz == 8);
       ty = szToITy(sz);
-      putIRegRDX( sz, 
-                  binop(mkSizedOp(ty,Iop_Sar8), 
+      putIRegRDX( sz,
+                  binop(mkSizedOp(ty,Iop_Sar8),
                         getIRegRAX(sz),
                         mkU8(sz == 2 ? 15 : (sz == 4 ? 31 : 63))) );
-      DIP(sz == 2 ? "cwd\n" 
-                  : (sz == 4 ? /*"cdq\n"*/ "cltd\n" 
+      DIP(sz == 2 ? "cwd\n"
+                  : (sz == 4 ? /*"cdq\n"*/ "cltd\n"
                              : "cqo\n"));
       return delta;
 
@@ -20125,7 +20134,7 @@ Long dis_ESC_NONE (
                         mkexpr(t2),
                         binop(Iop_And64,
                               IRExpr_Get(OFFB_DFLAG,Ity_I64),
-                              mkU64(1<<10))) 
+                              mkU64(1<<10)))
             );
 
       /* And patch in the ID flag. */
@@ -20133,7 +20142,7 @@ Long dis_ESC_NONE (
       assign( t4, binop(Iop_Or64,
                         mkexpr(t3),
                         binop(Iop_And64,
-                              binop(Iop_Shl64, IRExpr_Get(OFFB_IDFLAG,Ity_I64), 
+                              binop(Iop_Shl64, IRExpr_Get(OFFB_IDFLAG,Ity_I64),
                                                mkU8(21)),
                               mkU64(1<<21)))
             );
@@ -20143,7 +20152,7 @@ Long dis_ESC_NONE (
       assign( t5, binop(Iop_Or64,
                         mkexpr(t4),
                         binop(Iop_And64,
-                              binop(Iop_Shl64, IRExpr_Get(OFFB_ACFLAG,Ity_I64), 
+                              binop(Iop_Shl64, IRExpr_Get(OFFB_ACFLAG,Ity_I64),
                                                mkU8(18)),
                               mkU64(1<<18)))
             );
@@ -20152,7 +20161,7 @@ Long dis_ESC_NONE (
       if (sz == 2)
         storeLE( mkexpr(t1), unop(Iop_32to16,
                              unop(Iop_64to32,mkexpr(t5))) );
-      else 
+      else
         storeLE( mkexpr(t1), mkexpr(t5) );
 
       DIP("pushf%c\n", nameISize(sz));
@@ -20170,15 +20179,15 @@ Long dis_ESC_NONE (
       assign(t2, getIReg64(R_RSP));
       assign(t1, widenUto64(loadLE(szToITy(sz),mkexpr(t2))));
       putIReg64(R_RSP, binop(Iop_Add64, mkexpr(t2), mkU64(sz)));
-      /* t1 is the flag word.  Mask out everything except OSZACP and 
+      /* t1 is the flag word.  Mask out everything except OSZACP and
          set the flags thunk to AMD64G_CC_OP_COPY. */
       stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
       stmt( IRStmt_Put( OFFB_CC_DEP2, mkU64(0) ));
-      stmt( IRStmt_Put( OFFB_CC_DEP1, 
+      stmt( IRStmt_Put( OFFB_CC_DEP1,
                         binop(Iop_And64,
-                              mkexpr(t1), 
-                              mkU64( AMD64G_CC_MASK_C | AMD64G_CC_MASK_P 
-                                     | AMD64G_CC_MASK_A | AMD64G_CC_MASK_Z 
+                              mkexpr(t1),
+                              mkU64( AMD64G_CC_MASK_C | AMD64G_CC_MASK_P
+                                     | AMD64G_CC_MASK_A | AMD64G_CC_MASK_Z
                                      | AMD64G_CC_MASK_S| AMD64G_CC_MASK_O )
                              )
                        )
@@ -20186,39 +20195,39 @@ Long dis_ESC_NONE (
 
       /* Also need to set the D flag, which is held in bit 10 of t1.
          If zero, put 1 in OFFB_DFLAG, else -1 in OFFB_DFLAG. */
-      stmt( IRStmt_Put( 
+      stmt( IRStmt_Put(
                OFFB_DFLAG,
-               IRExpr_ITE( 
+               IRExpr_ITE(
                   unop(Iop_64to1,
-                       binop(Iop_And64, 
-                             binop(Iop_Shr64, mkexpr(t1), mkU8(10)), 
+                       binop(Iop_And64,
+                             binop(Iop_Shr64, mkexpr(t1), mkU8(10)),
                              mkU64(1))),
                   mkU64(0xFFFFFFFFFFFFFFFFULL),
                   mkU64(1)))
           );
 
       /* And set the ID flag */
-      stmt( IRStmt_Put( 
+      stmt( IRStmt_Put(
                OFFB_IDFLAG,
-               IRExpr_ITE( 
+               IRExpr_ITE(
                   unop(Iop_64to1,
-                       binop(Iop_And64, 
-                             binop(Iop_Shr64, mkexpr(t1), mkU8(21)), 
+                       binop(Iop_And64,
+                             binop(Iop_Shr64, mkexpr(t1), mkU8(21)),
                              mkU64(1))),
                   mkU64(1),
-                  mkU64(0))) 
+                  mkU64(0)))
           );
 
       /* And set the AC flag too */
-      stmt( IRStmt_Put( 
+      stmt( IRStmt_Put(
                OFFB_ACFLAG,
-               IRExpr_ITE( 
+               IRExpr_ITE(
                   unop(Iop_64to1,
-                       binop(Iop_And64, 
-                             binop(Iop_Shr64, mkexpr(t1), mkU8(18)), 
+                       binop(Iop_And64,
+                             binop(Iop_Shr64, mkexpr(t1), mkU8(18)),
                              mkU64(1))),
                   mkU64(1),
-                  mkU64(0))) 
+                  mkU64(0)))
           );
 
       DIP("popf%c\n", nameISize(sz));
@@ -20239,15 +20248,15 @@ Long dis_ESC_NONE (
       sz = 1;
       /* Fall through ... */
    case 0xA1: /* MOV Ov,eAX */
-      if (sz != 8 && sz != 4 && sz != 2 && sz != 1) 
+      if (sz != 8 && sz != 4 && sz != 2 && sz != 1)
          goto decode_failure;
-      d64 = getDisp64(delta); 
+      d64 = getDisp64(delta);
       delta += 8;
       ty = szToITy(sz);
       addr = newTemp(Ity_I64);
       assign( addr, handleAddrOverrides(vbi, pfx, mkU64(d64)) );
       putIRegRAX(sz, loadLE( ty, mkexpr(addr) ));
-      DIP("mov%c %s0x%llx, %s\n", nameISize(sz), 
+      DIP("mov%c %s0x%llx, %s\n", nameISize(sz),
                                   segRegTxt(pfx), d64,
                                   nameIRegRAX(sz));
       return delta;
@@ -20257,9 +20266,9 @@ Long dis_ESC_NONE (
       sz = 1;
       /* Fall through ... */
    case 0xA3: /* MOV eAX,Ov */
-      if (sz != 8 && sz != 4 && sz != 2 && sz != 1) 
+      if (sz != 8 && sz != 4 && sz != 2 && sz != 1)
          goto decode_failure;
-      d64 = getDisp64(delta); 
+      d64 = getDisp64(delta);
       delta += 8;
       ty = szToITy(sz);
       addr = newTemp(Ity_I64);
@@ -20296,7 +20305,7 @@ Long dis_ESC_NONE (
       if (haveF3(pfx) && !haveF2(pfx)) {
          if (opc == 0xA6)
             sz = 1;
-         dis_REP_op ( dres, AMD64CondZ, dis_CMPS, sz, 
+         dis_REP_op ( dres, AMD64CondZ, dis_CMPS, sz,
                       guest_RIP_curr_instr,
                       guest_RIP_bbstart+delta, "repe cmps", pfx );
          dres->whatNext = Dis_StopHere;
@@ -20345,7 +20354,7 @@ Long dis_ESC_NONE (
       if (haveF2(pfx) && !haveF3(pfx)) {
          if (opc == 0xAE)
             sz = 1;
-         dis_REP_op ( dres, AMD64CondNZ, dis_SCAS, sz, 
+         dis_REP_op ( dres, AMD64CondNZ, dis_SCAS, sz,
                       guest_RIP_curr_instr,
                       guest_RIP_bbstart+delta, "repne scas", pfx );
          vassert(dres->whatNext == Dis_StopHere);
@@ -20355,7 +20364,7 @@ Long dis_ESC_NONE (
       if (!haveF2(pfx) && haveF3(pfx)) {
          if (opc == 0xAE)
             sz = 1;
-         dis_REP_op ( dres, AMD64CondZ, dis_SCAS, sz, 
+         dis_REP_op ( dres, AMD64CondZ, dis_SCAS, sz,
                       guest_RIP_curr_instr,
                       guest_RIP_bbstart+delta, "repe scas", pfx );
          vassert(dres->whatNext == Dis_StopHere);
@@ -20380,7 +20389,7 @@ Long dis_ESC_NONE (
    case 0xB6: /* MOV imm,DH */
    case 0xB7: /* MOV imm,BH */
       if (haveF2orF3(pfx)) goto decode_failure;
-      d64 = getUChar(delta); 
+      d64 = getUChar(delta);
       delta += 1;
       putIRegRexB(1, pfx, opc-0xB0, mkU8(d64));
       DIP("movb $%lld,%s\n", d64, nameIRegRexB(1,pfx,opc-0xB0));
@@ -20401,15 +20410,15 @@ Long dis_ESC_NONE (
          d64 = getDisp64(delta);
          delta += 8;
          putIRegRexB(8, pfx, opc-0xB8, mkU64(d64));
-         DIP("movabsq $%lld,%s\n", (Long)d64, 
+         DIP("movabsq $%lld,%s\n", (Long)d64,
                                    nameIRegRexB(8,pfx,opc-0xB8));
       } else {
          d64 = getSDisp(imin(4,sz),delta);
          delta += imin(4,sz);
-         putIRegRexB(sz, pfx, opc-0xB8, 
+         putIRegRexB(sz, pfx, opc-0xB8,
                          mkU(szToITy(sz), d64 & mkSizeMask(sz)));
-         DIP("mov%c $%lld,%s\n", nameISize(sz), 
-                                 (Long)d64, 
+         DIP("mov%c $%lld,%s\n", nameISize(sz),
+                                 (Long)d64,
                                  nameIRegRexB(sz,pfx,opc-0xB8));
       }
       return delta;
@@ -20422,7 +20431,7 @@ Long dis_ESC_NONE (
       d_sz  = 1;
       d64   = getUChar(delta + am_sz);
       sz    = 1;
-      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz, 
+      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz,
                          mkU8(d64 & 0xFF), NULL, &decode_OK );
       if (!decode_OK) goto decode_failure;
       return delta;
@@ -20435,7 +20444,7 @@ Long dis_ESC_NONE (
       am_sz = lengthAMode(pfx,delta);
       d_sz  = 1;
       d64   = getUChar(delta + am_sz);
-      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz, 
+      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz,
                          mkU8(d64 & 0xFF), NULL, &decode_OK );
       if (!decode_OK) goto decode_failure;
       return delta;
@@ -20444,7 +20453,7 @@ Long dis_ESC_NONE (
    case 0xC2: /* RET imm16 */
       if (have66orF3(pfx)) goto decode_failure;
       if (haveF2(pfx)) DIP("bnd ; "); /* MPX bnd prefix. */
-      d64 = getUDisp16(delta); 
+      d64 = getUDisp16(delta);
       delta += 2;
       dis_ret(dres, vbi, d64);
       DIP("ret $%lld\n", d64);
@@ -20470,22 +20479,22 @@ Long dis_ESC_NONE (
             /* Neither F2 nor F3 are allowable. */
             if (haveF2orF3(pfx)) goto decode_failure;
             delta++; /* mod/rm byte */
-            d64 = getSDisp(imin(4,sz),delta); 
+            d64 = getSDisp(imin(4,sz),delta);
             delta += imin(4,sz);
-            putIRegE(sz, pfx, modrm, 
+            putIRegE(sz, pfx, modrm,
                          mkU(szToITy(sz), d64 & mkSizeMask(sz)));
-            DIP("mov%c $%lld, %s\n", nameISize(sz), 
-                                     (Long)d64, 
+            DIP("mov%c $%lld, %s\n", nameISize(sz),
+                                     (Long)d64,
                                      nameIRegE(sz,pfx,modrm));
          } else {
             if (haveF2(pfx)) goto decode_failure;
             /* F3(XRELEASE) is allowable here */
-            addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode ( &alen, vbi, pfx, delta, dis_buf,
                               /*xtra*/imin(4,sz) );
             delta += alen;
             d64 = getSDisp(imin(4,sz),delta);
             delta += imin(4,sz);
-            storeLE(mkexpr(addr), 
+            storeLE(mkexpr(addr),
                     mkU(szToITy(sz), d64 & mkSizeMask(sz)));
             DIP("mov%c $%lld, %s\n", nameISize(sz), (Long)d64, dis_buf);
          }
@@ -20495,7 +20504,7 @@ Long dis_ESC_NONE (
       if (opc == 0xC7 && modrm == 0xF8 && !have66orF2orF3(pfx) && sz == 4
           && (archinfo->hwcaps & VEX_HWCAPS_AMD64_AVX)) {
          delta++; /* mod/rm byte */
-         d64 = getSDisp(4,delta); 
+         d64 = getSDisp(4,delta);
          delta += 4;
          guest_RIP_next_mustcheck = True;
          guest_RIP_next_assumed   = guest_RIP_bbstart + delta;
@@ -20558,9 +20567,9 @@ Long dis_ESC_NONE (
       /* In 64-bit mode this defaults to a 64-bit operand size.  There
          is no way to encode a 32-bit variant.  Hence sz==4 but we do
          it as if sz=8. */
-      if (sz != 4) 
+      if (sz != 4)
          goto decode_failure;
-      t1 = newTemp(Ity_I64); 
+      t1 = newTemp(Ity_I64);
       t2 = newTemp(Ity_I64);
       assign(t1, getIReg64(R_RBP));
       /* First PUT RSP looks redundant, but need it because RSP must
@@ -20586,7 +20595,7 @@ Long dis_ESC_NONE (
       d_sz  = 0;
       d64   = 1;
       sz    = 1;
-      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz, 
+      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz,
                          mkU8(d64), NULL, &decode_OK );
       if (!decode_OK) goto decode_failure;
       return delta;
@@ -20599,7 +20608,7 @@ Long dis_ESC_NONE (
       am_sz = lengthAMode(pfx,delta);
       d_sz  = 0;
       d64   = 1;
-      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz, 
+      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz,
                          mkU8(d64), NULL, &decode_OK );
       if (!decode_OK) goto decode_failure;
       return delta;
@@ -20612,7 +20621,7 @@ Long dis_ESC_NONE (
       am_sz = lengthAMode(pfx,delta);
       d_sz  = 0;
       sz    = 1;
-      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz, 
+      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz,
                          getIRegCL(), "%cl", &decode_OK );
       if (!decode_OK) goto decode_failure;
       return delta;
@@ -20624,7 +20633,7 @@ Long dis_ESC_NONE (
       modrm = getUChar(delta);
       am_sz = lengthAMode(pfx,delta);
       d_sz  = 0;
-      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz, 
+      delta = dis_Grp2 ( vbi, pfx, delta, modrm, am_sz, d_sz, sz,
                          getIRegCL(), "%cl", &decode_OK );
       if (!decode_OK) goto decode_failure;
       return delta;
@@ -20640,7 +20649,7 @@ Long dis_ESC_NONE (
    case 0xDF: {
       Bool redundantREXWok = False;
 
-      if (haveF2orF3(pfx)) 
+      if (haveF2orF3(pfx))
          goto decode_failure;
 
       /* kludge to tolerate redundant rex.w prefixes (should do this
@@ -20697,7 +20706,7 @@ Long dis_ESC_NONE (
          /* 64to32 of 64-bit get is merely a get-put improvement
             trick. */
          putIReg32(R_RCX, binop(Iop_Sub32,
-                                unop(Iop_64to32, getIReg64(R_RCX)), 
+                                unop(Iop_64to32, getIReg64(R_RCX)),
                                 mkU32(1)));
       } else {
          putIReg64(R_RCX, binop(Iop_Sub64, getIReg64(R_RCX), mkU64(1)));
@@ -20710,15 +20719,15 @@ Long dis_ESC_NONE (
       count = getIReg64(R_RCX);
       cond = binop(Iop_CmpNE64, count, mkU64(0));
       switch (opc) {
-         case 0xE2: 
-            xtra = ""; 
+         case 0xE2:
+            xtra = "";
             break;
-         case 0xE1: 
-            xtra = "e"; 
+         case 0xE1:
+            xtra = "e";
             zbit = mk_amd64g_calculate_condition( AMD64CondZ );
             cond = mkAnd1(cond, zbit);
             break;
-         case 0xE0: 
+         case 0xE0:
             xtra = "ne";
             zbit = mk_amd64g_calculate_condition( AMD64CondNZ );
             cond = mkAnd1(cond, zbit);
@@ -20732,15 +20741,15 @@ Long dis_ESC_NONE (
       return delta;
     }
 
-   case 0xE3: 
+   case 0xE3:
       /* JRCXZ or JECXZ, depending address size override. */
       if (have66orF2orF3(pfx)) goto decode_failure;
-      d64 = (guest_RIP_bbstart+delta+1) + getSDisp8(delta); 
+      d64 = (guest_RIP_bbstart+delta+1) + getSDisp8(delta);
       delta++;
       if (haveASO(pfx)) {
          /* 32-bit */
-         stmt( IRStmt_Exit( binop(Iop_CmpEQ64, 
-                                  unop(Iop_32Uto64, getIReg32(R_RCX)), 
+         stmt( IRStmt_Exit( binop(Iop_CmpEQ64,
+                                  unop(Iop_32Uto64, getIReg32(R_RCX)),
                                   mkU64(0)),
                             Ijk_Boring,
                             IRConst_U64(d64),
@@ -20749,8 +20758,8 @@ Long dis_ESC_NONE (
          DIP("jecxz 0x%llx\n", d64);
       } else {
          /* 64-bit */
-         stmt( IRStmt_Exit( binop(Iop_CmpEQ64, 
-                                  getIReg64(R_RCX), 
+         stmt( IRStmt_Exit( binop(Iop_CmpEQ64,
+                                  getIReg64(R_RCX),
                                   mkU64(0)),
                             Ijk_Boring,
                             IRConst_U64(d64),
@@ -20761,7 +20770,7 @@ Long dis_ESC_NONE (
       return delta;
 
    case 0xE4: /* IN imm8, AL */
-      sz = 1; 
+      sz = 1;
       t1 = newTemp(Ity_I64);
       abyte = getUChar(delta); delta++;
       assign(t1, mkU64( abyte & 0xFF ));
@@ -20775,17 +20784,17 @@ Long dis_ESC_NONE (
       DIP("in%c $%d,%s\n", nameISize(sz), (Int)abyte, nameIRegRAX(sz));
       goto do_IN;
    case 0xEC: /* IN %DX, AL */
-      sz = 1; 
+      sz = 1;
       t1 = newTemp(Ity_I64);
       assign(t1, unop(Iop_16Uto64, getIRegRDX(2)));
-      DIP("in%c %s,%s\n", nameISize(sz), nameIRegRDX(2), 
+      DIP("in%c %s,%s\n", nameISize(sz), nameIRegRDX(2),
                                          nameIRegRAX(sz));
       goto do_IN;
    case 0xED: /* IN %DX, eAX */
       if (!(sz == 2 || sz == 4)) goto decode_failure;
       t1 = newTemp(Ity_I64);
       assign(t1, unop(Iop_16Uto64, getIRegRDX(2)));
-      DIP("in%c %s,%s\n", nameISize(sz), nameIRegRDX(2), 
+      DIP("in%c %s,%s\n", nameISize(sz), nameIRegRDX(2),
                                          nameIRegRAX(sz));
       goto do_IN;
    do_IN: {
@@ -20796,10 +20805,10 @@ Long dis_ESC_NONE (
       vassert(sz == 1 || sz == 2 || sz == 4);
       ty = szToITy(sz);
       t2 = newTemp(Ity_I64);
-      d = unsafeIRDirty_1_N( 
+      d = unsafeIRDirty_1_N(
              t2,
-             0/*regparms*/, 
-             "amd64g_dirtyhelper_IN", 
+             0/*regparms*/,
+             "amd64g_dirtyhelper_IN",
              &amd64g_dirtyhelper_IN,
              mkIRExprVec_2( mkexpr(t1), mkU64(sz) )
           );
@@ -20844,12 +20853,12 @@ Long dis_ESC_NONE (
       if (haveF2orF3(pfx)) goto decode_failure;
       vassert(sz == 1 || sz == 2 || sz == 4);
       ty = szToITy(sz);
-      d = unsafeIRDirty_0_N( 
-             0/*regparms*/, 
-             "amd64g_dirtyhelper_OUT", 
+      d = unsafeIRDirty_0_N(
+             0/*regparms*/,
+             "amd64g_dirtyhelper_OUT",
              &amd64g_dirtyhelper_OUT,
              mkIRExprVec_3( mkexpr(t1),
-                            widenUto64( getIRegRAX(sz) ), 
+                            widenUto64( getIRegRAX(sz) ),
                             mkU64(sz) )
           );
       stmt( IRStmt_Dirty(d) );
@@ -20860,9 +20869,9 @@ Long dis_ESC_NONE (
       if (haveF3(pfx)) goto decode_failure;
       if (haveF2(pfx)) DIP("bnd ; "); /* MPX bnd prefix. */
       d64 = getSDisp32(delta); delta += 4;
-      d64 += (guest_RIP_bbstart+delta); 
+      d64 += (guest_RIP_bbstart+delta);
       /* (guest_RIP_bbstart+delta) == return-to addr, d64 == call-to addr */
-      t1 = newTemp(Ity_I64); 
+      t1 = newTemp(Ity_I64);
       assign(t1, binop(Iop_Sub64, getIReg64(R_RSP), mkU64(8)));
       putIReg64(R_RSP, mkexpr(t1));
       storeLE( mkexpr(t1), mkU64(guest_RIP_bbstart+delta));
@@ -20882,10 +20891,10 @@ Long dis_ESC_NONE (
 
    case 0xE9: /* Jv (jump, 16/32 offset) */
       if (haveF3(pfx)) goto decode_failure;
-      if (sz != 4) 
+      if (sz != 4)
          goto decode_failure; /* JRS added 2004 July 11 */
       if (haveF2(pfx)) DIP("bnd ; "); /* MPX bnd prefix. */
-      d64 = (guest_RIP_bbstart+delta+sz) + getSDisp(sz,delta); 
+      d64 = (guest_RIP_bbstart+delta+sz) + getSDisp(sz,delta);
       delta += sz;
       if (resteerOkFn(callback_opaque,d64)) {
          dres->whatNext   = Dis_ResteerU;
@@ -20899,10 +20908,10 @@ Long dis_ESC_NONE (
 
    case 0xEB: /* Jb (jump, byte offset) */
       if (haveF3(pfx)) goto decode_failure;
-      if (sz != 4) 
+      if (sz != 4)
          goto decode_failure; /* JRS added 2004 July 11 */
       if (haveF2(pfx)) DIP("bnd ; "); /* MPX bnd prefix. */
-      d64 = (guest_RIP_bbstart+delta+1) + getSDisp8(delta); 
+      d64 = (guest_RIP_bbstart+delta+1) + getSDisp8(delta);
       delta++;
       if (resteerOkFn(callback_opaque,d64)) {
          dres->whatNext   = Dis_ResteerU;
@@ -20921,22 +20930,22 @@ Long dis_ESC_NONE (
       t2 = newTemp(Ity_I64);
       assign( t1, mk_amd64g_calculate_rflags_all() );
       switch (opc) {
-         case 0xF5: 
-            assign( t2, binop(Iop_Xor64, mkexpr(t1), 
+         case 0xF5:
+            assign( t2, binop(Iop_Xor64, mkexpr(t1),
                                          mkU64(AMD64G_CC_MASK_C)));
             DIP("cmc\n");
             break;
-         case 0xF8: 
-            assign( t2, binop(Iop_And64, mkexpr(t1), 
+         case 0xF8:
+            assign( t2, binop(Iop_And64, mkexpr(t1),
                                          mkU64(~AMD64G_CC_MASK_C)));
             DIP("clc\n");
             break;
-         case 0xF9: 
-            assign( t2, binop(Iop_Or64, mkexpr(t1), 
+         case 0xF9:
+            assign( t2, binop(Iop_Or64, mkexpr(t1),
                                         mkU64(AMD64G_CC_MASK_C)));
             DIP("stc\n");
             break;
-         default: 
+         default:
             vpanic("disInstr(x64)(cmc/clc/stc)");
       }
       stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
@@ -21029,7 +21038,7 @@ static IRTemp math_BSWAP ( IRTemp t1, IRType ty )
                     binop(Iop_And64,
                           binop(Iop_Shl64,mkexpr(t1),mkU8(8)),
                           mkexpr(m8))
-                   ) 
+                   )
             );
 
       assign( m16, mkU64(0xFFFF0000FFFF0000ULL) );
@@ -21041,7 +21050,7 @@ static IRTemp math_BSWAP ( IRTemp t1, IRType ty )
                     binop(Iop_And64,
                           binop(Iop_Shl64,mkexpr(s8),mkU8(16)),
                           mkexpr(m16))
-                   ) 
+                   )
             );
 
       assign( m32, mkU64(0xFFFFFFFF00000000ULL) );
@@ -21053,7 +21062,7 @@ static IRTemp math_BSWAP ( IRTemp t1, IRType ty )
                     binop(Iop_And64,
                           binop(Iop_Shl64,mkexpr(s16),mkU8(32)),
                           mkexpr(m32))
-                   ) 
+                   )
             );
       return t2;
    }
@@ -21076,7 +21085,7 @@ static IRTemp math_BSWAP ( IRTemp t1, IRType ty )
       return t2;
    }
    if (ty == Ity_I16) {
-      assign(t2, 
+      assign(t2,
              binop(Iop_Or16,
                    binop(Iop_Shl16, mkexpr(t1), mkU8(8)),
                    binop(Iop_Shr16, mkexpr(t1), mkU8(8)) ));
@@ -21098,7 +21107,7 @@ Long dis_ESC_0F (
         void*        callback_opaque,
         VexArchInfo* archinfo,
         VexAbiInfo*  vbi,
-        Prefix pfx, Int sz, Long deltaIN 
+        Prefix pfx, Int sz, Long deltaIN
      )
 {
    Long   d64   = 0;
@@ -21197,14 +21206,14 @@ Long dis_ESC_0F (
       /* 0F 01 F9 = RDTSCP */
       if (modrm == 0xF9 && (archinfo->hwcaps & VEX_HWCAPS_AMD64_RDTSCP)) {
          delta += 1;
-         /* Uses dirty helper: 
+         /* Uses dirty helper:
             void amd64g_dirtyhelper_RDTSCP ( VexGuestAMD64State* )
             declared to wr rax, rcx, rdx
          */
          const HChar* fName = "amd64g_dirtyhelper_RDTSCP";
          void*        fAddr = &amd64g_dirtyhelper_RDTSCP;
          IRDirty* d
-            = unsafeIRDirty_0_N ( 0/*regparms*/, 
+            = unsafeIRDirty_0_N ( 0/*regparms*/,
                                   fName, fAddr, mkIRExprVec_1(IRExpr_BBPTR()) );
          /* declare guest state effects */
          d->nFxState = 3;
@@ -21277,12 +21286,12 @@ Long dis_ESC_0F (
    case 0x31: { /* RDTSC */
       IRTemp   val  = newTemp(Ity_I64);
       IRExpr** args = mkIRExprVec_0();
-      IRDirty* d    = unsafeIRDirty_1_N ( 
-                         val, 
-                         0/*regparms*/, 
-                         "amd64g_dirtyhelper_RDTSC", 
-                         &amd64g_dirtyhelper_RDTSC, 
-                         args 
+      IRDirty* d    = unsafeIRDirty_1_N (
+                         val,
+                         0/*regparms*/,
+                         "amd64g_dirtyhelper_RDTSC",
+                         &amd64g_dirtyhelper_RDTSC,
+                         args
                       );
       if (have66orF2orF3(pfx)) goto decode_failure;
       /* execute the dirty call, dumping the result in val. */
@@ -21347,7 +21356,7 @@ Long dis_ESC_0F (
             the branch target address (d64).  If we wind up back at
             the first instruction of the trace, just stop; it's
             better to let the IR loop unroller handle that case. */
-         stmt( IRStmt_Exit( 
+         stmt( IRStmt_Exit(
                   mk_amd64g_calculate_condition(
                      (AMD64Condcode)(1 ^ (opc - 0x80))),
                   Ijk_Boring,
@@ -21368,7 +21377,7 @@ Long dis_ESC_0F (
             So we need to emit a side-exit to d64 (the dest) and
             continue disassembling at the insn immediately
             following this one. */
-         stmt( IRStmt_Exit( 
+         stmt( IRStmt_Exit(
                   mk_amd64g_calculate_condition((AMD64Condcode)
                                                 (opc - 0x80)),
                   Ijk_Boring,
@@ -21413,7 +21422,7 @@ Long dis_ESC_0F (
       if (epartIsReg(modrm)) {
          delta++;
          putIRegE(1, pfx, modrm, mkexpr(t1));
-         DIP("set%s %s\n", name_AMD64Condcode(opc-0x90), 
+         DIP("set%s %s\n", name_AMD64Condcode(opc-0x90),
                            nameIRegE(1,pfx,modrm));
       } else {
          addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
@@ -21484,7 +21493,7 @@ Long dis_ESC_0F (
    }
 
    case 0xA2: { /* CPUID */
-      /* Uses dirty helper: 
+      /* Uses dirty helper:
             void amd64g_dirtyhelper_CPUID ( VexGuestAMD64State* )
          declared to mod rax, wr rbx, rcx, rdx
       */
@@ -21515,7 +21524,7 @@ Long dis_ESC_0F (
       }
 
       vassert(fName); vassert(fAddr);
-      d = unsafeIRDirty_0_N ( 0/*regparms*/, 
+      d = unsafeIRDirty_0_N ( 0/*regparms*/,
                               fName, fAddr, mkIRExprVec_1(IRExpr_BBPTR()) );
       /* declare guest state effects */
       d->nFxState = 4;
@@ -21554,15 +21563,15 @@ Long dis_ESC_0F (
       modrm = getUChar(delta);
       d64   = delta + lengthAMode(pfx, delta);
       vex_sprintf(dis_buf, "$%d", (Int)getUChar(d64));
-      delta = dis_SHLRD_Gv_Ev ( 
-                 vbi, pfx, delta, modrm, sz, 
+      delta = dis_SHLRD_Gv_Ev (
+                 vbi, pfx, delta, modrm, sz,
                  mkU8(getUChar(d64)), True, /* literal */
                  dis_buf, True /* left */ );
       return delta;
 
    case 0xA5: /* SHLDv %cl,Gv,Ev */
       modrm = getUChar(delta);
-      delta = dis_SHLRD_Gv_Ev ( 
+      delta = dis_SHLRD_Gv_Ev (
                  vbi, pfx, delta, modrm, sz,
                  getIRegCL(), False, /* not literal */
                  "%cl", True /* left */ );
@@ -21581,16 +21590,16 @@ Long dis_ESC_0F (
       modrm = getUChar(delta);
       d64   = delta + lengthAMode(pfx, delta);
       vex_sprintf(dis_buf, "$%d", (Int)getUChar(d64));
-      delta = dis_SHLRD_Gv_Ev ( 
-                 vbi, pfx, delta, modrm, sz, 
+      delta = dis_SHLRD_Gv_Ev (
+                 vbi, pfx, delta, modrm, sz,
                  mkU8(getUChar(d64)), True, /* literal */
                  dis_buf, False /* right */ );
       return delta;
 
    case 0xAD: /* SHRDv %cl,Gv,Ev */
       modrm = getUChar(delta);
-      delta = dis_SHLRD_Gv_Ev ( 
-                 vbi, pfx, delta, modrm, sz, 
+      delta = dis_SHLRD_Gv_Ev (
+                 vbi, pfx, delta, modrm, sz,
                  getIRegCL(), False, /* not literal */
                  "%cl", False /* right */);
       return delta;
@@ -21702,7 +21711,7 @@ Long dis_ESC_0F (
       delta = dis_movx_E_G ( vbi, pfx, delta, 2, sz, True );
       return delta;
 
-   case 0xC0: { /* XADD Gb,Eb */ 
+   case 0xC0: { /* XADD Gb,Eb */
       Bool decode_OK = False;
       delta = dis_xadd_G_E ( &decode_OK, vbi, pfx, 1, delta );
       if (!decode_OK)
@@ -21710,7 +21719,7 @@ Long dis_ESC_0F (
       return delta;
    }
 
-   case 0xC1: { /* XADD Gv,Ev */ 
+   case 0xC1: { /* XADD Gv,Ev */
       Bool decode_OK = False;
       delta = dis_xadd_G_E ( &decode_OK, vbi, pfx, sz, delta );
       if (!decode_OK)
@@ -21782,8 +21791,8 @@ Long dis_ESC_0F (
 
       /* Do the DCAS */
       stmt( IRStmt_CAS(
-               mkIRCAS( oldHi, oldLo, 
-                        Iend_LE, mkexpr(addr), 
+               mkIRCAS( oldHi, oldLo,
+                        Iend_LE, mkexpr(addr),
                         mkexpr(expdHi), mkexpr(expdLo),
                         mkexpr(dataHi), mkexpr(dataLo)
             )));
@@ -21830,14 +21839,14 @@ Long dis_ESC_0F (
       /* Copy the success bit into the Z flag and leave the others
          unchanged */
       assign( flags_old, widenUto64(mk_amd64g_calculate_rflags_all()));
-      assign( 
+      assign(
          flags_new,
          binop(Iop_Or64,
-               binop(Iop_And64, mkexpr(flags_old), 
+               binop(Iop_And64, mkexpr(flags_old),
                                 mkU64(~AMD64G_CC_MASK_Z)),
                binop(Iop_Shl64,
                      binop(Iop_And64,
-                           unop(Iop_1Uto64, mkexpr(success)), mkU64(1)), 
+                           unop(Iop_1Uto64, mkexpr(success)), mkU64(1)),
                      mkU8(AMD64G_CC_SHIFT_Z)) ));
 
       stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
@@ -21901,8 +21910,8 @@ Long dis_ESC_0F (
 
       switch (opc) { /* second switch */
 
-      case 0x71: 
-      case 0x72: 
+      case 0x71:
+      case 0x72:
       case 0x73: /* PSLLgg/PSRAgg/PSRLgg mmxreg by imm8 */
 
       case 0x6E: /* MOVD (src)ireg-or-mem, (dst)mmxreg */
@@ -21910,24 +21919,24 @@ Long dis_ESC_0F (
       case 0x7F: /* MOVQ (src)mmxreg, (dst)mmxreg-or-mem */
       case 0x6F: /* MOVQ (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0xFC: 
-      case 0xFD: 
+      case 0xFC:
+      case 0xFD:
       case 0xFE: /* PADDgg (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0xEC: 
+      case 0xEC:
       case 0xED: /* PADDSgg (src)mmxreg-or-mem, (dst)mmxreg */
 
       case 0xDC:
       case 0xDD: /* PADDUSgg (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0xF8: 
-      case 0xF9: 
+      case 0xF8:
+      case 0xF9:
       case 0xFA: /* PSUBgg (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0xE8: 
+      case 0xE8:
       case 0xE9: /* PSUBSgg (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0xD8: 
+      case 0xD8:
       case 0xD9: /* PSUBUSgg (src)mmxreg-or-mem, (dst)mmxreg */
 
       case 0xE5: /* PMULHW (src)mmxreg-or-mem, (dst)mmxreg */
@@ -21935,24 +21944,24 @@ Long dis_ESC_0F (
 
       case 0xF5: /* PMADDWD (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0x74: 
-      case 0x75: 
+      case 0x74:
+      case 0x75:
       case 0x76: /* PCMPEQgg (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0x64: 
-      case 0x65: 
+      case 0x64:
+      case 0x65:
       case 0x66: /* PCMPGTgg (src)mmxreg-or-mem, (dst)mmxreg */
 
       case 0x6B: /* PACKSSDW (src)mmxreg-or-mem, (dst)mmxreg */
       case 0x63: /* PACKSSWB (src)mmxreg-or-mem, (dst)mmxreg */
       case 0x67: /* PACKUSWB (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0x68: 
-      case 0x69: 
+      case 0x68:
+      case 0x69:
       case 0x6A: /* PUNPCKHgg (src)mmxreg-or-mem, (dst)mmxreg */
 
-      case 0x60: 
-      case 0x61: 
+      case 0x60:
+      case 0x61:
       case 0x62: /* PUNPCKLgg (src)mmxreg-or-mem, (dst)mmxreg */
 
       case 0xDB: /* PAND (src)mmxreg-or-mem, (dst)mmxreg */
@@ -21961,15 +21970,15 @@ Long dis_ESC_0F (
       case 0xEF: /* PXOR (src)mmxreg-or-mem, (dst)mmxreg */
 
       case 0xF1: /* PSLLgg (src)mmxreg-or-mem, (dst)mmxreg */
-      case 0xF2: 
-      case 0xF3: 
+      case 0xF2:
+      case 0xF3:
 
       case 0xD1: /* PSRLgg (src)mmxreg-or-mem, (dst)mmxreg */
-      case 0xD2: 
-      case 0xD3: 
+      case 0xD2:
+      case 0xD3:
 
       case 0xE1: /* PSRAgg (src)mmxreg-or-mem, (dst)mmxreg */
-      case 0xE2: { 
+      case 0xE2: {
          Bool decode_OK = False;
          delta = dis_MMX ( &decode_OK, vbi, pfx, sz, deltaIN );
          if (decode_OK)
@@ -22044,7 +22053,7 @@ Long dis_ESC_0F38 (
         void*        callback_opaque,
         VexArchInfo* archinfo,
         VexAbiInfo*  vbi,
-        Prefix pfx, Int sz, Long deltaIN 
+        Prefix pfx, Int sz, Long deltaIN
      )
 {
    Long   delta = deltaIN;
@@ -22129,7 +22138,7 @@ Long dis_ESC_0F3A (
         void*        callback_opaque,
         VexArchInfo* archinfo,
         VexAbiInfo*  vbi,
-        Prefix pfx, Int sz, Long deltaIN 
+        Prefix pfx, Int sz, Long deltaIN
      )
 {
    Long   delta = deltaIN;
@@ -22272,7 +22281,7 @@ Long dis_VEX_NDS_128_AnySimdPfx_0F_WIG_complex (
 /* Vector by scalar shift of V by the amount specified at the bottom
    of E. */
 static ULong dis_AVX128_shiftV_byE ( VexAbiInfo* vbi,
-                                     Prefix pfx, Long delta, 
+                                     Prefix pfx, Long delta,
                                      const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -22316,7 +22325,7 @@ static ULong dis_AVX128_shiftV_byE ( VexAbiInfo* vbi,
    }
 
    if (shl || shr) {
-     assign( 
+     assign(
         g1,
         IRExpr_ITE(
            binop(Iop_CmpLT64U, mkexpr(amt), mkU64(size)),
@@ -22324,9 +22333,9 @@ static ULong dis_AVX128_shiftV_byE ( VexAbiInfo* vbi,
            mkV128(0x0000)
         )
      );
-   } else 
+   } else
    if (sar) {
-     assign( 
+     assign(
         g1,
         IRExpr_ITE(
            binop(Iop_CmpLT64U, mkexpr(amt), mkU64(size)),
@@ -22346,7 +22355,7 @@ static ULong dis_AVX128_shiftV_byE ( VexAbiInfo* vbi,
 /* Vector by scalar shift of V by the amount specified at the bottom
    of E. */
 static ULong dis_AVX256_shiftV_byE ( VexAbiInfo* vbi,
-                                     Prefix pfx, Long delta, 
+                                     Prefix pfx, Long delta,
                                      const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -22390,7 +22399,7 @@ static ULong dis_AVX256_shiftV_byE ( VexAbiInfo* vbi,
    }
 
    if (shl || shr) {
-     assign( 
+     assign(
         g1,
         IRExpr_ITE(
            binop(Iop_CmpLT64U, mkexpr(amt), mkU64(size)),
@@ -22398,9 +22407,9 @@ static ULong dis_AVX256_shiftV_byE ( VexAbiInfo* vbi,
            binop(Iop_V128HLtoV256, mkV128(0), mkV128(0))
         )
      );
-   } else 
+   } else
    if (sar) {
-     assign( 
+     assign(
         g1,
         IRExpr_ITE(
            binop(Iop_CmpLT64U, mkexpr(amt), mkU64(size)),
@@ -22532,7 +22541,7 @@ static ULong dis_AVX_var_shiftV_byE ( VexAbiInfo* vbi,
 /* Vector by scalar shift of E into V, by an immediate byte.  Modified
    version of dis_SSE_shiftE_imm. */
 static
-Long dis_AVX128_shiftE_to_V_imm( Prefix pfx, 
+Long dis_AVX128_shiftE_to_V_imm( Prefix pfx,
                                  Long delta, const HChar* opname, IROp op )
 {
    Bool    shl, shr, sar;
@@ -22542,7 +22551,7 @@ Long dis_AVX128_shiftE_to_V_imm( Prefix pfx,
    UInt    rD   = getVexNvvvv(pfx);
    UChar   amt, size;
    vassert(epartIsReg(rm));
-   vassert(gregLO3ofRM(rm) == 2 
+   vassert(gregLO3ofRM(rm) == 2
            || gregLO3ofRM(rm) == 4 || gregLO3ofRM(rm) == 6);
    amt = getUChar(delta+1);
    delta += 2;
@@ -22567,13 +22576,13 @@ Long dis_AVX128_shiftE_to_V_imm( Prefix pfx,
    }
 
    if (shl || shr) {
-     assign( e1, amt >= size 
+     assign( e1, amt >= size
                     ? mkV128(0x0000)
                     : binop(op, mkexpr(e0), mkU8(amt))
      );
-   } else 
+   } else
    if (sar) {
-     assign( e1, amt >= size 
+     assign( e1, amt >= size
                     ? binop(op, mkexpr(e0), mkU8(size-1))
                     : binop(op, mkexpr(e0), mkU8(amt))
      );
@@ -22589,7 +22598,7 @@ Long dis_AVX128_shiftE_to_V_imm( Prefix pfx,
 /* Vector by scalar shift of E into V, by an immediate byte.  Modified
    version of dis_AVX128_shiftE_to_V_imm. */
 static
-Long dis_AVX256_shiftE_to_V_imm( Prefix pfx, 
+Long dis_AVX256_shiftE_to_V_imm( Prefix pfx,
                                  Long delta, const HChar* opname, IROp op )
 {
    Bool    shl, shr, sar;
@@ -22599,7 +22608,7 @@ Long dis_AVX256_shiftE_to_V_imm( Prefix pfx,
    UInt    rD   = getVexNvvvv(pfx);
    UChar   amt, size;
    vassert(epartIsReg(rm));
-   vassert(gregLO3ofRM(rm) == 2 
+   vassert(gregLO3ofRM(rm) == 2
            || gregLO3ofRM(rm) == 4 || gregLO3ofRM(rm) == 6);
    amt = getUChar(delta+1);
    delta += 2;
@@ -22625,13 +22634,13 @@ Long dis_AVX256_shiftE_to_V_imm( Prefix pfx,
 
 
    if (shl || shr) {
-     assign( e1, amt >= size 
+     assign( e1, amt >= size
                     ? binop(Iop_V128HLtoV256, mkV128(0), mkV128(0))
                     : binop(op, mkexpr(e0), mkU8(amt))
      );
-   } else 
+   } else
    if (sar) {
-     assign( e1, amt >= size 
+     assign( e1, amt >= size
                     ? binop(op, mkexpr(e0), mkU8(size-1))
                     : binop(op, mkexpr(e0), mkU8(amt))
      );
@@ -22653,7 +22662,7 @@ Long dis_AVX256_shiftE_to_V_imm( Prefix pfx,
 */
 static Long dis_AVX128_E_V_to_G_lo64 ( /*OUT*/Bool* uses_vvvv,
                                        VexAbiInfo* vbi,
-                                       Prefix pfx, Long delta, 
+                                       Prefix pfx, Long delta,
                                        const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -22696,7 +22705,7 @@ static Long dis_AVX128_E_V_to_G_lo64 ( /*OUT*/Bool* uses_vvvv,
 */
 static Long dis_AVX128_E_V_to_G_lo64_unary ( /*OUT*/Bool* uses_vvvv,
                                              VexAbiInfo* vbi,
-                                             Prefix pfx, Long delta, 
+                                             Prefix pfx, Long delta,
                                              const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -22743,7 +22752,7 @@ static Long dis_AVX128_E_V_to_G_lo64_unary ( /*OUT*/Bool* uses_vvvv,
 */
 static Long dis_AVX128_E_V_to_G_lo32_unary ( /*OUT*/Bool* uses_vvvv,
                                              VexAbiInfo* vbi,
-                                             Prefix pfx, Long delta, 
+                                             Prefix pfx, Long delta,
                                              const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -22790,7 +22799,7 @@ static Long dis_AVX128_E_V_to_G_lo32_unary ( /*OUT*/Bool* uses_vvvv,
 */
 static Long dis_AVX128_E_V_to_G_lo32 ( /*OUT*/Bool* uses_vvvv,
                                        VexAbiInfo* vbi,
-                                       Prefix pfx, Long delta, 
+                                       Prefix pfx, Long delta,
                                        const HChar* opname, IROp op )
 {
    HChar   dis_buf[50];
@@ -22830,7 +22839,7 @@ static Long dis_AVX128_E_V_to_G_lo32 ( /*OUT*/Bool* uses_vvvv,
 */
 static Long dis_AVX128_E_V_to_G ( /*OUT*/Bool* uses_vvvv,
                                   VexAbiInfo* vbi,
-                                  Prefix pfx, Long delta, 
+                                  Prefix pfx, Long delta,
                                   const HChar* opname, IROp op )
 {
    return dis_VEX_NDS_128_AnySimdPfx_0F_WIG(
@@ -22846,7 +22855,7 @@ static Long dis_AVX128_E_V_to_G ( /*OUT*/Bool* uses_vvvv,
 static
 Long dis_AVX128_cmp_V_E_to_G ( /*OUT*/Bool* uses_vvvv,
                                VexAbiInfo* vbi,
-                               Prefix pfx, Long delta, 
+                               Prefix pfx, Long delta,
                                const HChar* opname, Bool all_lanes, Int sz )
 {
    vassert(sz == 4 || sz == 8);
@@ -22881,7 +22890,7 @@ Long dis_AVX128_cmp_V_E_to_G ( /*OUT*/Bool* uses_vvvv,
       imm8 = getUChar(delta+alen);
       Bool ok = findSSECmpOp(&preSwap, &op, &postNot, imm8, all_lanes, sz);
       if (!ok) return deltaIN; /* FAIL */
-      assign(argR, 
+      assign(argR,
              all_lanes   ? loadLE(Ity_V128, mkexpr(addr))
              : sz == 8   ? unop( Iop_64UtoV128, loadLE(Ity_I64, mkexpr(addr)))
              : /*sz==4*/   unop( Iop_32UtoV128, loadLE(Ity_I32, mkexpr(addr))));
@@ -22956,7 +22965,7 @@ Long dis_AVX128_cmp_V_E_to_G ( /*OUT*/Bool* uses_vvvv,
 static
 Long dis_AVX256_cmp_V_E_to_G ( /*OUT*/Bool* uses_vvvv,
                                VexAbiInfo* vbi,
-                               Prefix pfx, Long delta, 
+                               Prefix pfx, Long delta,
                                const HChar* opname, Int sz )
 {
    vassert(sz == 4 || sz == 8);
@@ -23026,7 +23035,7 @@ Long dis_AVX256_cmp_V_E_to_G ( /*OUT*/Bool* uses_vvvv,
 static
 Long dis_AVX128_E_to_G_unary ( /*OUT*/Bool* uses_vvvv,
                                VexAbiInfo* vbi,
-                               Prefix pfx, Long delta, 
+                               Prefix pfx, Long delta,
                                const HChar* opname,
                                IRTemp (*opFn)(IRTemp) )
 {
@@ -23059,7 +23068,7 @@ Long dis_AVX128_E_to_G_unary ( /*OUT*/Bool* uses_vvvv,
 static
 Long dis_AVX128_E_to_G_unary_all ( /*OUT*/Bool* uses_vvvv,
                                    VexAbiInfo* vbi,
-                                   Prefix pfx, Long delta, 
+                                   Prefix pfx, Long delta,
                                    const HChar* opname, IROp op )
 {
    HChar  dis_buf[50];
@@ -23156,7 +23165,7 @@ Long dis_VEX_NDS_256_AnySimdPfx_0F_WIG (
 */
 static Long dis_AVX256_E_V_to_G ( /*OUT*/Bool* uses_vvvv,
                                   VexAbiInfo* vbi,
-                                  Prefix pfx, Long delta, 
+                                  Prefix pfx, Long delta,
                                   const HChar* opname, IROp op )
 {
    return dis_VEX_NDS_256_AnySimdPfx_0F_WIG(
@@ -23234,7 +23243,7 @@ Long dis_AVX256_E_to_G_unary ( /*OUT*/Bool* uses_vvvv,
 static
 Long dis_AVX256_E_to_G_unary_all ( /*OUT*/Bool* uses_vvvv,
                                    VexAbiInfo* vbi,
-                                   Prefix pfx, Long delta, 
+                                   Prefix pfx, Long delta,
                                    const HChar* opname, IROp op )
 {
    HChar  dis_buf[50];
@@ -23285,7 +23294,7 @@ static Long dis_CVTDQ2PD_256 ( VexAbiInfo* vbi, Prefix pfx,
    IRTemp s3, s2, s1, s0;
    s3 = s2 = s1 = s0 = IRTemp_INVALID;
    breakupV128to32s( sV, &s3, &s2, &s1, &s0 );
-   IRExpr* res 
+   IRExpr* res
       = IRExpr_Qop(
            Iop_64x4toV256,
            unop(Iop_ReinterpF64asI64, unop(Iop_I32StoF64, mkexpr(s3))),
@@ -23319,7 +23328,7 @@ static Long dis_CVTPD2PS_256 ( VexAbiInfo* vbi, Prefix pfx,
       delta += alen;
       DIP("vcvtpd2psy %s,%s\n", dis_buf, nameXMMReg(rG) );
    }
-         
+
    assign( rmode, get_sse_roundingmode() );
    IRTemp t3, t2, t1, t0;
    t3 = t2 = t1 = t0 = IRTemp_INVALID;
@@ -23432,7 +23441,7 @@ Long dis_ESC_0F__VEX (
         void*        callback_opaque,
         VexArchInfo* archinfo,
         VexAbiInfo*  vbi,
-        Prefix pfx, Int sz, Long deltaIN 
+        Prefix pfx, Int sz, Long deltaIN
      )
 {
    IRTemp addr  = IRTemp_INVALID;
@@ -25217,9 +25226,9 @@ Long dis_ESC_0F__VEX (
             delta += 1;
             putYMMRegLoAndZU(
                gregOfRexRM(pfx,modrm),
-               unop( Iop_32UtoV128, getIReg32(eregOfRexRM(pfx,modrm)) ) 
+               unop( Iop_32UtoV128, getIReg32(eregOfRexRM(pfx,modrm)) )
             );
-            DIP("vmovd %s, %s\n", nameIReg32(eregOfRexRM(pfx,modrm)), 
+            DIP("vmovd %s, %s\n", nameIReg32(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
         } else {
             addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
@@ -25228,7 +25237,7 @@ Long dis_ESC_0F__VEX (
                gregOfRexRM(pfx,modrm),
                unop( Iop_32UtoV128,loadLE(Ity_I32, mkexpr(addr)))
                              );
-            DIP("vmovd %s, %s\n", dis_buf, 
+            DIP("vmovd %s, %s\n", dis_buf,
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
          }
          goto decode_success;
@@ -25242,9 +25251,9 @@ Long dis_ESC_0F__VEX (
             delta += 1;
             putYMMRegLoAndZU(
                gregOfRexRM(pfx,modrm),
-               unop( Iop_64UtoV128, getIReg64(eregOfRexRM(pfx,modrm)) ) 
+               unop( Iop_64UtoV128, getIReg64(eregOfRexRM(pfx,modrm)) )
             );
-            DIP("vmovq %s, %s\n", nameIReg64(eregOfRexRM(pfx,modrm)), 
+            DIP("vmovq %s, %s\n", nameIReg64(eregOfRexRM(pfx,modrm)),
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
         } else {
             addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 0 );
@@ -25253,7 +25262,7 @@ Long dis_ESC_0F__VEX (
                gregOfRexRM(pfx,modrm),
                unop( Iop_64UtoV128,loadLE(Ity_I64, mkexpr(addr)))
                              );
-            DIP("vmovq %s, %s\n", dis_buf, 
+            DIP("vmovq %s, %s\n", dis_buf,
                                   nameXMMReg(gregOfRexRM(pfx,modrm)));
          }
          goto decode_success;
@@ -25760,7 +25769,7 @@ Long dis_ESC_0F__VEX (
          think it is a load.  Also it's unclear whether this is W0, W1
          or WIG. */
       /* VMOVQ xmm2/m64, xmm1 = VEX.128.F3.0F.W0 7E /r */
-      if (haveF3no66noF2(pfx) 
+      if (haveF3no66noF2(pfx)
           && 0==getVexL(pfx)/*128*/ && 0==getRexW(pfx)/*W0*/) {
          vassert(sz == 4); /* even tho we are transferring 8, not 4. */
          UChar modrm = getUChar(delta);
@@ -25978,7 +25987,7 @@ Long dis_ESC_0F__VEX (
             imm8 = (Int)(getUChar(delta+alen) & 7);
             assign( new16, loadLE( Ity_I16, mkexpr(addr) ));
             delta += alen+1;
-            DIP( "vpinsrw $%d,%s,%s\n", 
+            DIP( "vpinsrw $%d,%s,%s\n",
                  imm8, dis_buf, nameXMMReg(rG) );
          }
 
@@ -26001,7 +26010,7 @@ Long dis_ESC_0F__VEX (
          if (delta > delta0) goto decode_success;
          /* else fall through -- decoding has failed */
       }
-      break; 
+      break;
 
    case 0xC6:
       /* VSHUFPS imm8, xmm3/m128, xmm2, xmm1, xmm2 */
@@ -26164,7 +26173,7 @@ Long dis_ESC_0F__VEX (
                                         "vpsrlw", Iop_ShrN16x8 );
          *uses_vvvv = True;
          goto decode_success;
-                        
+
       }
       /* VPSRLW xmm3/m128, ymm2, ymm1 = VEX.NDS.256.66.0F.WIG D1 /r */
       if (have66noF2noF3(pfx) && 1==getVexL(pfx)/*256*/) {
@@ -26172,7 +26181,7 @@ Long dis_ESC_0F__VEX (
                                         "vpsrlw", Iop_ShrN16x16 );
          *uses_vvvv = True;
          goto decode_success;
-                        
+
       }
       break;
 
@@ -26727,7 +26736,7 @@ Long dis_ESC_0F__VEX (
                                         "vpsllw", Iop_ShlN16x8 );
          *uses_vvvv = True;
          goto decode_success;
-                        
+
       }
       /* VPSLLW xmm3/m128, ymm2, ymm1 = VEX.NDS.256.66.0F.WIG F1 /r */
       if (have66noF2noF3(pfx) && 1==getVexL(pfx)/*256*/) {
@@ -26735,7 +26744,7 @@ Long dis_ESC_0F__VEX (
                                         "vpsllw", Iop_ShlN16x16 );
          *uses_vvvv = True;
          goto decode_success;
-                        
+
       }
       break;
 
@@ -27291,7 +27300,7 @@ static ULong dis_VMASKMOV_load ( Bool *uses_vvvv, VexAbiInfo* vbi,
    for (i = 0; i < 2 * (isYMM ? 2 : 1) * (ty == Ity_I32 ? 2 : 1); i++) {
       res[i] = newTemp(ty);
       cond = newTemp(Ity_I1);
-      assign( cond, 
+      assign( cond,
               binop(ty == Ity_I32 ? Iop_CmpLT32S : Iop_CmpLT64S,
                     ty == Ity_I32 ? getYMMRegLane32( rV, i )
                                   : getYMMRegLane64( rV, i ),
@@ -27381,7 +27390,7 @@ static ULong dis_VGATHER ( Bool *uses_vvvv, VexAbiInfo* vbi,
    for (i = 0; i < count2; i++) {
       IRExpr *expr, *addr_expr;
       cond = newTemp(Ity_I1);
-      assign( cond, 
+      assign( cond,
               binop(ty == Ity_I32 ? Iop_CmpLT32S : Iop_CmpLT64S,
                     ty == Ity_I32 ? getYMMRegLane32( rV, i )
                                   : getYMMRegLane64( rV, i ),
@@ -27434,7 +27443,7 @@ Long dis_ESC_0F38__VEX (
         void*        callback_opaque,
         VexArchInfo* archinfo,
         VexAbiInfo*  vbi,
-        Prefix pfx, Int sz, Long deltaIN 
+        Prefix pfx, Int sz, Long deltaIN
      )
 {
    IRTemp addr  = IRTemp_INVALID;
@@ -27501,7 +27510,7 @@ Long dis_ESC_0F38__VEX (
          goto decode_success;
       }
       break;
-      
+
    case 0x05:
    case 0x06:
    case 0x07:
@@ -28541,7 +28550,7 @@ Long dis_ESC_0F38__VEX (
       if (have66noF2noF3(pfx) && 0==getVexL(pfx)/*128*/) {
          delta = dis_PHMINPOSUW_128( vbi, pfx, delta, True/*isAvx*/ );
          goto decode_success;
-      } 
+      }
       break;
 
    case 0x45:
@@ -29595,7 +29604,7 @@ Long dis_ESC_0F3A__VEX (
         void*        callback_opaque,
         VexArchInfo* archinfo,
         VexAbiInfo*  vbi,
-        Prefix pfx, Int sz, Long deltaIN 
+        Prefix pfx, Int sz, Long deltaIN
      )
 {
    IRTemp addr  = IRTemp_INVALID;
@@ -30122,7 +30131,7 @@ Long dis_ESC_0F3A__VEX (
 
          if (epartIsReg(modrm)) {
             UInt rE = eregOfRexRM(pfx, modrm);
-            assign( src, 
+            assign( src,
                     isD ? getXMMRegLane64F(rE, 0) : getXMMRegLane32F(rE, 0) );
             imm = getUChar(delta+1);
             if (imm & ~15) break;
@@ -30146,7 +30155,7 @@ Long dis_ESC_0F3A__VEX (
             we can use that value directly in the IR as a rounding
             mode. */
          assign(res, binop(isD ? Iop_RoundF64toInt : Iop_RoundF32toInt,
-                           (imm & 4) ? get_sse_roundingmode() 
+                           (imm & 4) ? get_sse_roundingmode()
                                      : mkU32(imm & 3),
                            mkexpr(src)) );
 
@@ -30190,7 +30199,7 @@ Long dis_ESC_0F3A__VEX (
             assign(sE, loadLE(Ity_V256, mkexpr(addr)));
          }
          delta++;
-         putYMMReg( rG, 
+         putYMMReg( rG,
                     mkexpr( math_BLENDPS_256( sE, sV, imm8) ) );
          *uses_vvvv = True;
          goto decode_success;
@@ -30221,7 +30230,7 @@ Long dis_ESC_0F3A__VEX (
             assign(sE, loadLE(Ity_V128, mkexpr(addr)));
          }
          delta++;
-         putYMMRegLoAndZU( rG, 
+         putYMMRegLoAndZU( rG,
                            mkexpr( math_BLENDPS_128( sE, sV, imm8) ) );
          *uses_vvvv = True;
          goto decode_success;
@@ -30255,7 +30264,7 @@ Long dis_ESC_0F3A__VEX (
             assign(sE, loadLE(Ity_V256, mkexpr(addr)));
          }
          delta++;
-         putYMMReg( rG, 
+         putYMMReg( rG,
                     mkexpr( math_BLENDPD_256( sE, sV, imm8) ) );
          *uses_vvvv = True;
          goto decode_success;
@@ -30286,7 +30295,7 @@ Long dis_ESC_0F3A__VEX (
             assign(sE, loadLE(Ity_V128, mkexpr(addr)));
          }
          delta++;
-         putYMMRegLoAndZU( rG, 
+         putYMMRegLoAndZU( rG,
                            mkexpr( math_BLENDPD_128( sE, sV, imm8) ) );
          *uses_vvvv = True;
          goto decode_success;
@@ -30320,7 +30329,7 @@ Long dis_ESC_0F3A__VEX (
             assign(sE, loadLE(Ity_V128, mkexpr(addr)));
          }
          delta++;
-         putYMMRegLoAndZU( rG, 
+         putYMMRegLoAndZU( rG,
                            mkexpr( math_PBLENDW_128( sE, sV, imm8) ) );
          *uses_vvvv = True;
          goto decode_success;
@@ -30571,7 +30580,7 @@ Long dis_ESC_0F3A__VEX (
             imm8 = (Int)(getUChar(delta+alen) & 15);
             assign( src_u8, loadLE( Ity_I8, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "vpinsrb $%d,%s,%s,%s\n", 
+            DIP( "vpinsrb $%d,%s,%s,%s\n",
                  imm8, dis_buf, nameXMMReg(rV), nameXMMReg(rG) );
          }
 
@@ -30611,7 +30620,7 @@ Long dis_ESC_0F3A__VEX (
             assign( d2ins, loadLE( Ity_I32, mkexpr(addr) ) );
             imm8 = getUChar(delta+alen);
             delta += alen+1;
-            DIP( "insertps $%u, %s,%s\n", 
+            DIP( "insertps $%u, %s,%s\n",
                  imm8, dis_buf, nameXMMReg(rG) );
          }
 
@@ -30646,7 +30655,7 @@ Long dis_ESC_0F3A__VEX (
             imm8_10 = (Int)(getUChar(delta+alen) & 3);
             assign( src_u32, loadLE( Ity_I32, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "vpinsrd $%d,%s,%s,%s\n", 
+            DIP( "vpinsrd $%d,%s,%s,%s\n",
                  imm8_10, dis_buf, nameXMMReg(rV), nameXMMReg(rG) );
          }
 
@@ -30678,7 +30687,7 @@ Long dis_ESC_0F3A__VEX (
             imm8_0 = (Int)(getUChar(delta+alen) & 1);
             assign( src_u64, loadLE( Ity_I64, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "vpinsrd $%d,%s,%s,%s\n", 
+            DIP( "vpinsrd $%d,%s,%s,%s\n",
                  imm8_0, dis_buf, nameXMMReg(rV), nameXMMReg(rG) );
          }
 
@@ -30779,7 +30788,7 @@ Long dis_ESC_0F3A__VEX (
             imm8 = (Int)getUChar(delta+alen);
             assign( dst_vec, loadLE( Ity_V128, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "vdpps $%d,%s,%s,%s\n", 
+            DIP( "vdpps $%d,%s,%s,%s\n",
                  imm8, dis_buf, nameXMMReg(rV), nameXMMReg(rG) );
          }
 
@@ -30809,7 +30818,7 @@ Long dis_ESC_0F3A__VEX (
             imm8 = (Int)getUChar(delta+alen);
             assign( dst_vec, loadLE( Ity_V256, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "vdpps $%d,%s,%s,%s\n", 
+            DIP( "vdpps $%d,%s,%s,%s\n",
                  imm8, dis_buf, nameYMMReg(rV), nameYMMReg(rG) );
          }
 
@@ -30847,7 +30856,7 @@ Long dis_ESC_0F3A__VEX (
             imm8 = (Int)getUChar(delta+alen);
             assign( dst_vec, loadLE( Ity_V128, mkexpr(addr) ) );
             delta += alen+1;
-            DIP( "vdppd $%d,%s,%s,%s\n", 
+            DIP( "vdppd $%d,%s,%s,%s\n",
                  imm8, dis_buf, nameXMMReg(rV), nameXMMReg(rG) );
          }
 
@@ -30872,7 +30881,7 @@ Long dis_ESC_0F3A__VEX (
          UInt   rV      = getVexNvvvv(pfx);
 
          assign( dst_vec, getXMMReg(rV) );
-  
+
          if ( epartIsReg( modrm ) ) {
             UInt rE = eregOfRexRM(pfx, modrm);
 
@@ -30882,7 +30891,7 @@ Long dis_ESC_0F3A__VEX (
             DIP( "vmpsadbw $%d, %s,%s,%s\n", imm8,
                  nameXMMReg(rE), nameXMMReg(rV), nameXMMReg(rG) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             assign( src_vec, loadLE( Ity_V128, mkexpr(addr) ) );
             imm8 = (Int)getUChar(delta+alen);
@@ -30954,21 +30963,21 @@ Long dis_ESC_0F3A__VEX (
          UInt   rV    = getVexNvvvv(pfx);
 
          assign( dV, getXMMReg(rV) );
-  
+
          if ( epartIsReg( modrm ) ) {
             UInt rE = eregOfRexRM(pfx, modrm);
             imm8 = (Int)getUChar(delta+1);
             assign( sV, getXMMReg(rE) );
             delta += 1+1;
             DIP( "vpclmulqdq $%d, %s,%s,%s\n", imm8,
-                 nameXMMReg(rE), nameXMMReg(rV), nameXMMReg(rG) );    
+                 nameXMMReg(rE), nameXMMReg(rV), nameXMMReg(rG) );
          } else {
-            addr = disAMode( &alen, vbi, pfx, delta, dis_buf, 
+            addr = disAMode( &alen, vbi, pfx, delta, dis_buf,
                              1/* imm8 is 1 byte after the amode */ );
             assign( sV, loadLE( Ity_V128, mkexpr(addr) ) );
             imm8 = (Int)getUChar(delta+alen);
             delta += alen+1;
-            DIP( "vpclmulqdq $%d, %s,%s,%s\n", 
+            DIP( "vpclmulqdq $%d, %s,%s,%s\n",
                  imm8, dis_buf, nameXMMReg(rV), nameXMMReg(rG) );
          }
 
@@ -31173,9 +31182,9 @@ Long dis_ESC_0F3A__VEX (
 
 /* Disassemble a single instruction into IR.  The instruction is
    located in host memory at &guest_code[delta]. */
-   
+
 static
-DisResult disInstr_AMD64_WRK ( 
+DisResult disInstr_AMD64_WRK (
              /*OUT*/Bool* expect_CAS,
              Bool         (*resteerOkFn) ( /*opaque*/void*, Addr64 ),
              Bool         resteerCisOk,
@@ -31219,7 +31228,7 @@ DisResult disInstr_AMD64_WRK (
    vassert(guest_RIP_next_assumed == 0);
    vassert(guest_RIP_next_mustcheck == False);
 
-   t1 = t2 = t3 = t4 = t5 = t6 = IRTemp_INVALID; 
+   t1 = t2 = t3 = t4 = t5 = t6 = IRTemp_INVALID;
 
    DIP("\t0x%llx:  ", guest_RIP_bbstart+delta);
 
@@ -31232,16 +31241,16 @@ DisResult disInstr_AMD64_WRK (
          48C1C73D   rolq $61, %rdi
          48C1C733   rolq $51, %rdi
       */
-      if (code[ 0] == 0x48 && code[ 1] == 0xC1 && code[ 2] == 0xC7 
+      if (code[ 0] == 0x48 && code[ 1] == 0xC1 && code[ 2] == 0xC7
                                                && code[ 3] == 0x03 &&
-          code[ 4] == 0x48 && code[ 5] == 0xC1 && code[ 6] == 0xC7 
+          code[ 4] == 0x48 && code[ 5] == 0xC1 && code[ 6] == 0xC7
                                                && code[ 7] == 0x0D &&
-          code[ 8] == 0x48 && code[ 9] == 0xC1 && code[10] == 0xC7 
+          code[ 8] == 0x48 && code[ 9] == 0xC1 && code[10] == 0xC7
                                                && code[11] == 0x3D &&
-          code[12] == 0x48 && code[13] == 0xC1 && code[14] == 0xC7 
+          code[12] == 0x48 && code[13] == 0xC1 && code[14] == 0xC7
                                                && code[15] == 0x33) {
          /* Got a "Special" instruction preamble.  Which one is it? */
-         if (code[16] == 0x48 && code[17] == 0x87 
+         if (code[16] == 0x48 && code[17] == 0x87
                               && code[18] == 0xDB /* xchgq %rbx,%rbx */) {
             /* %RDX = client_request ( %RAX ) */
             DIP("%%rdx = client_request ( %%rax )\n");
@@ -31251,7 +31260,7 @@ DisResult disInstr_AMD64_WRK (
             goto decode_success;
          }
          else
-         if (code[16] == 0x48 && code[17] == 0x87 
+         if (code[16] == 0x48 && code[17] == 0x87
                               && code[18] == 0xC9 /* xchgq %rcx,%rcx */) {
             /* %RAX = guest_NRADDR */
             DIP("%%rax = guest_NRADDR\n");
@@ -31260,7 +31269,7 @@ DisResult disInstr_AMD64_WRK (
             goto decode_success;
          }
          else
-         if (code[16] == 0x48 && code[17] == 0x87 
+         if (code[16] == 0x48 && code[17] == 0x87
                               && code[18] == 0xD2 /* xchgq %rdx,%rdx */) {
             /* call-noredir *%RAX */
             DIP("call-noredir *%%rax\n");
@@ -31288,7 +31297,7 @@ DisResult disInstr_AMD64_WRK (
             // time.
             stmt(IRStmt_Put(OFFB_CMSTART, mkU64(guest_RIP_curr_instr)));
             stmt(IRStmt_Put(OFFB_CMLEN,   mkU64(19)));
-   
+
             delta += 19;
 
             stmt( IRStmt_Put( OFFB_RIP, mkU64(guest_RIP_bbstart + delta) ) );
@@ -31327,7 +31336,7 @@ DisResult disInstr_AMD64_WRK (
             if (pre & (1<<1)) pfx |= PFX_REXX;
             if (pre & (1<<0)) pfx |= PFX_REXB;
             break;
-         default: 
+         default:
             goto not_a_legacy_prefix;
       }
       n_prefixes++;
@@ -31406,7 +31415,7 @@ DisResult disInstr_AMD64_WRK (
    n = 0;
    if (pfx & PFX_F2) n++;
    if (pfx & PFX_F3) n++;
-   if (n > 1) 
+   if (n > 1)
       goto decode_failure; /* can't have both */
 
    n = 0;
@@ -31416,7 +31425,7 @@ DisResult disInstr_AMD64_WRK (
    if (pfx & PFX_FS) n++;
    if (pfx & PFX_GS) n++;
    if (pfx & PFX_SS) n++;
-   if (n > 1) 
+   if (n > 1)
       goto decode_failure; /* multiple seg overrides == illegal */
 
    /* We have a %fs prefix.  Reject it if there's no evidence in 'vbi'
@@ -31667,7 +31676,7 @@ DisResult disInstr_AMD64_WRK (
    /* ------------------------ XCHG ----------------------- */
 
    /* ------------------------ IN / OUT ----------------------- */
- 
+
    /* ------------------------ (Grp1 extensions) ---------- */
 
    /* ------------------------ (Grp2 extensions) ---------- */
@@ -31730,7 +31739,7 @@ DisResult disInstr_AMD64_WRK (
 
    /* ------------------------ ??? ------------------------ */
 #endif /* XYZZY */
-  
+
      //default:
   decode_failure:
    /* All decode failures end up here. */
@@ -31852,12 +31861,12 @@ DisResult disInstr_AMD64 ( IRSB*        irsb_IN,
    /* If disInstr_AMD64_WRK tried to figure out the next rip, check it
       got it right.  Failure of this assertion is serious and denotes
       a bug in disInstr. */
-   if (guest_RIP_next_mustcheck 
+   if (guest_RIP_next_mustcheck
        && guest_RIP_next_assumed != guest_RIP_curr_instr + dres.len) {
       vex_printf("\n");
-      vex_printf("assumed next %%rip = 0x%llx\n", 
+      vex_printf("assumed next %%rip = 0x%llx\n",
                  guest_RIP_next_assumed );
-      vex_printf(" actual next %%rip = 0x%llx\n", 
+      vex_printf(" actual next %%rip = 0x%llx\n",
                  guest_RIP_curr_instr + dres.len );
       vpanic("disInstr_AMD64: disInstr miscalculated next %rip");
    }

--- a/VEX/priv/host_amd64_defs.c
+++ b/VEX/priv/host_amd64_defs.c
@@ -3017,11 +3017,6 @@ Int emit_AMD64Instr ( /*MB_MOD*/Bool* is_profInc,
       *p++ = 0x0F; *p++ = 0xAE; *p++ = 0xF0;
       goto done;
 
-   case Ain_Pcommit:
-      /* pcommit */
-      *p++ = 0x66; *p++ = 0x0F; *p++ = 0xAE; *p++ = 0xF8;
-      goto done;
-
    case Ain_ACAS:
       /* lock */
       *p++ = 0xF0;

--- a/VEX/priv/host_amd64_isel.c
+++ b/VEX/priv/host_amd64_isel.c
@@ -121,7 +121,7 @@ static Bool isZeroU8 ( IRExpr* e )
              64-bit virtual HReg, which holds the high half
              of the value.
 
-   - The host subarchitecture we are selecting insns for.  
+   - The host subarchitecture we are selecting insns for.
      This is set at the start and does not change.
 
    - The code array, that is, the insns selected so far.
@@ -172,7 +172,7 @@ static HReg lookupIRTemp ( ISelEnv* env, IRTemp tmp )
    return env->vregmap[tmp];
 }
 
-static void lookupIRTempPair ( HReg* vrHI, HReg* vrLO, 
+static void lookupIRTempPair ( HReg* vrHI, HReg* vrLO,
                                ISelEnv* env, IRTemp tmp )
 {
    vassert(tmp >= 0);
@@ -231,9 +231,9 @@ static HReg          iselIntExpr_R       ( ISelEnv* env, IRExpr* e );
 static AMD64AMode*   iselIntExpr_AMode_wrk ( ISelEnv* env, IRExpr* e );
 static AMD64AMode*   iselIntExpr_AMode     ( ISelEnv* env, IRExpr* e );
 
-static void          iselInt128Expr_wrk ( /*OUT*/HReg* rHi, HReg* rLo, 
+static void          iselInt128Expr_wrk ( /*OUT*/HReg* rHi, HReg* rLo,
                                           ISelEnv* env, IRExpr* e );
-static void          iselInt128Expr     ( /*OUT*/HReg* rHi, HReg* rLo, 
+static void          iselInt128Expr     ( /*OUT*/HReg* rHi, HReg* rLo,
                                           ISelEnv* env, IRExpr* e );
 
 static AMD64CondCode iselCondCode_wrk    ( ISelEnv* env, IRExpr* e );
@@ -248,9 +248,9 @@ static HReg          iselFltExpr         ( ISelEnv* env, IRExpr* e );
 static HReg          iselVecExpr_wrk     ( ISelEnv* env, IRExpr* e );
 static HReg          iselVecExpr         ( ISelEnv* env, IRExpr* e );
 
-static void          iselDVecExpr_wrk ( /*OUT*/HReg* rHi, HReg* rLo, 
+static void          iselDVecExpr_wrk ( /*OUT*/HReg* rHi, HReg* rLo,
                                         ISelEnv* env, IRExpr* e );
-static void          iselDVecExpr     ( /*OUT*/HReg* rHi, HReg* rLo, 
+static void          iselDVecExpr     ( /*OUT*/HReg* rHi, HReg* rLo,
                                         ISelEnv* env, IRExpr* e );
 
 
@@ -262,12 +262,12 @@ static Bool sane_AMode ( AMD64AMode* am )
 {
    switch (am->tag) {
       case Aam_IR:
-         return 
+         return
             toBool( hregClass(am->Aam.IR.reg) == HRcInt64
                     && (hregIsVirtual(am->Aam.IR.reg)
                         || sameHReg(am->Aam.IR.reg, hregAMD64_RBP())) );
       case Aam_IRRS:
-         return 
+         return
             toBool( hregClass(am->Aam.IRRS.base) == HRcInt64
                     && hregIsVirtual(am->Aam.IRRS.base)
                     && hregClass(am->Aam.IRRS.index) == HRcInt64
@@ -329,16 +329,16 @@ static AMD64Instr* mk_vMOVsd_RR ( HReg src, HReg dst )
 static void add_to_rsp ( ISelEnv* env, Int n )
 {
    vassert(n > 0 && n < 256 && (n%8) == 0);
-   addInstr(env, 
-            AMD64Instr_Alu64R(Aalu_ADD, AMD64RMI_Imm(n), 
+   addInstr(env,
+            AMD64Instr_Alu64R(Aalu_ADD, AMD64RMI_Imm(n),
                                         hregAMD64_RSP()));
 }
 
 static void sub_from_rsp ( ISelEnv* env, Int n )
 {
    vassert(n > 0 && n < 256 && (n%8) == 0);
-   addInstr(env, 
-            AMD64Instr_Alu64R(Aalu_SUB, AMD64RMI_Imm(n), 
+   addInstr(env,
+            AMD64Instr_Alu64R(Aalu_SUB, AMD64RMI_Imm(n),
                                         hregAMD64_RSP()));
 }
 
@@ -405,8 +405,8 @@ static AMD64Instr* iselIntExpr_single_instruction ( ISelEnv* env,
                 dst);
    }
 
-   if (e->tag == Iex_Unop 
-       && e->Iex.Unop.op == Iop_32Uto64 
+   if (e->tag == Iex_Unop
+       && e->Iex.Unop.op == Iop_32Uto64
        && e->Iex.Unop.arg->tag == Iex_RdTmp) {
       HReg src = lookupIRTemp(env, e->Iex.Unop.arg->Iex.RdTmp.tmp);
       return AMD64Instr_MovxLQ(False, src, dst);
@@ -538,7 +538,7 @@ void doHelperCall ( /*OUT*/UInt*   stackAdjustAfterCall,
       goto slowscheme;
 
    if (guard) {
-      if (guard->tag == Iex_Const 
+      if (guard->tag == Iex_Const
           && guard->Iex.Const.con->tag == Ico_U1
           && guard->Iex.Const.con->Ico.U1 == True) {
          /* unconditional */
@@ -568,7 +568,7 @@ void doHelperCall ( /*OUT*/UInt*   stackAdjustAfterCall,
       if (LIKELY(!is_IRExpr_VECRET_or_BBPTR(arg))) {
          vassert(typeOfIRExpr(env->type_env, args[i]) == Ity_I64);
       }
-      fastinstrs[i] 
+      fastinstrs[i]
          = iselIntExpr_single_instruction( env, argregs[i], args[i] );
       if (fastinstrs[i] == NULL)
          goto slowscheme;
@@ -635,7 +635,7 @@ void doHelperCall ( /*OUT*/UInt*   stackAdjustAfterCall,
       guard is 1:Bit. */
    cc = Acc_ALWAYS;
    if (guard) {
-      if (guard->tag == Iex_Const 
+      if (guard->tag == Iex_Const
           && guard->Iex.Const.con->tag == Ico_U1
           && guard->Iex.Const.con->Ico.U1 == True) {
          /* unconditional -- do nothing */
@@ -700,7 +700,7 @@ void doHelperCall ( /*OUT*/UInt*   stackAdjustAfterCall,
    offset. */
 
 static
-AMD64AMode* genGuestArrayOffset ( ISelEnv* env, IRRegArray* descr, 
+AMD64AMode* genGuestArrayOffset ( ISelEnv* env, IRRegArray* descr,
                                   IRExpr* off, Int bias )
 {
    HReg tmp, roff;
@@ -728,10 +728,10 @@ AMD64AMode* genGuestArrayOffset ( ISelEnv* env, IRRegArray* descr,
       /* Make sure the bias is sane, in the sense that there are
          no significant bits above bit 30 in it. */
       vassert(-10000 < bias && bias < 10000);
-      addInstr(env, 
+      addInstr(env,
                AMD64Instr_Alu64R(Aalu_ADD, AMD64RMI_Imm(bias), tmp));
    }
-   addInstr(env, 
+   addInstr(env,
             AMD64Instr_Alu64R(Aalu_AND, AMD64RMI_Imm(7), tmp));
    vassert(elemSz == 1 || elemSz == 8);
    return
@@ -744,7 +744,7 @@ AMD64AMode* genGuestArrayOffset ( ISelEnv* env, IRRegArray* descr,
 static
 void set_SSE_rounding_default ( ISelEnv* env )
 {
-   /* pushq $DEFAULT_MXCSR 
+   /* pushq $DEFAULT_MXCSR
       ldmxcsr 0(%rsp)
       addq $8, %rsp
    */
@@ -756,7 +756,7 @@ void set_SSE_rounding_default ( ISelEnv* env )
 
 /* Mess with the FPU's rounding mode: set to the default rounding mode
    (DEFAULT_FPUCW). */
-static 
+static
 void set_FPU_rounding_default ( ISelEnv* env )
 {
    /* movq $DEFAULT_FPUCW, -8(%rsp)
@@ -789,7 +789,7 @@ void set_SSE_rounding_mode ( ISelEnv* env, IRExpr* mode )
       pushq %reg
       ldmxcsr 0(%esp)
       addq $8, %rsp
-   */      
+   */
    HReg        reg      = newVRegI(env);
    AMD64AMode* zero_rsp = AMD64AMode_IR(0, hregAMD64_RSP());
    addInstr(env, AMD64Instr_Alu64R(Aalu_MOV, AMD64RMI_Imm(3), reg));
@@ -826,9 +826,9 @@ void set_FPU_rounding_mode ( ISelEnv* env, IRExpr* mode )
    addInstr(env, mk_iMOVsd_RR(rrm, rrm2));
    addInstr(env, AMD64Instr_Alu64R(Aalu_AND, AMD64RMI_Imm(3), rrm2));
    addInstr(env, AMD64Instr_Sh64(Ash_SHL, 10, rrm2));
-   addInstr(env, AMD64Instr_Alu64R(Aalu_OR, 
+   addInstr(env, AMD64Instr_Alu64R(Aalu_OR,
                                    AMD64RMI_Imm(DEFAULT_FPUCW), rrm2));
-   addInstr(env, AMD64Instr_Alu64M(Aalu_MOV, 
+   addInstr(env, AMD64Instr_Alu64M(Aalu_MOV,
                                    AMD64RI_Reg(rrm2), m8_rsp));
    addInstr(env, AMD64Instr_A87LdCW(m8_rsp));
 }
@@ -981,15 +981,15 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
 
       /* Is it an addition or logical style op? */
       switch (e->Iex.Binop.op) {
-         case Iop_Add8: case Iop_Add16: case Iop_Add32: case Iop_Add64: 
+         case Iop_Add8: case Iop_Add16: case Iop_Add32: case Iop_Add64:
             aluOp = Aalu_ADD; break;
          case Iop_Sub8: case Iop_Sub16: case Iop_Sub32: case Iop_Sub64:
             aluOp = Aalu_SUB; break;
-         case Iop_And8: case Iop_And16: case Iop_And32: case Iop_And64: 
+         case Iop_And8: case Iop_And16: case Iop_And32: case Iop_And64:
             aluOp = Aalu_AND; break;
-         case Iop_Or8:  case Iop_Or16:  case Iop_Or32:  case Iop_Or64: 
+         case Iop_Or8:  case Iop_Or16:  case Iop_Or32:  case Iop_Or64:
             aluOp = Aalu_OR; break;
-         case Iop_Xor8: case Iop_Xor16: case Iop_Xor32: case Iop_Xor64: 
+         case Iop_Xor8: case Iop_Xor16: case Iop_Xor32: case Iop_Xor64:
             aluOp = Aalu_XOR; break;
          case Iop_Mul16: case Iop_Mul32: case Iop_Mul64:
             aluOp = Aalu_MUL; break;
@@ -1011,9 +1011,9 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
       switch (e->Iex.Binop.op) {
          case Iop_Shl64: case Iop_Shl32: case Iop_Shl16: case Iop_Shl8:
             shOp = Ash_SHL; break;
-         case Iop_Shr64: case Iop_Shr32: case Iop_Shr16: case Iop_Shr8: 
+         case Iop_Shr64: case Iop_Shr32: case Iop_Shr16: case Iop_Shr8:
             shOp = Ash_SHR; break;
-         case Iop_Sar64: case Iop_Sar32: case Iop_Sar16: case Iop_Sar8: 
+         case Iop_Sar64: case Iop_Sar32: case Iop_Sar16: case Iop_Sar8:
             shOp = Ash_SAR; break;
          default:
             shOp = Ash_INVALID; break;
@@ -1027,7 +1027,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
 
          /* Do any necessary widening for 32/16/8 bit operands */
          switch (e->Iex.Binop.op) {
-            case Iop_Shr64: case Iop_Shl64: case Iop_Sar64: 
+            case Iop_Shr64: case Iop_Shl64: case Iop_Sar64:
                break;
             case Iop_Shl32: case Iop_Shl16: case Iop_Shl8:
                break;
@@ -1053,7 +1053,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             case Iop_Sar32:
                addInstr(env, AMD64Instr_MovxLQ(True, dst, dst));
                break;
-            default: 
+            default:
                ppIROp(e->Iex.Binop.op);
                vassert(0);
          }
@@ -1181,7 +1181,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             fn = (HWord)h_generic_calc_Sub32x2; break;
 
          case Iop_ShlN32x2:
-            fn = (HWord)h_generic_calc_ShlN32x2; 
+            fn = (HWord)h_generic_calc_ShlN32x2;
             second_is_UInt = True;
             break;
          case Iop_ShlN16x4:
@@ -1193,33 +1193,33 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             second_is_UInt = True;
             break;
          case Iop_ShrN32x2:
-            fn = (HWord)h_generic_calc_ShrN32x2; 
-            second_is_UInt = True; 
+            fn = (HWord)h_generic_calc_ShrN32x2;
+            second_is_UInt = True;
             break;
          case Iop_ShrN16x4:
             fn = (HWord)h_generic_calc_ShrN16x4;
-            second_is_UInt = True; 
+            second_is_UInt = True;
             break;
          case Iop_SarN32x2:
             fn = (HWord)h_generic_calc_SarN32x2;
-            second_is_UInt = True; 
+            second_is_UInt = True;
             break;
          case Iop_SarN16x4:
             fn = (HWord)h_generic_calc_SarN16x4;
-            second_is_UInt = True; 
+            second_is_UInt = True;
             break;
          case Iop_SarN8x8:
             fn = (HWord)h_generic_calc_SarN8x8;
-            second_is_UInt = True; 
+            second_is_UInt = True;
             break;
 
          default:
             fn = (HWord)0; break;
       }
       if (fn != (HWord)0) {
-         /* Note: the following assumes all helpers are of signature 
+         /* Note: the following assumes all helpers are of signature
                ULong fn ( ULong, ULong ), and they are
-            not marked as regparm functions. 
+            not marked as regparm functions.
          */
          HReg dst  = newVRegI(env);
          HReg argL = iselIntExpr_R(env, e->Iex.Binop.arg1);
@@ -1256,7 +1256,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
          HReg      dst     = newVRegI(env);
          Bool      syned   = toBool(e->Iex.Binop.op == Iop_DivModS64to32);
          AMD64RM*  rmRight = iselIntExpr_RM(env, e->Iex.Binop.arg2);
-         /* Compute the left operand into a reg, and then 
+         /* Compute the left operand into a reg, and then
             put the top half in edx and the bottom in eax. */
          HReg left64 = iselIntExpr_R(env, e->Iex.Binop.arg1);
          addInstr(env, mk_iMOVsd_RR(left64, rdx));
@@ -1318,8 +1318,8 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
       if (e->Iex.Binop.op == Iop_MullS32
           || e->Iex.Binop.op == Iop_MullS16
           || e->Iex.Binop.op == Iop_MullS8
-          || e->Iex.Binop.op == Iop_MullU32 
-          || e->Iex.Binop.op == Iop_MullU16 
+          || e->Iex.Binop.op == Iop_MullU32
+          || e->Iex.Binop.op == Iop_MullU16
           || e->Iex.Binop.op == Iop_MullU8) {
          HReg a32   = newVRegI(env);
          HReg b32   = newVRegI(env);
@@ -1556,7 +1556,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             HReg dst = newVRegI(env);
             HReg src = iselIntExpr_R(env, e->Iex.Unop.arg);
             addInstr(env, AMD64Instr_Bsfr64(False,src,tmp));
-            addInstr(env, AMD64Instr_Alu64R(Aalu_MOV, 
+            addInstr(env, AMD64Instr_Alu64R(Aalu_MOV,
                                             AMD64RMI_Imm(63), dst));
             addInstr(env, AMD64Instr_Alu64R(Aalu_SUB,
                                             AMD64RMI_Reg(tmp), dst));
@@ -1620,7 +1620,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             AMD64AMode* off_rsp = AMD64AMode_IR(off, rsp);
             addInstr(env, AMD64Instr_SseLdSt(False/*store*/,
                                              16, vec, m16_rsp));
-            addInstr(env, AMD64Instr_Alu64R( Aalu_MOV, 
+            addInstr(env, AMD64Instr_Alu64R( Aalu_MOV,
                                              AMD64RMI_Mem(off_rsp), dst ));
             return dst;
          }
@@ -1646,7 +1646,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             AMD64AMode* off_rsp = AMD64AMode_IR(off, rsp);
             addInstr(env, AMD64Instr_SseLdSt(False/*store*/,
                                              16, vec, m16_rsp));
-            addInstr(env, AMD64Instr_Alu64R( Aalu_MOV, 
+            addInstr(env, AMD64Instr_Alu64R( Aalu_MOV,
                                              AMD64RMI_Mem(off_rsp), dst ));
             return dst;
          }
@@ -1722,11 +1722,11 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             addInstr(env, AMD64Instr_SseLdSt(False/*store*/,
                                              16, vec, m16_rsp));
             /* hi 64 bits into RDI -- the first arg */
-            addInstr(env, AMD64Instr_Alu64R( Aalu_MOV, 
+            addInstr(env, AMD64Instr_Alu64R( Aalu_MOV,
                                              AMD64RMI_Mem(m8_rsp),
                                              hregAMD64_RDI() )); /* 1st arg */
             /* lo 64 bits into RSI -- the 2nd arg */
-            addInstr(env, AMD64Instr_Alu64R( Aalu_MOV, 
+            addInstr(env, AMD64Instr_Alu64R( Aalu_MOV,
                                              AMD64RMI_Mem(m16_rsp),
                                              hregAMD64_RSI() )); /* 2nd arg */
             addInstr(env, AMD64Instr_Call( Acc_ALWAYS, (ULong)fn,
@@ -1740,7 +1740,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             return dst;
          }
 
-         default: 
+         default:
             break;
       }
 
@@ -1757,9 +1757,9 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
       }
       if (fn != (HWord)0) {
          /* Note: the following assumes all helpers are of
-            signature 
+            signature
                ULong fn ( ULong ), and they are
-            not marked as regparm functions. 
+            not marked as regparm functions.
          */
          HReg dst = newVRegI(env);
          HReg arg = iselIntExpr_R(env, e->Iex.Unop.arg);
@@ -1778,7 +1778,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
       if (ty == Ity_I64) {
          HReg dst = newVRegI(env);
          addInstr(env, AMD64Instr_Alu64R(
-                          Aalu_MOV, 
+                          Aalu_MOV,
                           AMD64RMI_Mem(
                              AMD64AMode_IR(e->Iex.Get.offset,
                                            hregAMD64_RBP())),
@@ -1798,9 +1798,9 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
    }
 
    case Iex_GetI: {
-      AMD64AMode* am 
+      AMD64AMode* am
          = genGuestArrayOffset(
-              env, e->Iex.GetI.descr, 
+              env, e->Iex.GetI.descr,
                    e->Iex.GetI.ix, e->Iex.GetI.bias );
       HReg dst = newVRegI(env);
       if (ty == Ity_I8) {
@@ -1900,7 +1900,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
             case Iop_PRem1C3210F64:
                addInstr(env, AMD64Instr_A87FpOp(Afp_PREM1));
                break;
-            default: 
+            default:
                vassert(0);
          }
          /* Ignore the result, and instead make off with the FPU's
@@ -1913,7 +1913,7 @@ static HReg iselIntExpr_R_wrk ( ISelEnv* env, IRExpr* e )
       break;
    }
 
-   default: 
+   default:
    break;
    } /* switch (e->tag) */
 
@@ -1954,8 +1954,8 @@ static AMD64AMode* iselIntExpr_AMode_wrk ( ISelEnv* env, IRExpr* e )
    /*              bind0        bind1  bind2   bind3   */
    DEFINE_PATTERN(p_complex,
       binop( Iop_Add64,
-             binop( Iop_Add64, 
-                    bind(0), 
+             binop( Iop_Add64,
+                    bind(0),
                     binop(Iop_Shl64, bind(1), bind(2))
                   ),
              bind(3)
@@ -1966,7 +1966,7 @@ static AMD64AMode* iselIntExpr_AMode_wrk ( ISelEnv* env, IRExpr* e )
       IRExpr* expr2  = mi.bindee[1];
       IRExpr* imm8   = mi.bindee[2];
       IRExpr* simm32 = mi.bindee[3];
-      if (imm8->tag == Iex_Const 
+      if (imm8->tag == Iex_Const
           && imm8->Iex.Const.con->tag == Ico_U8
           && imm8->Iex.Const.con->Ico.U8 < 4
           /* imm8 is OK, now check simm32 */
@@ -1998,14 +1998,14 @@ static AMD64AMode* iselIntExpr_AMode_wrk ( ISelEnv* env, IRExpr* e )
    }
 
    /* Add64(expr,i) */
-   if (e->tag == Iex_Binop 
+   if (e->tag == Iex_Binop
        && e->Iex.Binop.op == Iop_Add64
        && e->Iex.Binop.arg2->tag == Iex_Const
        && e->Iex.Binop.arg2->Iex.Const.con->tag == Ico_U64
        && fitsIn32Bits(e->Iex.Binop.arg2->Iex.Const.con->Ico.U64)) {
       HReg r1 = iselIntExpr_R(env, e->Iex.Binop.arg1);
       return AMD64AMode_IR(
-                toUInt(e->Iex.Binop.arg2->Iex.Const.con->Ico.U64), 
+                toUInt(e->Iex.Binop.arg2->Iex.Const.con->Ico.U64),
                 r1
              );
    }
@@ -2047,7 +2047,7 @@ static AMD64RMI* iselIntExpr_RMI ( ISelEnv* env, IRExpr* e )
 static AMD64RMI* iselIntExpr_RMI_wrk ( ISelEnv* env, IRExpr* e )
 {
    IRType ty = typeOfIRExpr(env->type_env,e);
-   vassert(ty == Ity_I64 || ty == Ity_I32 
+   vassert(ty == Ity_I64 || ty == Ity_I32
            || ty == Ity_I16 || ty == Ity_I8);
 
    /* special case: immediate 64/32/16/8 */
@@ -2116,7 +2116,7 @@ static AMD64RI* iselIntExpr_RI ( ISelEnv* env, IRExpr* e )
 static AMD64RI* iselIntExpr_RI_wrk ( ISelEnv* env, IRExpr* e )
 {
    IRType ty = typeOfIRExpr(env->type_env,e);
-   vassert(ty == Ity_I64 || ty == Ity_I32 
+   vassert(ty == Ity_I64 || ty == Ity_I32
            || ty == Ity_I16 || ty == Ity_I8);
 
    /* special case: immediate */
@@ -2129,7 +2129,7 @@ static AMD64RI* iselIntExpr_RI_wrk ( ISelEnv* env, IRExpr* e )
            break;
          case Ico_U32:
             return AMD64RI_Imm(e->Iex.Const.con->Ico.U32);
-         case Ico_U16: 
+         case Ico_U16:
             return AMD64RI_Imm(0xFFFF & e->Iex.Const.con->Ico.U16);
          case Ico_U8:
             return AMD64RI_Imm(0xFF & e->Iex.Const.con->Ico.U8);
@@ -2224,7 +2224,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    if (e->tag == Iex_Const) {
       HReg r;
       vassert(e->Iex.Const.con->tag == Ico_U1);
-      vassert(e->Iex.Const.con->Ico.U1 == True 
+      vassert(e->Iex.Const.con->Ico.U1 == True
               || e->Iex.Const.con->Ico.U1 == False);
       r = newVRegI(env);
       addInstr(env, AMD64Instr_Alu64R(Aalu_MOV,AMD64RMI_Imm(0),r));
@@ -2259,7 +2259,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    /* --- patterns rooted at: CmpNEZ8 --- */
 
    /* CmpNEZ8(x) */
-   if (e->tag == Iex_Unop 
+   if (e->tag == Iex_Unop
        && e->Iex.Unop.op == Iop_CmpNEZ8) {
       HReg r = iselIntExpr_R(env, e->Iex.Unop.arg);
       addInstr(env, AMD64Instr_Test64(0xFF,r));
@@ -2269,7 +2269,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    /* --- patterns rooted at: CmpNEZ16 --- */
 
    /* CmpNEZ16(x) */
-   if (e->tag == Iex_Unop 
+   if (e->tag == Iex_Unop
        && e->Iex.Unop.op == Iop_CmpNEZ16) {
       HReg r = iselIntExpr_R(env, e->Iex.Unop.arg);
       addInstr(env, AMD64Instr_Test64(0xFFFF,r));
@@ -2279,7 +2279,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    /* --- patterns rooted at: CmpNEZ32 --- */
 
    /* CmpNEZ32(x) */
-   if (e->tag == Iex_Unop 
+   if (e->tag == Iex_Unop
        && e->Iex.Unop.op == Iop_CmpNEZ32) {
       HReg      r1   = iselIntExpr_R(env, e->Iex.Unop.arg);
       AMD64RMI* rmi2 = AMD64RMI_Imm(0);
@@ -2305,7 +2305,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    }
 
    /* CmpNEZ64(x) */
-   if (e->tag == Iex_Unop 
+   if (e->tag == Iex_Unop
        && e->Iex.Unop.op == Iop_CmpNEZ64) {
       HReg      r1   = iselIntExpr_R(env, e->Iex.Unop.arg);
       AMD64RMI* rmi2 = AMD64RMI_Imm(0);
@@ -2316,7 +2316,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    /* --- patterns rooted at: Cmp{EQ,NE}{8,16,32} --- */
 
    /* CmpEQ8 / CmpNE8 */
-   if (e->tag == Iex_Binop 
+   if (e->tag == Iex_Binop
        && (e->Iex.Binop.op == Iop_CmpEQ8
            || e->Iex.Binop.op == Iop_CmpNE8
            || e->Iex.Binop.op == Iop_CasCmpEQ8
@@ -2345,7 +2345,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    }
 
    /* CmpEQ16 / CmpNE16 */
-   if (e->tag == Iex_Binop 
+   if (e->tag == Iex_Binop
        && (e->Iex.Binop.op == Iop_CmpEQ16
            || e->Iex.Binop.op == Iop_CmpNE16
            || e->Iex.Binop.op == Iop_CasCmpEQ16
@@ -2365,7 +2365,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
 
    /* CmpNE64(ccall, 64-bit constant) (--smc-check=all optimisation).
       Saves a "movq %rax, %tmp" compared to the default route. */
-   if (e->tag == Iex_Binop 
+   if (e->tag == Iex_Binop
        && e->Iex.Binop.op == Iop_CmpNE64
        && e->Iex.Binop.arg1->tag == Iex_CCall
        && e->Iex.Binop.arg2->tag == Iex_Const) {
@@ -2392,7 +2392,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    }
 
    /* Cmp*64*(x,y) */
-   if (e->tag == Iex_Binop 
+   if (e->tag == Iex_Binop
        && (e->Iex.Binop.op == Iop_CmpEQ64
            || e->Iex.Binop.op == Iop_CmpNE64
            || e->Iex.Binop.op == Iop_CmpLT64S
@@ -2418,7 +2418,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    }
 
    /* Cmp*32*(x,y) */
-   if (e->tag == Iex_Binop 
+   if (e->tag == Iex_Binop
        && (e->Iex.Binop.op == Iop_CmpEQ32
            || e->Iex.Binop.op == Iop_CmpNE32
            || e->Iex.Binop.op == Iop_CmpLT32S
@@ -2457,7 +2457,7 @@ static AMD64CondCode iselCondCode_wrk ( ISelEnv* env, IRExpr* e )
    either real or virtual regs; in any case they must not be changed
    by subsequent code emitted by the caller.  */
 
-static void iselInt128Expr ( HReg* rHi, HReg* rLo, 
+static void iselInt128Expr ( HReg* rHi, HReg* rLo,
                              ISelEnv* env, IRExpr* e )
 {
    iselInt128Expr_wrk(rHi, rLo, env, e);
@@ -2471,7 +2471,7 @@ static void iselInt128Expr ( HReg* rHi, HReg* rLo,
 }
 
 /* DO NOT CALL THIS DIRECTLY ! */
-static void iselInt128Expr_wrk ( HReg* rHi, HReg* rLo, 
+static void iselInt128Expr_wrk ( HReg* rHi, HReg* rLo,
                                  ISelEnv* env, IRExpr* e )
 {
    vassert(e);
@@ -2482,7 +2482,7 @@ static void iselInt128Expr_wrk ( HReg* rHi, HReg* rLo,
       lookupIRTempPair( rHi, rLo, env, e->Iex.RdTmp.tmp);
       return;
    }
- 
+
    /* --------- BINARY ops --------- */
    if (e->tag == Iex_Binop) {
       switch (e->Iex.Binop.op) {
@@ -2534,7 +2534,7 @@ static void iselInt128Expr_wrk ( HReg* rHi, HReg* rLo,
             *rLo = iselIntExpr_R(env, e->Iex.Binop.arg2);
             return;
 
-         default: 
+         default:
             break;
       }
    } /* if (e->tag == Iex_Binop) */
@@ -2780,7 +2780,7 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
       addInstr(env, AMD64Instr_Imm64(u.u64, tmp));
       addInstr(env, AMD64Instr_Push(AMD64RMI_Reg(tmp)));
       addInstr(env, AMD64Instr_SseLdSt(
-                       True/*load*/, 8, res, 
+                       True/*load*/, 8, res,
                        AMD64AMode_IR(0, hregAMD64_RSP())
               ));
       add_to_rsp(env, 8);
@@ -2805,9 +2805,9 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
    }
 
    if (e->tag == Iex_GetI) {
-      AMD64AMode* am 
+      AMD64AMode* am
          = genGuestArrayOffset(
-              env, e->Iex.GetI.descr, 
+              env, e->Iex.GetI.descr,
                    e->Iex.GetI.ix, e->Iex.GetI.bias );
       HReg res = newVRegV(env);
       addInstr(env, AMD64Instr_SseLdSt( True/*load*/, 8, res, am ));
@@ -2909,7 +2909,7 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
    }
 
    IRTriop *triop = e->Iex.Triop.details;
-   if (e->tag == Iex_Triop 
+   if (e->tag == Iex_Triop
        && (triop->op == Iop_ScaleF64
            || triop->op == Iop_AtanF64
            || triop->op == Iop_Yl2xF64
@@ -2921,7 +2921,7 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
       HReg        arg1   = iselDblExpr(env, triop->arg2);
       HReg        arg2   = iselDblExpr(env, triop->arg3);
       HReg        dst    = newVRegV(env);
-      Bool     arg2first = toBool(triop->op == Iop_ScaleF64 
+      Bool     arg2first = toBool(triop->op == Iop_ScaleF64
                                   || triop->op == Iop_PRemF64
                                   || triop->op == Iop_PRem1F64);
       addInstr(env, AMD64Instr_A87Free(2));
@@ -2940,16 +2940,16 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
       /* XXXROUNDINGFIXME */
       /* set roundingmode here */
       switch (triop->op) {
-         case Iop_ScaleF64: 
+         case Iop_ScaleF64:
             addInstr(env, AMD64Instr_A87FpOp(Afp_SCALE));
             break;
-         case Iop_AtanF64: 
+         case Iop_AtanF64:
             addInstr(env, AMD64Instr_A87FpOp(Afp_ATAN));
             break;
-         case Iop_Yl2xF64: 
+         case Iop_Yl2xF64:
             addInstr(env, AMD64Instr_A87FpOp(Afp_YL2X));
             break;
-         case Iop_Yl2xp1F64: 
+         case Iop_Yl2xp1F64:
             addInstr(env, AMD64Instr_A87FpOp(Afp_YL2XP1));
             break;
          case Iop_PRemF64:
@@ -2958,7 +2958,7 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
          case Iop_PRem1F64:
             addInstr(env, AMD64Instr_A87FpOp(Afp_PREM1));
             break;
-         default: 
+         default:
             vassert(0);
       }
 
@@ -2985,7 +2985,7 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
       return dst;
    }
 
-   if (e->tag == Iex_Unop 
+   if (e->tag == Iex_Unop
        && (e->Iex.Unop.op == Iop_NegF64
            || e->Iex.Unop.op == Iop_AbsF64)) {
       /* Sigh ... very rough code.  Could do much better. */
@@ -3051,7 +3051,7 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
 //..             addInstr(env, X86Instr_Push(X86RMI_Reg(ri)));
 //..             set_FPU_rounding_default(env);
 //..             addInstr(env, X86Instr_FpLdStI(
-//..                              True/*load*/, 4, dst, 
+//..                              True/*load*/, 4, dst,
 //..                              X86AMode_IR(0, hregX86_ESP())));
 //..             add_to_esp(env, 4);
 //..             return dst;
@@ -3077,7 +3077,7 @@ static HReg iselDblExpr_wrk ( ISelEnv* env, IRExpr* e )
             addInstr(env, AMD64Instr_SseSDSS(False/*S->D*/, f32, f64));
             return f64;
          }
-         default: 
+         default:
             break;
       }
    }
@@ -3134,7 +3134,7 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, IRExpr* e )
    if (e->tag == Iex_Get) {
       HReg dst = newVRegV(env);
       addInstr(env, AMD64Instr_SseLdSt(
-                       True/*load*/, 
+                       True/*load*/,
                        16,
                        dst,
                        AMD64AMode_IR(e->Iex.Get.offset, hregAMD64_RBP())
@@ -3190,7 +3190,7 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, IRExpr* e )
          /* Ideally, we want to do a 64Ix2 comparison against zero of
             the operand.  Problem is no such insn exists.  Solution
             therefore is to do a 32Ix4 comparison instead, and bitwise-
-            negate (NOT) the result.  Let a,b,c,d be 32-bit lanes, and 
+            negate (NOT) the result.  Let a,b,c,d be 32-bit lanes, and
             let the not'd result of this initial comparison be a:b:c:d.
             What we need to compute is (a|b):(a|b):(c|d):(c|d).  So, use
             pshufd to create a value b:a:d:c, and OR that with a:b:c:d,
@@ -3198,8 +3198,8 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, IRExpr* e )
 
             The required selection sequence is 2,3,0,1, which
             according to Intel's documentation means the pshufd
-            literal value is 0xB1, that is, 
-            (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0) 
+            literal value is 0xB1, that is,
+            (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0)
          */
          HReg arg  = iselVecExpr(env, e->Iex.Unop.arg);
          HReg tmp  = generate_zeroes_V128(env);
@@ -3422,29 +3422,29 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, IRExpr* e )
          return dst;
       }
 
-      case Iop_QNarrowBin32Sto16Sx8: 
+      case Iop_QNarrowBin32Sto16Sx8:
          op = Asse_PACKSSD; arg1isEReg = True; goto do_SseReRg;
-      case Iop_QNarrowBin16Sto8Sx16: 
+      case Iop_QNarrowBin16Sto8Sx16:
          op = Asse_PACKSSW; arg1isEReg = True; goto do_SseReRg;
-      case Iop_QNarrowBin16Sto8Ux16: 
+      case Iop_QNarrowBin16Sto8Ux16:
          op = Asse_PACKUSW; arg1isEReg = True; goto do_SseReRg;
 
-      case Iop_InterleaveHI8x16: 
+      case Iop_InterleaveHI8x16:
          op = Asse_UNPCKHB; arg1isEReg = True; goto do_SseReRg;
-      case Iop_InterleaveHI16x8: 
+      case Iop_InterleaveHI16x8:
          op = Asse_UNPCKHW; arg1isEReg = True; goto do_SseReRg;
-      case Iop_InterleaveHI32x4: 
+      case Iop_InterleaveHI32x4:
          op = Asse_UNPCKHD; arg1isEReg = True; goto do_SseReRg;
-      case Iop_InterleaveHI64x2: 
+      case Iop_InterleaveHI64x2:
          op = Asse_UNPCKHQ; arg1isEReg = True; goto do_SseReRg;
 
-      case Iop_InterleaveLO8x16: 
+      case Iop_InterleaveLO8x16:
          op = Asse_UNPCKLB; arg1isEReg = True; goto do_SseReRg;
-      case Iop_InterleaveLO16x8: 
+      case Iop_InterleaveLO16x8:
          op = Asse_UNPCKLW; arg1isEReg = True; goto do_SseReRg;
-      case Iop_InterleaveLO32x4: 
+      case Iop_InterleaveLO32x4:
          op = Asse_UNPCKLD; arg1isEReg = True; goto do_SseReRg;
-      case Iop_InterleaveLO64x2: 
+      case Iop_InterleaveLO64x2:
          op = Asse_UNPCKLQ; arg1isEReg = True; goto do_SseReRg;
 
       case Iop_AndV128:    op = Asse_AND;      goto do_SseReRg;
@@ -3566,7 +3566,7 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, IRExpr* e )
                                         argp));
          /* andq $-16, %r_argp      -- 16-align the pointer */
          addInstr(env, AMD64Instr_Alu64R(Aalu_AND,
-                                         AMD64RMI_Imm( ~(UInt)15 ), 
+                                         AMD64RMI_Imm( ~(UInt)15 ),
                                          argp));
          /* Prepare 3 arg regs:
             leaq 0(%r_argp), %rdi
@@ -3618,7 +3618,7 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, IRExpr* e )
                                         argp));
          /* andq $-16, %r_argp      -- 16-align the pointer */
          addInstr(env, AMD64Instr_Alu64R(Aalu_AND,
-                                         AMD64RMI_Imm( ~(UInt)15 ), 
+                                         AMD64RMI_Imm( ~(UInt)15 ),
                                          argp));
          /* Prepare 2 vector arg regs:
             leaq 0(%r_argp), %rdi
@@ -3716,7 +3716,7 @@ static HReg iselVecExpr_wrk ( ISelEnv* env, IRExpr* e )
 /*--- ISEL: SIMD (V256) expressions, into 2 XMM regs.    --*/
 /*---------------------------------------------------------*/
 
-static void iselDVecExpr ( /*OUT*/HReg* rHi, /*OUT*/HReg* rLo, 
+static void iselDVecExpr ( /*OUT*/HReg* rHi, /*OUT*/HReg* rLo,
                            ISelEnv* env, IRExpr* e )
 {
    iselDVecExpr_wrk( rHi, rLo, env, e );
@@ -3731,7 +3731,7 @@ static void iselDVecExpr ( /*OUT*/HReg* rHi, /*OUT*/HReg* rLo,
 
 
 /* DO NOT CALL THIS DIRECTLY */
-static void iselDVecExpr_wrk ( /*OUT*/HReg* rHi, /*OUT*/HReg* rLo, 
+static void iselDVecExpr_wrk ( /*OUT*/HReg* rHi, /*OUT*/HReg* rLo,
                                ISelEnv* env, IRExpr* e )
 {
    HWord fn = 0; /* address of helper fn, if required */
@@ -3746,7 +3746,7 @@ static void iselDVecExpr_wrk ( /*OUT*/HReg* rHi, /*OUT*/HReg* rLo,
       lookupIRTempPair( rHi, rLo, env, e->Iex.RdTmp.tmp);
       return;
    }
- 
+
    if (e->tag == Iex_Get) {
       HReg        vHi  = newVRegV(env);
       HReg        vLo  = newVRegV(env);
@@ -4376,14 +4376,14 @@ static void iselStmt ( ISelEnv* env, IRStmt* stmt )
       }
       if (ty == Ity_F64) {
          HReg f64 = iselDblExpr(env, stmt->Ist.Put.data);
-         AMD64AMode* am = AMD64AMode_IR( stmt->Ist.Put.offset, 
+         AMD64AMode* am = AMD64AMode_IR( stmt->Ist.Put.offset,
                                          hregAMD64_RBP() );
          addInstr(env, AMD64Instr_SseLdSt( False/*store*/, 8, f64, am ));
          return;
       }
       if (ty == Ity_V128) {
          HReg        vec = iselVecExpr(env, stmt->Ist.Put.data);
-         AMD64AMode* am  = AMD64AMode_IR(stmt->Ist.Put.offset, 
+         AMD64AMode* am  = AMD64AMode_IR(stmt->Ist.Put.offset,
                                          hregAMD64_RBP());
          addInstr(env, AMD64Instr_SseLdSt(False/*store*/, 16, vec, am));
          return;
@@ -4405,9 +4405,9 @@ static void iselStmt ( ISelEnv* env, IRStmt* stmt )
    case Ist_PutI: {
       IRPutI *puti = stmt->Ist.PutI.details;
 
-      AMD64AMode* am 
+      AMD64AMode* am
          = genGuestArrayOffset(
-              env, puti->descr, 
+              env, puti->descr,
                    puti->ix, puti->bias );
 
       IRType ty = typeOfIRExpr(env->type_env, puti->data);
@@ -4440,7 +4440,7 @@ static void iselStmt ( ISelEnv* env, IRStmt* stmt )
          created IR) we get t = address-expression, (t is later used
          twice) and so doing this naturally turns address-expression
          back into an AMD64 amode. */
-      if (ty == Ity_I64 
+      if (ty == Ity_I64
           && stmt->Ist.WrTmp.data->tag == Iex_Binop
           && stmt->Ist.WrTmp.data->Iex.Binop.op == Iop_Add64) {
          AMD64AMode* am = iselIntExpr_AMode(env, stmt->Ist.WrTmp.data);
@@ -4457,7 +4457,7 @@ static void iselStmt ( ISelEnv* env, IRStmt* stmt )
          return;
       }
 
-      if (ty == Ity_I64 || ty == Ity_I32 
+      if (ty == Ity_I64 || ty == Ity_I32
           || ty == Ity_I16 || ty == Ity_I8) {
          AMD64RMI* rmi = iselIntExpr_RMI(env, stmt->Ist.WrTmp.data);
          HReg dst = lookupIRTemp(env, tmp);
@@ -4592,10 +4592,11 @@ static void iselStmt ( ISelEnv* env, IRStmt* stmt )
    case Ist_MBE:
       switch (stmt->Ist.MBE.event) {
          case Imbe_Fence:
+         case Imbe_SFence:
+         case Imbe_LFence:
             addInstr(env, AMD64Instr_MFence());
             return;
          case Imbe_Drain:
-            addInstr(env, AMD64Instr_Pcommit());
             return;
          default:
             break;
@@ -4619,11 +4620,11 @@ static void iselStmt ( ISelEnv* env, IRStmt* stmt )
          addInstr(env, mk_iMOVsd_RR(rExpd, rOld));
          addInstr(env, mk_iMOVsd_RR(rExpd, hregAMD64_RAX()));
          addInstr(env, mk_iMOVsd_RR(rData, hregAMD64_RBX()));
-         switch (ty) { 
+         switch (ty) {
             case Ity_I64: sz = 8; break;
             case Ity_I32: sz = 4; break;
             case Ity_I16: sz = 2; break;
-            case Ity_I8:  sz = 1; break; 
+            case Ity_I8:  sz = 1; break;
             default: goto unhandled_cas;
          }
          addInstr(env, AMD64Instr_ACAS(am, sz));
@@ -4645,7 +4646,7 @@ static void iselStmt ( ISelEnv* env, IRStmt* stmt )
          HReg rExpdLo = iselIntExpr_R(env, cas->expdLo);
          HReg rOldHi  = lookupIRTemp(env, cas->oldHi);
          HReg rOldLo  = lookupIRTemp(env, cas->oldLo);
-         switch (ty) { 
+         switch (ty) {
             case Ity_I64:
                if (!(env->hwcaps & VEX_HWCAPS_AMD64_CX16))
                   goto unhandled_cas; /* we'd have to generate
@@ -4799,8 +4800,8 @@ static void iselNext ( ISelEnv* env,
             Bool toFastEP
                = ((Addr64)cdst->Ico.U64) > env->max_ga;
             if (0) vex_printf("%s", toFastEP ? "X" : ".");
-            addInstr(env, AMD64Instr_XDirect(cdst->Ico.U64, 
-                                             amRIP, Acc_ALWAYS, 
+            addInstr(env, AMD64Instr_XDirect(cdst->Ico.U64,
+                                             amRIP, Acc_ALWAYS,
                                              toFastEP));
          } else {
             /* .. very occasionally .. */

--- a/VEX/priv/ir_defs.c
+++ b/VEX/priv/ir_defs.c
@@ -118,7 +118,7 @@ void ppIRTemp ( IRTemp tmp )
 
 void ppIROp ( IROp op )
 {
-   const HChar* str = NULL; 
+   const HChar* str = NULL;
    IROp   base;
    switch (op) {
       case Iop_Add8 ... Iop_Add64:
@@ -338,7 +338,7 @@ void ppIROp ( IROp op )
       case Iop_TruncF64asF32: vex_printf("TruncF64asF32"); return;
 
       case Iop_QAdd32S: vex_printf("QAdd32S"); return;
-      case Iop_QSub32S: vex_printf("QSub32S"); return; 
+      case Iop_QSub32S: vex_printf("QSub32S"); return;
       case Iop_Add16x2:   vex_printf("Add16x2"); return;
       case Iop_Sub16x2:   vex_printf("Sub16x2"); return;
       case Iop_QAdd16Sx2: vex_printf("QAdd16Sx2"); return;
@@ -651,7 +651,7 @@ void ppIROp ( IROp op )
       case Iop_Sqrt64F0x2: vex_printf("Sqrt64F0x2"); return;
       case Iop_Sqrt32Fx8:  vex_printf("Sqrt32Fx8"); return;
       case Iop_Sqrt64Fx4:  vex_printf("Sqrt64Fx4"); return;
- 
+
       case Iop_Sub32Fx4:  vex_printf("Sub32Fx4"); return;
       case Iop_Sub32Fx2:  vex_printf("Sub32Fx2"); return;
       case Iop_Sub32F0x4: vex_printf("Sub32F0x4"); return;
@@ -1238,7 +1238,7 @@ void ppIROp ( IROp op )
       default: vpanic("ppIROp(1)");
    }
 
-   vassert(str);  
+   vassert(str);
    switch (op - base) {
       case 0: vex_printf("%s",str); vex_printf("8"); break;
       case 1: vex_printf("%s",str); vex_printf("16"); break;
@@ -1455,12 +1455,12 @@ void ppIRStoreG ( IRStoreG* sg )
 void ppIRLoadGOp ( IRLoadGOp cvt )
 {
    switch (cvt) {
-      case ILGop_INVALID: vex_printf("ILGop_INVALID"); break;      
-      case ILGop_Ident32: vex_printf("Ident32"); break;      
-      case ILGop_16Uto32: vex_printf("16Uto32"); break;      
-      case ILGop_16Sto32: vex_printf("16Sto32"); break;      
-      case ILGop_8Uto32:  vex_printf("8Uto32"); break;      
-      case ILGop_8Sto32:  vex_printf("8Sto32"); break;      
+      case ILGop_INVALID: vex_printf("ILGop_INVALID"); break;
+      case ILGop_Ident32: vex_printf("Ident32"); break;
+      case ILGop_16Uto32: vex_printf("16Uto32"); break;
+      case ILGop_16Sto32: vex_printf("16Sto32"); break;
+      case ILGop_8Uto32:  vex_printf("8Uto32"); break;
+      case ILGop_8Sto32:  vex_printf("8Sto32"); break;
       default: vpanic("ppIRLoadGOp");
    }
 }
@@ -1518,9 +1518,29 @@ void ppIRMBusEvent ( IRMBusEvent event )
          vex_printf("CancelReservation"); break;
       case Imbe_Drain:
          vex_printf("Drain"); break;
+      case Imbe_SFence:
+         vex_printf("SFence"); break;
+      case Imbe_LFence:
+         vex_printf("LFence"); break;
       default:
          vpanic("ppIRMBusEvent");
    }
+}
+
+void ppIRFlushEvent ( IRFlushKind flush_kind, IRExpr* e )
+{
+   switch (flush_kind) {
+      case Ifk_flush:
+         vex_printf("FLUSH("); break;
+      case Ifk_flushopt:
+         vex_printf("FLUSHOPT("); break;
+      case Ifk_clwb:
+         vex_printf("CLWB("); break;
+      default:
+         vpanic("ppIRFlushEvent");
+   }
+   ppIRExpr(e);
+   vex_printf(")");
 }
 
 void ppIRStmt ( IRStmt* s )
@@ -1534,7 +1554,7 @@ void ppIRStmt ( IRStmt* s )
          vex_printf("IR-NoOp");
          break;
       case Ist_IMark:
-         vex_printf( "------ IMark(0x%llx, %d, %u) ------", 
+         vex_printf( "------ IMark(0x%llx, %d, %u) ------",
                      s->Ist.IMark.addr, s->Ist.IMark.len,
                      (UInt)s->Ist.IMark.delta);
          break;
@@ -1606,11 +1626,9 @@ void ppIRStmt ( IRStmt* s )
          vex_printf(" } ");
          break;
       case Ist_Flush:
-         vex_printf( "FLUSH(");
-         ppIRExpr(s->Ist.Flush.addr);
-         vex_printf( ")");
+         ppIRFlushEvent(s->Ist.Flush.fk, s->Ist.Flush.addr);
          break;
-      default: 
+      default:
          vpanic("ppIRStmt");
    }
 }
@@ -1623,13 +1641,13 @@ void ppIRTypeEnv ( IRTypeEnv* env ) {
       ppIRTemp(i);
       vex_printf( ":");
       ppIRType(env->types[i]);
-      if (i % 8 == 7) 
-         vex_printf( "\n"); 
-      else 
+      if (i % 8 == 7)
+         vex_printf( "\n");
+      else
          vex_printf( "   ");
    }
-   if (env->types_used > 0 && env->types_used % 8 != 7) 
-      vex_printf( "\n"); 
+   if (env->types_used > 0 && env->types_used % 8 != 7)
+      vex_printf( "\n");
 }
 
 void ppIRSB ( IRSB* bb )
@@ -1798,7 +1816,7 @@ IRExpr* IRExpr_RdTmp ( IRTemp tmp ) {
    e->Iex.RdTmp.tmp = tmp;
    return e;
 }
-IRExpr* IRExpr_Qop ( IROp op, IRExpr* arg1, IRExpr* arg2, 
+IRExpr* IRExpr_Qop ( IROp op, IRExpr* arg1, IRExpr* arg2,
                               IRExpr* arg3, IRExpr* arg4 ) {
    IRExpr* e       = LibVEX_Alloc(sizeof(IRExpr));
    IRQop*  qop     = LibVEX_Alloc(sizeof(IRQop));
@@ -1811,7 +1829,7 @@ IRExpr* IRExpr_Qop ( IROp op, IRExpr* arg1, IRExpr* arg2,
    e->Iex.Qop.details = qop;
    return e;
 }
-IRExpr* IRExpr_Triop  ( IROp op, IRExpr* arg1, 
+IRExpr* IRExpr_Triop  ( IROp op, IRExpr* arg1,
                                  IRExpr* arg2, IRExpr* arg3 ) {
    IRExpr*  e         = LibVEX_Alloc(sizeof(IRExpr));
    IRTriop* triop     = LibVEX_Alloc(sizeof(IRTriop));
@@ -1993,7 +2011,7 @@ IRDirty* emptyIRDirty ( void ) {
 /* Constructors -- IRCAS */
 
 IRCAS* mkIRCAS ( IRTemp oldHi, IRTemp oldLo,
-                 IREndness end, IRExpr* addr, 
+                 IREndness end, IRExpr* addr,
                  IRExpr* expdHi, IRExpr* expdLo,
                  IRExpr* dataHi, IRExpr* dataLo ) {
    IRCAS* cas = LibVEX_Alloc(sizeof(IRCAS));
@@ -2159,10 +2177,11 @@ IRStmt* IRStmt_Exit ( IRExpr* guard, IRJumpKind jk, IRConst* dst,
    s->Ist.Exit.offsIP = offsIP;
    return s;
 }
-IRStmt* IRStmt_Flush ( IRExpr* addr ) {
+IRStmt* IRStmt_Flush ( IRExpr* addr, IRFlushKind fk ) {
    IRStmt* s           = LibVEX_Alloc(sizeof(IRStmt));
    s->tag              = Ist_Flush;
    s->Ist.Flush.addr   = addr;
+   s->Ist.Flush.fk     = fk;
    return s;
 }
 
@@ -2262,13 +2281,13 @@ IRRegArray* deepCopyIRRegArray ( IRRegArray* d )
 IRExpr* deepCopyIRExpr ( IRExpr* e )
 {
    switch (e->tag) {
-      case Iex_Get: 
+      case Iex_Get:
          return IRExpr_Get(e->Iex.Get.offset, e->Iex.Get.ty);
-      case Iex_GetI: 
-         return IRExpr_GetI(deepCopyIRRegArray(e->Iex.GetI.descr), 
+      case Iex_GetI:
+         return IRExpr_GetI(deepCopyIRRegArray(e->Iex.GetI.descr),
                             deepCopyIRExpr(e->Iex.GetI.ix),
                             e->Iex.GetI.bias);
-      case Iex_RdTmp: 
+      case Iex_RdTmp:
          return IRExpr_RdTmp(e->Iex.RdTmp.tmp);
       case Iex_Qop: {
          IRQop* qop = e->Iex.Qop.details;
@@ -2287,25 +2306,25 @@ IRExpr* deepCopyIRExpr ( IRExpr* e )
                              deepCopyIRExpr(triop->arg2),
                              deepCopyIRExpr(triop->arg3));
       }
-      case Iex_Binop: 
+      case Iex_Binop:
          return IRExpr_Binop(e->Iex.Binop.op,
                              deepCopyIRExpr(e->Iex.Binop.arg1),
                              deepCopyIRExpr(e->Iex.Binop.arg2));
-      case Iex_Unop: 
+      case Iex_Unop:
          return IRExpr_Unop(e->Iex.Unop.op,
                             deepCopyIRExpr(e->Iex.Unop.arg));
-      case Iex_Load: 
+      case Iex_Load:
          return IRExpr_Load(e->Iex.Load.end,
                             e->Iex.Load.ty,
                             deepCopyIRExpr(e->Iex.Load.addr));
-      case Iex_Const: 
+      case Iex_Const:
          return IRExpr_Const(deepCopyIRConst(e->Iex.Const.con));
       case Iex_CCall:
          return IRExpr_CCall(deepCopyIRCallee(e->Iex.CCall.cee),
                              e->Iex.CCall.retty,
                              deepCopyIRExprVec(e->Iex.CCall.args));
 
-      case Iex_ITE: 
+      case Iex_ITE:
          return IRExpr_ITE(deepCopyIRExpr(e->Iex.ITE.cond),
                            deepCopyIRExpr(e->Iex.ITE.iftrue),
                            deepCopyIRExpr(e->Iex.ITE.iffalse));
@@ -2351,7 +2370,7 @@ IRPutI* deepCopyIRPutI ( IRPutI * puti )
 {
   return mkIRPutI( deepCopyIRRegArray(puti->descr),
                    deepCopyIRExpr(puti->ix),
-                   puti->bias, 
+                   puti->bias,
                    deepCopyIRExpr(puti->data));
 }
 
@@ -2368,15 +2387,15 @@ IRStmt* deepCopyIRStmt ( IRStmt* s )
          return IRStmt_IMark(s->Ist.IMark.addr,
                              s->Ist.IMark.len,
                              s->Ist.IMark.delta);
-      case Ist_Put: 
-         return IRStmt_Put(s->Ist.Put.offset, 
+      case Ist_Put:
+         return IRStmt_Put(s->Ist.Put.offset,
                            deepCopyIRExpr(s->Ist.Put.data));
-      case Ist_PutI: 
+      case Ist_PutI:
          return IRStmt_PutI(deepCopyIRPutI(s->Ist.PutI.details));
       case Ist_WrTmp:
          return IRStmt_WrTmp(s->Ist.WrTmp.tmp,
                              deepCopyIRExpr(s->Ist.WrTmp.data));
-      case Ist_Store: 
+      case Ist_Store:
          return IRStmt_Store(s->Ist.Store.end,
                              deepCopyIRExpr(s->Ist.Store.addr),
                              deepCopyIRExpr(s->Ist.Store.data));
@@ -2403,17 +2422,18 @@ IRStmt* deepCopyIRStmt ( IRStmt* s )
                             s->Ist.LLSC.storedata
                                ? deepCopyIRExpr(s->Ist.LLSC.storedata)
                                : NULL);
-      case Ist_Dirty: 
+      case Ist_Dirty:
          return IRStmt_Dirty(deepCopyIRDirty(s->Ist.Dirty.details));
       case Ist_MBE:
          return IRStmt_MBE(s->Ist.MBE.event);
-      case Ist_Exit: 
+      case Ist_Exit:
          return IRStmt_Exit(deepCopyIRExpr(s->Ist.Exit.guard),
                             s->Ist.Exit.jk,
                             deepCopyIRConst(s->Ist.Exit.dst),
                             s->Ist.Exit.offsIP);
       case Ist_Flush:
-         return IRStmt_Flush(deepCopyIRExpr(s->Ist.Flush.addr));
+         return IRStmt_Flush(deepCopyIRExpr(s->Ist.Flush.addr),
+                             s->Ist.Flush.fk);
       default:
          vpanic("deepCopyIRStmt");
    }
@@ -2460,10 +2480,10 @@ IRSB* deepCopyIRSBExceptStmts ( IRSB* bb )
 /*---------------------------------------------------------------*/
 
 static
-void typeOfPrimop ( IROp op, 
+void typeOfPrimop ( IROp op,
                     /*OUTs*/
-                    IRType* t_dst, 
-                    IRType* t_arg1, IRType* t_arg2, 
+                    IRType* t_dst,
+                    IRType* t_arg1, IRType* t_arg2,
                     IRType* t_arg3, IRType* t_arg4 )
 {
 #  define UNARY(_ta1,_td)                                      \
@@ -2492,7 +2512,7 @@ void typeOfPrimop ( IROp op,
    *t_arg3 = Ity_INVALID;
    *t_arg4 = Ity_INVALID;
    switch (op) {
-      case Iop_Add8: case Iop_Sub8: case Iop_Mul8: 
+      case Iop_Add8: case Iop_Sub8: case Iop_Mul8:
       case Iop_Or8:  case Iop_And8: case Iop_Xor8:
          BINARY(Ity_I8,Ity_I8, Ity_I8);
 
@@ -2722,7 +2742,7 @@ void typeOfPrimop ( IROp op,
       case Iop_8Uto16: case Iop_8Sto16:
          UNARY(Ity_I8, Ity_I16);
 
-      case Iop_16Uto32: case Iop_16Sto32: 
+      case Iop_16Uto32: case Iop_16Sto32:
          UNARY(Ity_I16, Ity_I32);
 
       case Iop_32Sto64: case Iop_32Uto64:
@@ -2739,9 +2759,9 @@ void typeOfPrimop ( IROp op,
       case Iop_32to8: UNARY(Ity_I32, Ity_I8);
       case Iop_64to8: UNARY(Ity_I64, Ity_I8);
 
-      case Iop_AddF64:    case Iop_SubF64: 
+      case Iop_AddF64:    case Iop_SubF64:
       case Iop_MulF64:    case Iop_DivF64:
-      case Iop_AddF64r32: case Iop_SubF64r32: 
+      case Iop_AddF64r32: case Iop_SubF64r32:
       case Iop_MulF64r32: case Iop_DivF64r32:
          TERNARY(ity_RMode,Ity_F64,Ity_F64, Ity_F64);
 
@@ -2749,7 +2769,7 @@ void typeOfPrimop ( IROp op,
       case Iop_MulF32: case Iop_DivF32:
          TERNARY(ity_RMode,Ity_F32,Ity_F32, Ity_F32);
 
-      case Iop_NegF64: case Iop_AbsF64: 
+      case Iop_NegF64: case Iop_AbsF64:
          UNARY(Ity_F64, Ity_F64);
 
       case Iop_NegF32: case Iop_AbsF32:
@@ -2802,14 +2822,14 @@ void typeOfPrimop ( IROp op,
       case Iop_ReinterpI32asF32: UNARY(Ity_I32, Ity_F32);
       case Iop_ReinterpF32asI32: UNARY(Ity_F32, Ity_I32);
 
-      case Iop_AtanF64: case Iop_Yl2xF64:  case Iop_Yl2xp1F64: 
+      case Iop_AtanF64: case Iop_Yl2xF64:  case Iop_Yl2xp1F64:
       case Iop_ScaleF64: case Iop_PRemF64: case Iop_PRem1F64:
          TERNARY(ity_RMode,Ity_F64,Ity_F64, Ity_F64);
 
       case Iop_PRemC3210F64: case Iop_PRem1C3210F64:
          TERNARY(ity_RMode,Ity_F64,Ity_F64, Ity_I32);
 
-      case Iop_SinF64: case Iop_CosF64: case Iop_TanF64: 
+      case Iop_SinF64: case Iop_CosF64: case Iop_TanF64:
       case Iop_2xm1F64:
       case Iop_RoundF64toInt: BINARY(ity_RMode,Ity_F64, Ity_F64);
 
@@ -2905,7 +2925,7 @@ void typeOfPrimop ( IROp op,
       case Iop_Sub32F0x4:
       case Iop_Sub64F0x2:
       case Iop_AndV128: case Iop_OrV128: case Iop_XorV128:
-      case Iop_Add8x16:   case Iop_Add16x8:   
+      case Iop_Add8x16:   case Iop_Add16x8:
       case Iop_Add32x4:   case Iop_Add64x2:
       case Iop_QAdd8Ux16: case Iop_QAdd16Ux8:
       case Iop_QAdd32Ux4: case Iop_QAdd64Ux2:
@@ -2926,8 +2946,8 @@ void typeOfPrimop ( IROp op,
       case Iop_PolynomialMul8x16:
       case Iop_PolynomialMulAdd8x16: case Iop_PolynomialMulAdd16x8:
       case Iop_PolynomialMulAdd32x4: case Iop_PolynomialMulAdd64x2:
-      case Iop_MulHi16Ux8: case Iop_MulHi32Ux4: 
-      case Iop_MulHi16Sx8: case Iop_MulHi32Sx4: 
+      case Iop_MulHi16Ux8: case Iop_MulHi32Ux4:
+      case Iop_MulHi16Sx8: case Iop_MulHi32Sx4:
       case Iop_QDMulHi16Sx8: case Iop_QDMulHi32Sx4:
       case Iop_QRDMulHi16Sx8: case Iop_QRDMulHi32Sx4:
       case Iop_MullEven8Ux16: case Iop_MullEven16Ux8: case Iop_MullEven32Ux4:
@@ -3023,9 +3043,9 @@ void typeOfPrimop ( IROp op,
          UNARY(Ity_V128, Ity_V128);
 
       case Iop_ShlV128: case Iop_ShrV128:
-      case Iop_ShlN8x16: case Iop_ShlN16x8: 
+      case Iop_ShlN8x16: case Iop_ShlN16x8:
       case Iop_ShlN32x4: case Iop_ShlN64x2:
-      case Iop_ShrN8x16: case Iop_ShrN16x8: 
+      case Iop_ShrN8x16: case Iop_ShrN16x8:
       case Iop_ShrN32x4: case Iop_ShrN64x2:
       case Iop_SarN8x16: case Iop_SarN16x8:
       case Iop_SarN32x4: case Iop_SarN64x2:
@@ -3119,9 +3139,9 @@ void typeOfPrimop ( IROp op,
          TERNARY(ity_RMode,Ity_F128,Ity_F128, Ity_F128);
 
       case Iop_Add64Fx2: case Iop_Sub64Fx2:
-      case Iop_Mul64Fx2: case Iop_Div64Fx2: 
+      case Iop_Mul64Fx2: case Iop_Div64Fx2:
       case Iop_Add32Fx4: case Iop_Sub32Fx4:
-      case Iop_Mul32Fx4: case Iop_Div32Fx4: 
+      case Iop_Mul32Fx4: case Iop_Div32Fx4:
          TERNARY(ity_RMode,Ity_V128,Ity_V128, Ity_V128);
 
       case Iop_Add64Fx4: case Iop_Sub64Fx4:
@@ -3455,7 +3475,7 @@ IRTemp newIRTemp ( IRTypeEnv* env, IRType ty )
    } else {
       Int i;
       Int new_size = env->types_size==0 ? 8 : 2*env->types_size;
-      IRType* new_types 
+      IRType* new_types
          = LibVEX_Alloc(new_size * sizeof(IRType));
       for (i = 0; i < env->types_used; i++)
          new_types[i] = env->types[i];
@@ -3470,7 +3490,7 @@ IRTemp newIRTemp ( IRTypeEnv* env, IRType ty )
 /*--- Helper functions for the IR -- finding types of exprs   ---*/
 /*---------------------------------------------------------------*/
 
-inline 
+inline
 IRType typeOfIRTemp ( IRTypeEnv* env, IRTemp tmp )
 {
    vassert(tmp >= 0);
@@ -3527,7 +3547,7 @@ IRType typeOfIRExpr ( IRTypeEnv* tyenv, IRExpr* e )
       case Iex_Const:
          return typeOfIRConst(e->Iex.Const.con);
       case Iex_Qop:
-         typeOfPrimop(e->Iex.Qop.details->op, 
+         typeOfPrimop(e->Iex.Qop.details->op,
                       &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
          return t_dst;
       case Iex_Triop:
@@ -3535,11 +3555,11 @@ IRType typeOfIRExpr ( IRTypeEnv* tyenv, IRExpr* e )
                       &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
          return t_dst;
       case Iex_Binop:
-         typeOfPrimop(e->Iex.Binop.op, 
+         typeOfPrimop(e->Iex.Binop.op,
                       &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
          return t_dst;
       case Iex_Unop:
-         typeOfPrimop(e->Iex.Unop.op, 
+         typeOfPrimop(e->Iex.Unop.op,
                       &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
          return t_dst;
       case Iex_CCall:
@@ -3565,13 +3585,13 @@ Bool isPlausibleIRType ( IRType ty )
 {
    switch (ty) {
       case Ity_INVALID: case Ity_I1:
-      case Ity_I8: case Ity_I16: case Ity_I32: 
+      case Ity_I8: case Ity_I16: case Ity_I32:
       case Ity_I64: case Ity_I128:
       case Ity_F32: case Ity_F64: case Ity_F128:
       case Ity_D32: case Ity_D64: case Ity_D128:
       case Ity_V128: case Ity_V256:
          return True;
-      default: 
+      default:
          return False;
    }
 }
@@ -3617,7 +3637,7 @@ Bool isFlatIRStmt ( IRStmt* st )
          return isIRAtom(st->Ist.Put.data);
       case Ist_PutI:
          puti = st->Ist.PutI.details;
-         return toBool( isIRAtom(puti->ix) 
+         return toBool( isIRAtom(puti->ix)
                         && isIRAtom(puti->data) );
       case Ist_WrTmp:
          /* This is the only interesting case.  The RHS can be any
@@ -3631,35 +3651,35 @@ Bool isFlatIRStmt ( IRStmt* st )
             case Iex_RdTmp:  return True;
             case Iex_Qop:    qop = e->Iex.Qop.details;
                              return toBool(
-                                    isIRAtom(qop->arg1) 
+                                    isIRAtom(qop->arg1)
                                     && isIRAtom(qop->arg2)
                                     && isIRAtom(qop->arg3)
                                     && isIRAtom(qop->arg4));
             case Iex_Triop:  triop = e->Iex.Triop.details;
                              return toBool(
-                                    isIRAtom(triop->arg1) 
+                                    isIRAtom(triop->arg1)
                                     && isIRAtom(triop->arg2)
                                     && isIRAtom(triop->arg3));
             case Iex_Binop:  return toBool(
-                                    isIRAtom(e->Iex.Binop.arg1) 
+                                    isIRAtom(e->Iex.Binop.arg1)
                                     && isIRAtom(e->Iex.Binop.arg2));
             case Iex_Unop:   return isIRAtom(e->Iex.Unop.arg);
             case Iex_Load:   return isIRAtom(e->Iex.Load.addr);
             case Iex_Const:  return True;
             case Iex_CCall:  for (i = 0; e->Iex.CCall.args[i]; i++)
-                                if (!isIRAtom(e->Iex.CCall.args[i])) 
+                                if (!isIRAtom(e->Iex.CCall.args[i]))
                                    return False;
                              return True;
             case Iex_ITE:    return toBool (
-                                    isIRAtom(e->Iex.ITE.cond) 
-                                    && isIRAtom(e->Iex.ITE.iftrue) 
+                                    isIRAtom(e->Iex.ITE.cond)
+                                    && isIRAtom(e->Iex.ITE.iftrue)
                                     && isIRAtom(e->Iex.ITE.iffalse));
             default:         vpanic("isFlatIRStmt(e)");
          }
          /*notreached*/
          vassert(0);
       case Ist_Store:
-         return toBool( isIRAtom(st->Ist.Store.addr) 
+         return toBool( isIRAtom(st->Ist.Store.addr)
                         && isIRAtom(st->Ist.Store.data) );
       case Ist_StoreG: {
          IRStoreG* sg = st->Ist.StoreG.details;
@@ -3684,12 +3704,12 @@ Bool isFlatIRStmt ( IRStmt* st )
                                ? isIRAtom(st->Ist.LLSC.storedata) : True) );
       case Ist_Dirty:
          di = st->Ist.Dirty.details;
-         if (!isIRAtom(di->guard)) 
+         if (!isIRAtom(di->guard))
             return False;
          for (i = 0; di->args[i]; i++)
-            if (!isIRAtom_or_VECRET_or_BBPTR(di->args[i])) 
+            if (!isIRAtom_or_VECRET_or_BBPTR(di->args[i]))
                return False;
-         if (di->mAddr && !isIRAtom(di->mAddr)) 
+         if (di->mAddr && !isIRAtom(di->mAddr))
             return False;
          return True;
       case Ist_NoOp:
@@ -3766,9 +3786,9 @@ static Bool saneIRCallee ( IRCallee* cee )
 static Bool saneIRConst ( IRConst* con )
 {
    switch (con->tag) {
-      case Ico_U1: 
+      case Ico_U1:
          return toBool( con->Ico.U1 == True || con->Ico.U1 == False );
-      default: 
+      default:
          /* Is there anything we can meaningfully check?  I don't
             think so. */
          return True;
@@ -3793,7 +3813,7 @@ void useBeforeDef_Expr ( IRSB* bb, IRStmt* stmt, IRExpr* expr, Int* def_counts )
 {
    Int i;
    switch (expr->tag) {
-      case Iex_Get: 
+      case Iex_Get:
          break;
       case Iex_GetI:
          useBeforeDef_Expr(bb,stmt,expr->Iex.GetI.ix,def_counts);
@@ -3932,7 +3952,7 @@ void useBeforeDef_Stmt ( IRSB* bb, IRStmt* stmt, Int* def_counts )
       case Ist_Flush:
          useBeforeDef_Expr(bb,stmt,stmt->Ist.Flush.addr,def_counts);
          break;
-      default: 
+      default:
          vpanic("useBeforeDef_Stmt");
    }
 }
@@ -3961,9 +3981,9 @@ void tcExpr ( IRSB* bb, IRStmt* stmt, IRExpr* expr, IRType gWordTy )
          tcExpr(bb,stmt, qop->arg2, gWordTy );
          tcExpr(bb,stmt, qop->arg3, gWordTy );
          tcExpr(bb,stmt, qop->arg4, gWordTy );
-         typeOfPrimop(qop->op, 
+         typeOfPrimop(qop->op,
                       &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
-         if (t_arg1 == Ity_INVALID || t_arg2 == Ity_INVALID 
+         if (t_arg1 == Ity_INVALID || t_arg2 == Ity_INVALID
              || t_arg3 == Ity_INVALID || t_arg4 == Ity_INVALID) {
             vex_printf(" op name: " );
             ppIROp(qop->op);
@@ -3976,7 +3996,7 @@ void tcExpr ( IRSB* bb, IRStmt* stmt, IRExpr* expr, IRType gWordTy )
          ttarg2 = typeOfIRExpr(tyenv, qop->arg2);
          ttarg3 = typeOfIRExpr(tyenv, qop->arg3);
          ttarg4 = typeOfIRExpr(tyenv, qop->arg4);
-         if (t_arg1 != ttarg1 || t_arg2 != ttarg2 
+         if (t_arg1 != ttarg1 || t_arg2 != ttarg2
              || t_arg3 != ttarg3 || t_arg4 != ttarg4) {
             vex_printf(" op name: ");
             ppIROp(qop->op);
@@ -4012,9 +4032,9 @@ void tcExpr ( IRSB* bb, IRStmt* stmt, IRExpr* expr, IRType gWordTy )
          tcExpr(bb,stmt, triop->arg1, gWordTy );
          tcExpr(bb,stmt, triop->arg2, gWordTy );
          tcExpr(bb,stmt, triop->arg3, gWordTy );
-         typeOfPrimop(triop->op, 
+         typeOfPrimop(triop->op,
                       &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
-         if (t_arg1 == Ity_INVALID || t_arg2 == Ity_INVALID 
+         if (t_arg1 == Ity_INVALID || t_arg2 == Ity_INVALID
              || t_arg3 == Ity_INVALID || t_arg4 != Ity_INVALID) {
             vex_printf(" op name: " );
             ppIROp(triop->op);
@@ -4055,9 +4075,9 @@ void tcExpr ( IRSB* bb, IRStmt* stmt, IRExpr* expr, IRType gWordTy )
          IRType ttarg1, ttarg2;
          tcExpr(bb,stmt, expr->Iex.Binop.arg1, gWordTy );
          tcExpr(bb,stmt, expr->Iex.Binop.arg2, gWordTy );
-         typeOfPrimop(expr->Iex.Binop.op, 
+         typeOfPrimop(expr->Iex.Binop.op,
                       &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
-         if (t_arg1 == Ity_INVALID || t_arg2 == Ity_INVALID 
+         if (t_arg1 == Ity_INVALID || t_arg2 == Ity_INVALID
              || t_arg3 != Ity_INVALID || t_arg4 != Ity_INVALID) {
             vex_printf(" op name: " );
             ppIROp(expr->Iex.Binop.op);
@@ -4091,7 +4111,7 @@ void tcExpr ( IRSB* bb, IRStmt* stmt, IRExpr* expr, IRType gWordTy )
       }
       case Iex_Unop:
          tcExpr(bb,stmt, expr->Iex.Unop.arg, gWordTy );
-         typeOfPrimop(expr->Iex.Unop.op, 
+         typeOfPrimop(expr->Iex.Unop.op,
                       &t_dst, &t_arg1, &t_arg2, &t_arg3, &t_arg4);
          if (t_arg1 == Ity_INVALID || t_arg2 != Ity_INVALID
              || t_arg3 != Ity_INVALID || t_arg4 != Ity_INVALID)
@@ -4109,7 +4129,7 @@ void tcExpr ( IRSB* bb, IRStmt* stmt, IRExpr* expr, IRType gWordTy )
       case Iex_CCall:
          if (!saneIRCallee(expr->Iex.CCall.cee))
             sanityCheckFail(bb,stmt,"Iex.CCall.cee: bad IRCallee");
-         if (expr->Iex.CCall.cee->regparms > countArgs(expr->Iex.CCall.args)) 
+         if (expr->Iex.CCall.cee->regparms > countArgs(expr->Iex.CCall.args))
             sanityCheckFail(bb,stmt,"Iex.CCall.cee: #regparms > #args");
          for (i = 0; expr->Iex.CCall.args[i]; i++) {
             if (i >= 32)
@@ -4139,7 +4159,7 @@ void tcExpr ( IRSB* bb, IRStmt* stmt, IRExpr* expr, IRType gWordTy )
              != typeOfIRExpr(tyenv, expr->Iex.ITE.iffalse))
             sanityCheckFail(bb,stmt,"Iex.ITE: iftrue/iffalse mismatch");
          break;
-      default: 
+      default:
          vpanic("tcExpr");
    }
 }
@@ -4182,7 +4202,7 @@ void tcStmt ( IRSB* bb, IRStmt* stmt, IRType gWordTy )
          tcExpr( bb, stmt, puti->ix, gWordTy );
          if (typeOfIRExpr(tyenv,puti->data) == Ity_I1)
             sanityCheckFail(bb,stmt,"IRStmt.PutI.data: cannot PutI :: Ity_I1");
-         if (typeOfIRExpr(tyenv,puti->data) 
+         if (typeOfIRExpr(tyenv,puti->data)
              != puti->descr->elemTy)
             sanityCheckFail(bb,stmt,"IRStmt.PutI.data: data ty != elem ty");
          if (typeOfIRExpr(tyenv,puti->ix) != Ity_I32)
@@ -4245,12 +4265,12 @@ void tcStmt ( IRSB* bb, IRStmt* stmt, IRType gWordTy )
       case Ist_CAS:
          cas = stmt->Ist.CAS.details;
          /* make sure it's definitely either a CAS or a DCAS */
-         if (cas->oldHi == IRTemp_INVALID 
+         if (cas->oldHi == IRTemp_INVALID
              && cas->expdHi == NULL && cas->dataHi == NULL) {
             /* fine; it's a single cas */
          }
          else
-         if (cas->oldHi != IRTemp_INVALID 
+         if (cas->oldHi != IRTemp_INVALID
              && cas->expdHi != NULL && cas->dataHi != NULL) {
             /* fine; it's a double cas */
          }
@@ -4410,6 +4430,7 @@ void tcStmt ( IRSB* bb, IRStmt* stmt, IRType gWordTy )
       case Ist_MBE:
          switch (stmt->Ist.MBE.event) {
             case Imbe_Fence: case Imbe_CancelReservation: case Imbe_Drain:
+            case Imbe_SFence: case Imbe_LFence:
                break;
             default: sanityCheckFail(bb,stmt,"IRStmt.MBE.event: unknown");
                break;
@@ -4498,32 +4519,32 @@ void sanityCheckIRSB ( IRSB* bb,          const HChar* caller,
       switch (stmt->tag) {
       case Ist_WrTmp:
          if (stmt->Ist.WrTmp.tmp < 0 || stmt->Ist.WrTmp.tmp >= n_temps)
-            sanityCheckFail(bb, stmt, 
+            sanityCheckFail(bb, stmt,
                "IRStmt.Tmp: destination tmp is out of range");
          def_counts[stmt->Ist.WrTmp.tmp]++;
          if (def_counts[stmt->Ist.WrTmp.tmp] > 1)
-            sanityCheckFail(bb, stmt, 
+            sanityCheckFail(bb, stmt,
                "IRStmt.Tmp: destination tmp is assigned more than once");
          break;
       case Ist_LoadG:
          lg = stmt->Ist.LoadG.details;
          if (lg->dst < 0 || lg->dst >= n_temps)
-             sanityCheckFail(bb, stmt, 
+             sanityCheckFail(bb, stmt,
                 "IRStmt.LoadG: destination tmp is out of range");
          def_counts[lg->dst]++;
          if (def_counts[lg->dst] > 1)
-             sanityCheckFail(bb, stmt, 
+             sanityCheckFail(bb, stmt,
                 "IRStmt.LoadG: destination tmp is assigned more than once");
          break;
       case Ist_Dirty:
          d = stmt->Ist.Dirty.details;
          if (d->tmp != IRTemp_INVALID) {
             if (d->tmp < 0 || d->tmp >= n_temps)
-               sanityCheckFail(bb, stmt, 
+               sanityCheckFail(bb, stmt,
                   "IRStmt.Dirty: destination tmp is out of range");
             def_counts[d->tmp]++;
             if (def_counts[d->tmp] > 1)
-               sanityCheckFail(bb, stmt, 
+               sanityCheckFail(bb, stmt,
                   "IRStmt.Dirty: destination tmp is assigned more than once");
          }
          break;
@@ -4531,19 +4552,19 @@ void sanityCheckIRSB ( IRSB* bb,          const HChar* caller,
          cas = stmt->Ist.CAS.details;
          if (cas->oldHi != IRTemp_INVALID) {
             if (cas->oldHi < 0 || cas->oldHi >= n_temps)
-                sanityCheckFail(bb, stmt, 
+                sanityCheckFail(bb, stmt,
                    "IRStmt.CAS: destination tmpHi is out of range");
              def_counts[cas->oldHi]++;
              if (def_counts[cas->oldHi] > 1)
-                sanityCheckFail(bb, stmt, 
+                sanityCheckFail(bb, stmt,
                    "IRStmt.CAS: destination tmpHi is assigned more than once");
          }
          if (cas->oldLo < 0 || cas->oldLo >= n_temps)
-            sanityCheckFail(bb, stmt, 
+            sanityCheckFail(bb, stmt,
                "IRStmt.CAS: destination tmpLo is out of range");
          def_counts[cas->oldLo]++;
          if (def_counts[cas->oldLo] > 1)
-            sanityCheckFail(bb, stmt, 
+            sanityCheckFail(bb, stmt,
                "IRStmt.CAS: destination tmpLo is assigned more than once");
          break;
       case Ist_LLSC:
@@ -4600,7 +4621,7 @@ Bool eqIRConst ( IRConst* c1, IRConst* c2 )
 
 Bool eqIRRegArray ( IRRegArray* descr1, IRRegArray* descr2 )
 {
-   return toBool( descr1->base == descr2->base 
+   return toBool( descr1->base == descr2->base
                   && descr1->elemTy == descr2->elemTy
                   && descr1->nElems == descr2->nElems );
 }
@@ -4647,8 +4668,8 @@ IRExpr* mkIRExpr_HWord ( HWord hw )
    vpanic("mkIRExpr_HWord");
 }
 
-IRDirty* unsafeIRDirty_0_N ( Int regparms, const HChar* name, void* addr, 
-                             IRExpr** args ) 
+IRDirty* unsafeIRDirty_0_N ( Int regparms, const HChar* name, void* addr,
+                             IRExpr** args )
 {
    IRDirty* d = emptyIRDirty();
    d->cee   = mkIRCallee ( regparms, name, addr );
@@ -4657,9 +4678,9 @@ IRDirty* unsafeIRDirty_0_N ( Int regparms, const HChar* name, void* addr,
    return d;
 }
 
-IRDirty* unsafeIRDirty_1_N ( IRTemp dst, 
-                             Int regparms, const HChar* name, void* addr, 
-                             IRExpr** args ) 
+IRDirty* unsafeIRDirty_1_N ( IRTemp dst,
+                             Int regparms, const HChar* name, void* addr,
+                             IRExpr** args )
 {
    IRDirty* d = emptyIRDirty();
    d->cee   = mkIRCallee ( regparms, name, addr );
@@ -4670,10 +4691,10 @@ IRDirty* unsafeIRDirty_1_N ( IRTemp dst,
 }
 
 IRExpr* mkIRExprCCall ( IRType retty,
-                        Int regparms, const HChar* name, void* addr, 
+                        Int regparms, const HChar* name, void* addr,
                         IRExpr** args )
 {
-   return IRExpr_CCall ( mkIRCallee ( regparms, name, addr ), 
+   return IRExpr_CCall ( mkIRCallee ( regparms, name, addr ),
                          retty, args );
 }
 

--- a/VEX/priv/ir_opt.c
+++ b/VEX/priv/ir_opt.c
@@ -514,7 +514,7 @@ static void flatten_Stmt ( IRSB* bb, IRStmt* st )
          break;
       case Ist_Flush:
          e1 = flatten_Expr(bb, st->Ist.Flush.addr);
-         addStmtToIRSB(bb, IRStmt_Flush(e1));
+         addStmtToIRSB(bb, IRStmt_Flush(e1, st->Ist.Flush.fk));
          break;
       default:
          vex_printf("\n");
@@ -2729,7 +2729,8 @@ static IRStmt* subst_and_fold_Stmt ( IRExpr** env, IRStmt* st )
       case Ist_Flush:
          vassert(isIRAtom(st->Ist.Flush.addr));
          return IRStmt_Flush(
-                   fold_Expr(env, subst_Expr(env, st->Ist.Flush.addr))
+                   fold_Expr(env, subst_Expr(env, st->Ist.Flush.addr)),
+                   st->Ist.Flush.fk
                 );
 
    default:
@@ -5537,7 +5538,8 @@ static IRStmt* atbSubst_Stmt ( ATmpInfo* env, IRStmt* st )
 
       case Ist_Flush:
          return IRStmt_Flush(
-                   atbSubst_Expr(env, st->Ist.Flush.addr)
+                   atbSubst_Expr(env, st->Ist.Flush.addr),
+                   st->Ist.Flush.fk
                 );
 
       default: 

--- a/VEX/pub/libvex_ir.h
+++ b/VEX/pub/libvex_ir.h
@@ -2410,7 +2410,13 @@ typedef
          back end, just as LL and SC themselves are. */
       Imbe_CancelReservation,
       /* Needed only on amd64.  It drains the iMC cache. */
-      Imbe_Drain
+      Imbe_Drain,
+      /* Might be interesting for some kinds of tools */
+      /* XXX it would probably be a good idea to add a new fence kind to the
+       MBE statement, this however needs a lot of changes - to be considered
+       in the long run.*/
+      Imbe_SFence,
+      Imbe_LFence
    }
    IRMBusEvent;
 
@@ -2522,6 +2528,20 @@ extern IRPutI* mkIRPutI ( IRRegArray* descr, IRExpr* ix,
 
 extern IRPutI* deepCopyIRPutI ( IRPutI* );
 
+/* --------------- Flush operations --------------- */
+
+/* For some analysis tools, the type of flush operation is important. This is
+   what this enum is for.
+ */
+typedef
+   enum {
+      Ifk_flush = 0,        /* normal CLFLUSH */
+      Ifk_flushopt,         /* CLFLUSHOPT */
+      Ifk_clwb,             /* CLWB */
+
+   } IRFlushKind;
+
+void ppIRFlushEvent ( IRFlushKind flush_kind, IRExpr* e );
 
 /* --------------- Guarded loads and stores --------------- */
 
@@ -2876,7 +2896,8 @@ typedef
             ppIRStmt output: FLUSH(<addr>), eg. FLUSH(t1)
          */
          struct {
-            IRExpr*   addr;     /* flush address */
+            IRExpr*     addr;       /* flush address */
+            IRFlushKind  fk;        /* flush kind */
          } Flush;
        } Ist;
    }
@@ -2899,7 +2920,7 @@ extern IRStmt* IRStmt_LLSC    ( IREndness end, IRTemp result,
                                 IRExpr* addr, IRExpr* storedata );
 extern IRStmt* IRStmt_Dirty   ( IRDirty* details );
 extern IRStmt* IRStmt_MBE     ( IRMBusEvent event );
-extern IRStmt* IRStmt_Flush   ( IRExpr* addr );
+extern IRStmt* IRStmt_Flush   ( IRExpr* addr, IRFlushKind fk );
 extern IRStmt* IRStmt_Exit    ( IRExpr* guard, IRJumpKind jk, IRConst* dst,
                                 Int offsIP );
 

--- a/cachegrind/cg_main.c
+++ b/cachegrind/cg_main.c
@@ -219,7 +219,7 @@ static void get_debug_info(Addr instr_addr, HChar file[FILE_LEN],
    HChar dir[FILE_LEN];
    Bool found_dirname;
    Bool found_file_line = VG_(get_filename_linenum)(
-                             instr_addr, 
+                             instr_addr,
                              file, FILE_LEN,
                              dir,  FILE_LEN, &found_dirname,
                              line
@@ -241,7 +241,7 @@ static void get_debug_info(Addr instr_addr, HChar file[FILE_LEN],
       VG_(strcat)(dir, file);    // Append file to dir
       VG_(strcpy)(file, dir);    // Move dir+file to file
    }
-   
+
    if (found_file_line) {
       if (found_fn) full_debugs++;
       else          file_line_debugs++;
@@ -399,7 +399,7 @@ void log_1IrNoX_1Dr_cache_access(InstrInfo* n, Addr data_addr, Word data_size)
 			 &n->parent->Ir.m1, &n->parent->Ir.mL);
    n->parent->Ir.a++;
 
-   cachesim_D1_doref(data_addr, data_size, 
+   cachesim_D1_doref(data_addr, data_size,
                      &n->parent->Dr.m1, &n->parent->Dr.mL);
    n->parent->Dr.a++;
 }
@@ -414,7 +414,7 @@ void log_1IrNoX_1Dw_cache_access(InstrInfo* n, Addr data_addr, Word data_size)
 			 &n->parent->Ir.m1, &n->parent->Ir.mL);
    n->parent->Ir.a++;
 
-   cachesim_D1_doref(data_addr, data_size, 
+   cachesim_D1_doref(data_addr, data_size,
                      &n->parent->Dw.m1, &n->parent->Dw.mL);
    n->parent->Dw.a++;
 }
@@ -427,7 +427,7 @@ void log_0Ir_1Dr_cache_access(InstrInfo* n, Addr data_addr, Word data_size)
 {
    //VG_(printf)("0Ir_1Dr:  CCaddr=0x%010lx,  daddr=0x%010lx,  dsize=%lu\n",
    //            n, data_addr, data_size);
-   cachesim_D1_doref(data_addr, data_size, 
+   cachesim_D1_doref(data_addr, data_size,
                      &n->parent->Dr.m1, &n->parent->Dr.mL);
    n->parent->Dr.a++;
 }
@@ -438,7 +438,7 @@ void log_0Ir_1Dw_cache_access(InstrInfo* n, Addr data_addr, Word data_size)
 {
    //VG_(printf)("0Ir_1Dw:  CCaddr=0x%010lx,  daddr=0x%010lx,  dsize=%lu\n",
    //            n, data_addr, data_size);
-   cachesim_D1_doref(data_addr, data_size, 
+   cachesim_D1_doref(data_addr, data_size,
                      &n->parent->Dw.m1, &n->parent->Dw.mL);
    n->parent->Dw.a++;
 }
@@ -454,7 +454,7 @@ void log_cond_branch(InstrInfo* n, Word taken)
    //VG_(printf)("cbrnch:  CCaddr=0x%010lx,  taken=0x%010lx\n",
    //             n, taken);
    n->parent->Bc.b++;
-   n->parent->Bc.mp 
+   n->parent->Bc.mp
       += (1 & do_cond_branch_predict(n->instr_addr, taken));
 }
 
@@ -503,11 +503,11 @@ void log_ind_branch(InstrInfo* n, UWord actual_dst)
    events with a single helper call.  */
 
 typedef
-   IRExpr 
+   IRExpr
    IRAtom;
 
-typedef 
-   enum { 
+typedef
+   enum {
       Ev_IrNoX,  // Instruction read not crossing cache lines
       Ev_IrGen,  // Generic Ir, not being detected as IrNoX
       Ev_Dr,     // Data read
@@ -629,7 +629,7 @@ SB_info* get_SB_info(IRSB* sbIn, Addr origAddr)
    // BB never translated before (at this address, at least;  could have
    // been unloaded and then reloaded elsewhere in memory)
    sbInfo = VG_(OSetGen_AllocNode)(instrInfoTable,
-                                sizeof(SB_info) + n_instrs*sizeof(InstrInfo)); 
+                                sizeof(SB_info) + n_instrs*sizeof(InstrInfo));
    sbInfo->SB_addr  = origAddr;
    sbInfo->n_instrs = n_instrs;
    VG_(OSetGen_Insert)( instrInfoTable, sbInfo );
@@ -649,30 +649,30 @@ static void showEvent ( Event* ev )
          break;
       case Ev_Dr:
          VG_(printf)("Dr %p %d EA=", ev->inode, ev->Ev.Dr.szB);
-         ppIRExpr(ev->Ev.Dr.ea); 
+         ppIRExpr(ev->Ev.Dr.ea);
          VG_(printf)("\n");
          break;
       case Ev_Dw:
          VG_(printf)("Dw %p %d EA=", ev->inode, ev->Ev.Dw.szB);
-         ppIRExpr(ev->Ev.Dw.ea); 
+         ppIRExpr(ev->Ev.Dw.ea);
          VG_(printf)("\n");
          break;
       case Ev_Dm:
          VG_(printf)("Dm %p %d EA=", ev->inode, ev->Ev.Dm.szB);
-         ppIRExpr(ev->Ev.Dm.ea); 
+         ppIRExpr(ev->Ev.Dm.ea);
          VG_(printf)("\n");
          break;
       case Ev_Bc:
          VG_(printf)("Bc %p   GA=", ev->inode);
-         ppIRExpr(ev->Ev.Bc.taken); 
+         ppIRExpr(ev->Ev.Bc.taken);
          VG_(printf)("\n");
          break;
       case Ev_Bi:
          VG_(printf)("Bi %p  DST=", ev->inode);
-         ppIRExpr(ev->Ev.Bi.dst); 
+         ppIRExpr(ev->Ev.Bi.dst);
          VG_(printf)("\n");
          break;
-      default: 
+      default:
          tl_assert(0);
          break;
    }
@@ -725,9 +725,9 @@ static void flushEvents ( CgState* cgs )
       ev  = &cgs->events[i];
       ev2 = ( i < cgs->events_used-1 ? &cgs->events[i+1] : NULL );
       ev3 = ( i < cgs->events_used-2 ? &cgs->events[i+2] : NULL );
-      
+
       if (DEBUG_CG) {
-         VG_(printf)("   flush "); 
+         VG_(printf)("   flush ");
          showEvent( ev );
       }
 
@@ -779,8 +779,8 @@ static void flushEvents ( CgState* cgs )
                   helperName = "log_3Ir";
                   helperAddr = &log_3Ir;
                }
-               argv = mkIRExprVec_3( i_node_expr, 
-                                     mkIRExpr_HWord( (HWord)ev2->inode ), 
+               argv = mkIRExprVec_3( i_node_expr,
+                                     mkIRExpr_HWord( (HWord)ev2->inode ),
                                      mkIRExpr_HWord( (HWord)ev3->inode ) );
                regparms = 3;
                i += 3;
@@ -831,8 +831,8 @@ static void flushEvents ( CgState* cgs )
             /* Data read or modify */
             helperName = "log_0Ir_1Dr_cache_access";
             helperAddr = &log_0Ir_1Dr_cache_access;
-            argv = mkIRExprVec_3( i_node_expr, 
-                                  get_Event_dea(ev), 
+            argv = mkIRExprVec_3( i_node_expr,
+                                  get_Event_dea(ev),
                                   mkIRExpr_HWord( get_Event_dszB(ev) ) );
             regparms = 3;
             i++;
@@ -842,7 +842,7 @@ static void flushEvents ( CgState* cgs )
             helperName = "log_0Ir_1Dw_cache_access";
             helperAddr = &log_0Ir_1Dw_cache_access;
             argv = mkIRExprVec_3( i_node_expr,
-                                  get_Event_dea(ev), 
+                                  get_Event_dea(ev),
                                   mkIRExpr_HWord( get_Event_dszB(ev) ) );
             regparms = 3;
             i++;
@@ -871,8 +871,8 @@ static void flushEvents ( CgState* cgs )
       tl_assert(helperName);
       tl_assert(helperAddr);
       tl_assert(argv);
-      di = unsafeIRDirty_0_N( regparms, 
-                              helperName, VG_(fnptr_to_fnentry)( helperAddr ), 
+      di = unsafeIRDirty_0_N( regparms,
+                              helperName, VG_(fnptr_to_fnentry)( helperAddr ),
                               argv );
       addStmtToIRSB( cgs->sbOut, IRStmt_Dirty(di) );
    }
@@ -994,8 +994,8 @@ void addEvent_D_guarded ( CgState* cgs, InstrInfo* inode,
                                 ea, mkIRExpr_HWord( datasize ) );
    regparms    = 3;
    di          = unsafeIRDirty_0_N(
-                    regparms, 
-                    helperName, VG_(fnptr_to_fnentry)( helperAddr ), 
+                    regparms,
+                    helperName, VG_(fnptr_to_fnentry)( helperAddr ),
                     argv );
    di->guard = guard;
    addStmtToIRSB( cgs->sbOut, IRStmt_Dirty(di) );
@@ -1007,7 +1007,7 @@ void addEvent_Bc ( CgState* cgs, InstrInfo* inode, IRAtom* guard )
 {
    Event* evt;
    tl_assert(isIRAtom(guard));
-   tl_assert(typeOfIRExpr(cgs->sbOut->tyenv, guard) 
+   tl_assert(typeOfIRExpr(cgs->sbOut->tyenv, guard)
              == (sizeof(HWord)==4 ? Ity_I32 : Ity_I64));
    if (!clo_branch_sim)
       return;
@@ -1027,7 +1027,7 @@ void addEvent_Bi ( CgState* cgs, InstrInfo* inode, IRAtom* whereTo )
 {
    Event* evt;
    tl_assert(isIRAtom(whereTo));
-   tl_assert(typeOfIRExpr(cgs->sbOut->tyenv, whereTo) 
+   tl_assert(typeOfIRExpr(cgs->sbOut->tyenv, whereTo)
              == (sizeof(HWord)==4 ? Ity_I32 : Ity_I64));
    if (!clo_branch_sim)
       return;
@@ -1047,8 +1047,8 @@ void addEvent_Bi ( CgState* cgs, InstrInfo* inode, IRAtom* whereTo )
 
 static
 IRSB* cg_instrument ( VgCallbackClosure* closure,
-                      IRSB* sbIn, 
-                      VexGuestLayout* layout, 
+                      IRSB* sbIn,
+                      VexGuestLayout* layout,
                       VexGuestExtents* vge,
                       VexArchInfo* archinfo_host,
                       IRType gWordTy, IRType hWordTy )
@@ -1109,6 +1109,7 @@ IRSB* cg_instrument ( VgCallbackClosure* closure,
          case Ist_Put:
          case Ist_PutI:
          case Ist_MBE:
+         case Ist_Flush:
             break;
 
          case Ist_IMark:
@@ -1124,7 +1125,7 @@ IRSB* cg_instrument ( VgCallbackClosure* closure,
                      || VG_CLREQ_SZB == isize );
 
             // Get space for and init the inode, record it as the current one.
-            // Subsequent Dr/Dw/Dm events from the same instruction will 
+            // Subsequent Dr/Dw/Dm events from the same instruction will
             // also use it.
             curr_inode = setup_InstrInfo(&cgs, cia, isize);
 
@@ -1137,7 +1138,7 @@ IRSB* cg_instrument ( VgCallbackClosure* closure,
                IRExpr* aexpr = data->Iex.Load.addr;
                // Note also, endianness info is ignored.  I guess
                // that's not interesting.
-               addEvent_Dr( &cgs, curr_inode, sizeofIRType(data->Iex.Load.ty), 
+               addEvent_Dr( &cgs, curr_inode, sizeofIRType(data->Iex.Load.ty),
                                   aexpr );
             }
             break;
@@ -1146,7 +1147,7 @@ IRSB* cg_instrument ( VgCallbackClosure* closure,
          case Ist_Store: {
             IRExpr* data  = st->Ist.Store.data;
             IRExpr* aexpr = st->Ist.Store.addr;
-            addEvent_Dw( &cgs, curr_inode, 
+            addEvent_Dw( &cgs, curr_inode,
                          sizeofIRType(typeOfIRExpr(tyenv, data)), aexpr );
             break;
          }
@@ -1328,9 +1329,9 @@ IRSB* cg_instrument ( VgCallbackClosure* closure,
    if ((sbIn->jumpkind == Ijk_Boring) || (sbIn->jumpkind == Ijk_Call)) {
       if (0) { ppIRExpr( sbIn->next ); VG_(printf)("\n"); }
       switch (sbIn->next->tag) {
-         case Iex_Const: 
+         case Iex_Const:
             break; /* boring - branch to known address */
-         case Iex_RdTmp: 
+         case Iex_RdTmp:
             /* looks like an indirect branch (branch to unknown) */
             addEvent_Bi( &cgs, curr_inode, sbIn->next );
             break;
@@ -1338,7 +1339,7 @@ IRSB* cg_instrument ( VgCallbackClosure* closure,
             /* shouldn't happen - if the incoming IR is properly
                flattened, should only have tmp and const cases to
                consider. */
-            tl_assert(0); 
+            tl_assert(0);
       }
    }
 
@@ -1422,7 +1423,7 @@ static void fprint_CC_table_and_calc_totals(void)
    VG_(strcpy)(buf, "cmd:");
    VG_(write)(fd, (void*)buf, VG_(strlen)(buf));
    VG_(write)(fd, " ", 1);
-   VG_(write)(fd, VG_(args_the_exename), 
+   VG_(write)(fd, VG_(args_the_exename),
               VG_(strlen)( VG_(args_the_exename) ));
    for (i = 0; i < VG_(sizeXA)( VG_(args_for_client) ); i++) {
       HChar* arg = * (HChar**) VG_(indexXA)( VG_(args_for_client), i );
@@ -1484,10 +1485,10 @@ static void fprint_CC_table_and_calc_totals(void)
                              " %llu %llu %llu"
                              " %llu %llu %llu %llu\n",
                             lineCC->loc.line,
-                            lineCC->Ir.a, lineCC->Ir.m1, lineCC->Ir.mL, 
+                            lineCC->Ir.a, lineCC->Ir.m1, lineCC->Ir.mL,
                             lineCC->Dr.a, lineCC->Dr.m1, lineCC->Dr.mL,
                             lineCC->Dw.a, lineCC->Dw.m1, lineCC->Dw.mL,
-                            lineCC->Bc.b, lineCC->Bc.mp, 
+                            lineCC->Bc.b, lineCC->Bc.mp,
                             lineCC->Bi.b, lineCC->Bi.mp);
       }
       else if (clo_cache_sim && !clo_branch_sim) {
@@ -1495,7 +1496,7 @@ static void fprint_CC_table_and_calc_totals(void)
                              " %llu %llu %llu"
                              " %llu %llu %llu\n",
                             lineCC->loc.line,
-                            lineCC->Ir.a, lineCC->Ir.m1, lineCC->Ir.mL, 
+                            lineCC->Ir.a, lineCC->Ir.m1, lineCC->Ir.mL,
                             lineCC->Dr.a, lineCC->Dr.m1, lineCC->Dr.mL,
                             lineCC->Dw.a, lineCC->Dw.m1, lineCC->Dw.mL);
       }
@@ -1503,8 +1504,8 @@ static void fprint_CC_table_and_calc_totals(void)
          VG_(sprintf)(buf, "%u %llu"
                              " %llu %llu %llu %llu\n",
                             lineCC->loc.line,
-                            lineCC->Ir.a, 
-                            lineCC->Bc.b, lineCC->Bc.mp, 
+                            lineCC->Ir.a,
+                            lineCC->Bc.b, lineCC->Bc.mp,
                             lineCC->Bi.b, lineCC->Bi.mp);
       }
       else {
@@ -1540,11 +1541,11 @@ static void fprint_CC_table_and_calc_totals(void)
                         " %llu %llu %llu"
                         " %llu %llu %llu"
                         " %llu %llu %llu"
-                        " %llu %llu %llu %llu\n", 
+                        " %llu %llu %llu %llu\n",
                         Ir_total.a, Ir_total.m1, Ir_total.mL,
                         Dr_total.a, Dr_total.m1, Dr_total.mL,
                         Dw_total.a, Dw_total.m1, Dw_total.mL,
-                        Bc_total.b, Bc_total.mp, 
+                        Bc_total.b, Bc_total.mp,
                         Bi_total.b, Bi_total.mp);
    }
    else if (clo_cache_sim && !clo_branch_sim) {
@@ -1559,14 +1560,14 @@ static void fprint_CC_table_and_calc_totals(void)
    else if (!clo_cache_sim && clo_branch_sim) {
       VG_(sprintf)(buf, "summary:"
                         " %llu"
-                        " %llu %llu %llu %llu\n", 
+                        " %llu %llu %llu %llu\n",
                         Ir_total.a,
-                        Bc_total.b, Bc_total.mp, 
+                        Bc_total.b, Bc_total.mp,
                         Bi_total.b, Bi_total.mp);
    }
    else {
       VG_(sprintf)(buf, "summary:"
-                        " %llu\n", 
+                        " %llu\n",
                         Ir_total.a);
    }
 
@@ -1598,7 +1599,7 @@ static void cg_fini(Int exitcode)
 
    fprint_CC_table_and_calc_totals();
 
-   if (VG_(clo_verbosity) == 0) 
+   if (VG_(clo_verbosity) == 0)
       return;
 
    // Nb: this isn't called "MAX" because that overshadows a global on Darwin.
@@ -1640,7 +1641,7 @@ static void cg_fini(Int exitcode)
       VG_(sprintf)(fmt, "%%s %%,%dllu  (%%,%dllu rd   + %%,%dllu wr)\n",
                         l1, l2, l3);
 
-      VG_(umsg)(fmt, "D   refs:     ", 
+      VG_(umsg)(fmt, "D   refs:     ",
                      D_total.a, Dr_total.a, Dw_total.a);
       VG_(umsg)(fmt, "D1  misses:   ",
                      D_total.m1, Dr_total.m1, Dw_total.m1);
@@ -1718,18 +1719,18 @@ static void cg_fini(Int exitcode)
       VG_(dmsg)("cachegrind: distinct instrs NoX: %d\n", distinct_instrsNoX);
       VG_(dmsg)("cachegrind: distinct instrs Gen: %d\n", distinct_instrsGen);
       VG_(dmsg)("cachegrind: debug lookups      : %d\n", debug_lookups);
-      
+
       VG_(percentify)(full_debugs,      debug_lookups, 1, 6, buf1);
       VG_(percentify)(file_line_debugs, debug_lookups, 1, 6, buf2);
       VG_(percentify)(fn_debugs,        debug_lookups, 1, 6, buf3);
       VG_(percentify)(no_debugs,        debug_lookups, 1, 6, buf4);
-      VG_(dmsg)("cachegrind: with full      info:%s (%d)\n", 
+      VG_(dmsg)("cachegrind: with full      info:%s (%d)\n",
                 buf1, full_debugs);
-      VG_(dmsg)("cachegrind: with file/line info:%s (%d)\n", 
+      VG_(dmsg)("cachegrind: with file/line info:%s (%d)\n",
                 buf2, file_line_debugs);
-      VG_(dmsg)("cachegrind: with fn name   info:%s (%d)\n", 
+      VG_(dmsg)("cachegrind: with fn name   info:%s (%d)\n",
                 buf3, fn_debugs);
-      VG_(dmsg)("cachegrind: with zero      info:%s (%d)\n", 
+      VG_(dmsg)("cachegrind: with zero      info:%s (%d)\n",
                 buf4, no_debugs);
 
       VG_(dmsg)("cachegrind: string table size: %lu\n",
@@ -1757,7 +1758,7 @@ void cg_discard_superblock_info ( Addr64 orig_addr64, VexGuestExtents vge )
    tl_assert(vge.n_used > 0);
 
    if (DEBUG_CG)
-      VG_(printf)( "discard_basic_block_info: %p, %p, %llu\n", 
+      VG_(printf)( "discard_basic_block_info: %p, %p, %llu\n",
                    (void*)(Addr)orig_addr,
                    (void*)(Addr)vge.base[0], (ULong)vge.len[0]);
 
@@ -1835,7 +1836,7 @@ static void cg_pre_clo_init(void)
 
 static void cg_post_clo_init(void)
 {
-   cache_t I1c, D1c, LLc; 
+   cache_t I1c, D1c, LLc;
 
    CC_table =
       VG_(OSetGen_Create)(offsetof(LineCC, loc),

--- a/drd/drd_load_store.c
+++ b/drd/drd_load_store.c
@@ -443,7 +443,7 @@ static void instr_trace_mem_store(IRSB* const bb, IRExpr* const addr_expr,
       } else if (size > sizeof(HWord) && !data_expr_hi
                  && ty_data_expr == Ity_I64) {
          IRTemp tmp;
-         
+
          tl_assert(sizeof(HWord) == 4);
          tl_assert(size == 8);
          tmp = newIRTemp(bb->tyenv, Ity_I32);
@@ -633,6 +633,9 @@ IRSB* DRD_(instrument)(VgCallbackClosure* const closure,
          switch (st->Ist.MBE.event)
          {
          case Imbe_Fence:
+         case Imbe_LFence:
+         case Imbe_SFence:
+         case Imbe_Drain:
             break; /* not interesting to DRD */
          case Imbe_CancelReservation:
             break; /* not interesting to DRD */
@@ -794,6 +797,7 @@ IRSB* DRD_(instrument)(VgCallbackClosure* const closure,
       case Ist_Put:
       case Ist_PutI:
       case Ist_Exit:
+      case Ist_Flush:
          /* None of these can contain any memory references. */
          addStmtToIRSB(bb, st);
          break;

--- a/exp-sgcheck/sg_main.c
+++ b/exp-sgcheck/sg_main.c
@@ -90,7 +90,7 @@ static void sg_free ( void* p ) {
    some of the comparisons were done signedly instead of
    unsignedly. */
 inline
-static Word cmp_nonempty_intervals ( Addr a1, SizeT n1, 
+static Word cmp_nonempty_intervals ( Addr a1, SizeT n1,
                                      Addr a2, SizeT n2 ) {
    UWord a1w = (UWord)a1;
    UWord n1w = (UWord)n1;
@@ -187,9 +187,9 @@ static Word StackBlock__cmp ( const StackBlock* fb1, const StackBlock* fb2 )
 
 /* Returns True if all fields except .szB are the same.  szBs may or
    may not be the same; they are simply not consulted. */
-static Bool StackBlock__all_fields_except_szB_are_equal ( 
+static Bool StackBlock__all_fields_except_szB_are_equal (
                StackBlock* fb1,
-               StackBlock* fb2 
+               StackBlock* fb2
             )
 {
    tl_assert(StackBlock__sane(fb1));
@@ -229,7 +229,7 @@ static void pp_StackBlocks ( XArray* sbs )
       VG_(message)(Vg_DebugMsg,
          "   StackBlock{ off %ld szB %lu spRel:%c isVec:%c \"%s\" }\n",
          sb->base, sb->szB, sb->spRel ? 'Y' : 'N',
-         sb->isVec ? 'Y' : 'N', &sb->name[0] 
+         sb->isVec ? 'Y' : 'N', &sb->name[0]
       );
    }
    VG_(message)(Vg_DebugMsg, ">>> STACKBLOCKS\n" );
@@ -245,7 +245,7 @@ static void init_StackBlocks_set ( void )
 {
    tl_assert(!frameBlocks_set);
    frameBlocks_set
-      = VG_(newFM)( sg_malloc, "di.sg_main.iSBs.1", sg_free, 
+      = VG_(newFM)( sg_malloc, "di.sg_main.iSBs.1", sg_free,
                     (Word(*)(UWord,UWord))StackBlocks__cmp );
    tl_assert(frameBlocks_set);
 }
@@ -421,7 +421,7 @@ static void init_GlobalBlock_set ( void )
 {
    tl_assert(!globalBlock_set);
     globalBlock_set
-       = VG_(newFM)( sg_malloc, "di.sg_main.iGBs.1", sg_free, 
+       = VG_(newFM)( sg_malloc, "di.sg_main.iGBs.1", sg_free,
                      (Word(*)(UWord,UWord))GlobalBlock__cmp );
    tl_assert(globalBlock_set);
 }
@@ -569,7 +569,7 @@ static void add_blocks_to_StackTree (
 }
 
 static void del_blocks_from_StackTree ( /*MOD*/WordFM* sitree,
-                                        XArray* /* Addr */ bases ) 
+                                        XArray* /* Addr */ bases )
 {
    UWord oldK, oldV;
    Word i, nBases = VG_(sizeXA)( bases );
@@ -616,7 +616,7 @@ static WordFM* new_StackTree ( void ) {
 //                                                          //
 //////////////////////////////////////////////////////////////
 
-/* A node in a global interval tree.  Zero length intervals 
+/* A node in a global interval tree.  Zero length intervals
    (.szB == 0) are not allowed.
 
    A global interval tree is a (WordFM GlobalTreeNode* void).  There
@@ -632,7 +632,7 @@ typedef
 
 static void GlobalTreeNode__pp ( GlobalTreeNode* nd ) {
    tl_assert(nd->descr);
-   VG_(printf)("GTNode [%#lx,+%ld) %s", 
+   VG_(printf)("GTNode [%#lx,+%ld) %s",
                nd->addr, nd->szB, nd->descr->name);
 }
 
@@ -843,7 +843,7 @@ typedef
 static void pp_Invar ( Invar* i )
 {
    switch (i->tag) {
-      case Inv_Unset: 
+      case Inv_Unset:
          VG_(printf)("Unset");
          break;
       case Inv_Unknown:
@@ -1068,7 +1068,7 @@ static void ourGlobals_init ( void )
       siTrees[i] = NULL;
    }
    invalidate_all_QCaches();
-   giTree = VG_(newFM)( sg_malloc, "di.sg_main.oGi.1", sg_free, 
+   giTree = VG_(newFM)( sg_malloc, "di.sg_main.oGi.1", sg_free,
                         (Word(*)(UWord,UWord))cmp_intervals_GlobalTreeNode );
 }
 
@@ -1092,7 +1092,7 @@ static void acquire_globals ( ULong di_handle )
    for (i = 0; i < n; i++) {
       GlobalBlock* gbp;
       GlobalBlock* gb = VG_(indexXA)( gbs, i );
-      if (0) VG_(printf)("   new Global size %2lu at %#lx:  %s %s\n", 
+      if (0) VG_(printf)("   new Global size %2lu at %#lx:  %s %s\n",
                          gb->szB, gb->addr, gb->soname, gb->name );
       tl_assert(gb->szB > 0);
       /* Make a persistent copy of each GlobalBlock, and add it
@@ -1302,7 +1302,7 @@ static void preen_global_Invars ( Addr a, SizeT len )
                continue; /* not in use */
             if (0) { pp_Invar(&ii->invar); VG_(printf)(" x\n"); }
             preen_global_Invar( &ii->invar, a, len );
-            xx++;           
+            xx++;
          }
          tl_assert(xx == frame->htab_used);
       }
@@ -1387,7 +1387,7 @@ static void resize_II_hash_table ( StackFrame* sf )
 
 __attribute__((noinline))
 static IInstance* find_or_create_IInstance_SLOW (
-                     StackFrame* sf, 
+                     StackFrame* sf,
                      Addr ip,
                      XArray* /* StackBlock */ ip_frameblocks
                   )
@@ -1405,7 +1405,7 @@ static IInstance* find_or_create_IInstance_SLOW (
       resize_II_hash_table(sf);
    }
    tl_assert(2 * sf->htab_used <= sf->htab_size);
-  
+
    ix = compute_II_hash(ip, sf->htab_size);
    i = sf->htab_size;
    while (1) {
@@ -1444,7 +1444,7 @@ static IInstance* find_or_create_IInstance_SLOW (
 
 inline
 static IInstance* find_or_create_IInstance (
-                     StackFrame* sf, 
+                     StackFrame* sf,
                      Addr ip,
                      XArray* /* StackBlock */ ip_frameblocks
                   )
@@ -1504,7 +1504,7 @@ static XArray* /* Addr */ calculate_StackBlock_EAs (
 /* Try to classify the block into which a memory access falls, and
    write the result in 'inv'.  This writes all relevant fields of
    'inv'. */
-__attribute__((noinline)) 
+__attribute__((noinline))
 static void classify_address ( /*OUT*/Invar* inv,
                                ThreadId tid,
                                Addr ea, Addr sp, Addr fp,
@@ -1514,7 +1514,7 @@ static void classify_address ( /*OUT*/Invar* inv,
    tl_assert(szB > 0);
    /* First, look in the stack blocks accessible in this instruction's
       frame. */
-   { 
+   {
      Word i, nBlocks = VG_(sizeXA)( thisInstrBlocks );
      if (nBlocks == 0) stats__t_i_b_empty++;
      for (i = 0; i < nBlocks; i++) {
@@ -1642,7 +1642,7 @@ static void classify_address ( /*OUT*/Invar* inv,
            gKey.szB  = szB;
            if (0) VG_(printf)("Tree sizes %ld %ld\n",
                               VG_(sizeFM)(siTrees[tid]), VG_(sizeFM)(giTree));
-           sOK = VG_(findBoundsFM)( siTrees[tid], 
+           sOK = VG_(findBoundsFM)( siTrees[tid],
                                     (UWord*)&sLB,    NULL/*unused*/,
                                     (UWord*)&sUB,    NULL/*unused*/,
                                     (UWord)&sNegInf, 0/*unused*/,
@@ -1758,7 +1758,7 @@ static void classify_address ( /*OUT*/Invar* inv,
 
 
 /* CALLED FROM GENERATED CODE */
-static 
+static
 VG_REGPARM(3)
 void helperc__mem_access ( /* Known only at run time: */
                            Addr ea, Addr sp, Addr fp,
@@ -1872,7 +1872,7 @@ void shadowStack_new_frame ( ThreadId tid,
          = calculate_StackBlock_EAs( descrs_at_call_insn,
                                      sp_at_call_insn, fp_at_call_insn );
       if (caller->blocks_added_by_call)
-         add_blocks_to_StackTree( siTrees[tid], 
+         add_blocks_to_StackTree( siTrees[tid],
                                   descrs_at_call_insn,
                                   caller->blocks_added_by_call,
                                   caller->depth /* stack depth at which
@@ -1886,7 +1886,7 @@ void shadowStack_new_frame ( ThreadId tid,
          if (sb) stats__max_sitree_size = s;
          if (gb) stats__max_gitree_size = g;
          if (0 && (sb || gb))
-            VG_(message)(Vg_DebugMsg, 
+            VG_(message)(Vg_DebugMsg,
                          "exp-sgcheck: new max tree sizes: "
                          "StackTree %ld, GlobalTree %ld\n",
                          stats__max_sitree_size, stats__max_gitree_size );
@@ -2041,7 +2041,7 @@ static void shadowStack_unwind ( ThreadId tid, Addr sp_now )
    - at each Call transfer, generate a call to shadowStack_new_frame
      do this by manually inspecting the IR
 
-   - at each sp change, if the sp change is negative, 
+   - at each sp change, if the sp change is negative,
      call shadowStack_unwind
      do this by asking for SP-change analysis
 
@@ -2115,7 +2115,7 @@ static IRTemp gen_Get_FP ( struct _SGEnv*  sge,
 }
 
 static void instrument_mem_access ( struct _SGEnv* sge,
-                                    IRSB*   bbOut, 
+                                    IRSB*   bbOut,
                                     IRExpr* addr,
                                     Int     szB,
                                     Bool    isStore,
@@ -2162,8 +2162,8 @@ static void instrument_mem_access ( struct _SGEnv* sge,
                          mkIRExpr_HWord( curr_IP ),
                          mkIRExpr_HWord( (HWord)frameBlocks ) );
      IRDirty* di
-        = unsafeIRDirty_0_N( 3/*regparms*/, 
-                             "helperc__mem_access", 
+        = unsafeIRDirty_0_N( 3/*regparms*/,
+                             "helperc__mem_access",
                             VG_(fnptr_to_fnentry)( &helperc__mem_access ),
                              args );
 
@@ -2196,7 +2196,7 @@ void sg_instrument_fini ( struct _SGEnv * env )
 /* Add instrumentation for 'st' to 'sbOut', and possibly modify 'env'
    as required.  This must be called before 'st' itself is added to
    'sbOut'. */
-void sg_instrument_IRStmt ( /*MOD*/struct _SGEnv * env, 
+void sg_instrument_IRStmt ( /*MOD*/struct _SGEnv * env,
                             /*MOD*/IRSB* sbOut,
                             IRStmt* st,
                             VexGuestLayout* layout,
@@ -2213,6 +2213,7 @@ void sg_instrument_IRStmt ( /*MOD*/struct _SGEnv * env,
       case Ist_Put:
       case Ist_PutI:
       case Ist_MBE:
+      case Ist_Flush:
          /* None of these can contain any memory references. */
          break;
 
@@ -2230,9 +2231,9 @@ void sg_instrument_IRStmt ( /*MOD*/struct _SGEnv * env,
       case Ist_Store:
          tl_assert(env->curr_IP_known);
          if (env->firstRef) {
-            instrument_mem_access( 
-               env, sbOut, 
-               st->Ist.Store.addr, 
+            instrument_mem_access(
+               env, sbOut,
+               st->Ist.Store.addr,
                sizeofIRType(typeOfIRExpr(sbOut->tyenv, st->Ist.Store.data)),
                True/*isStore*/,
                sizeofIRType(hWordTy),
@@ -2273,13 +2274,13 @@ void sg_instrument_IRStmt ( /*MOD*/struct _SGEnv * env,
                tl_assert(d->mSize != 0);
                dataSize = d->mSize;
                if (d->mFx == Ifx_Read || d->mFx == Ifx_Modify) {
-                  instrument_mem_access( 
+                  instrument_mem_access(
                      env, sbOut, d->mAddr, dataSize, False/*!isStore*/,
                      sizeofIRType(hWordTy), env->curr_IP, layout
                   );
                }
                if (d->mFx == Ifx_Write || d->mFx == Ifx_Modify) {
-                  instrument_mem_access( 
+                  instrument_mem_access(
                      env, sbOut, d->mAddr, dataSize, True/*isStore*/,
                      sizeofIRType(hWordTy), env->curr_IP, layout
                   );
@@ -2330,7 +2331,7 @@ void sg_instrument_IRStmt ( /*MOD*/struct _SGEnv * env,
 /* Add instrumentation for the final jump of an IRSB 'sbOut', and
    possibly modify 'env' as required.  This must be the last
    instrumentation statement in the block. */
-void sg_instrument_final_jump ( /*MOD*/struct _SGEnv * env, 
+void sg_instrument_final_jump ( /*MOD*/struct _SGEnv * env,
                                 /*MOD*/IRSB* sbOut,
                                 IRExpr* next,
                                 IRJumpKind jumpkind,
@@ -2358,7 +2359,7 @@ void sg_instrument_final_jump ( /*MOD*/struct _SGEnv * env,
       args
          = mkIRExprVec_5(
               IRExpr_RdTmp(sp_post_call_insn),
-              IRExpr_RdTmp(fp_post_call_insn), 
+              IRExpr_RdTmp(fp_post_call_insn),
                          /* assume the call doesn't change FP */
               next,
               mkIRExpr_HWord( (HWord)frameBlocks ),
@@ -2368,7 +2369,7 @@ void sg_instrument_final_jump ( /*MOD*/struct _SGEnv * env,
               3/*regparms*/,
               "helperc__new_frame",
               VG_(fnptr_to_fnentry)( &helperc__new_frame ),
-              args ); 
+              args );
       addStmtToIRSB( sbOut, IRStmt_Dirty(di) );
    }
 }
@@ -2530,13 +2531,13 @@ void sg_fini(Int exitcode)
          stats__Invars_preened, stats__Invars_changed);
       VG_(message)(Vg_DebugMsg,
          " sg_:   t_i_b_MT: %'12llu\n", stats__t_i_b_empty);
-      VG_(message)(Vg_DebugMsg, 
+      VG_(message)(Vg_DebugMsg,
          " sg_:     qcache: %'llu searches, %'llu probes, %'llu misses\n",
          stats__qcache_queries, stats__qcache_probes, stats__qcache_misses);
-      VG_(message)(Vg_DebugMsg, 
+      VG_(message)(Vg_DebugMsg,
          " sg_:  htab-fast: %'llu hits\n",
          stats__htab_fast);
-      VG_(message)(Vg_DebugMsg, 
+      VG_(message)(Vg_DebugMsg,
          " sg_:  htab-slow: %'llu searches, %'llu probes, %'llu resizes\n",
          stats__htab_searches, stats__htab_probes, stats__htab_resizes);
    }

--- a/helgrind/hg_main.c
+++ b/helgrind/hg_main.c
@@ -141,7 +141,7 @@ static WordFM* map_locks = NULL; /* WordFM LockAddr Lock* */
 static WordSetU* univ_lsets = NULL; /* sets of Lock* */
 static WordSetU* univ_laog  = NULL; /* sets of Lock*, for LAOG */
 static Int next_gc_univ_laog = 1;
-/* univ_laog will be garbaged collected when the nr of element in univ_laog is 
+/* univ_laog will be garbaged collected when the nr of element in univ_laog is
    >= next_gc_univ_laog. */
 
 /* Allow libhb to get at the universe of locksets stored
@@ -208,7 +208,7 @@ static Lock* mk_LockN ( LockKind kind, Addr guestaddr ) {
 
 /* Release storage for a Lock.  Also release storage in .heldBy, if
    any. Removes from admin_locks double linked list. */
-static void del_LockN ( Lock* lk ) 
+static void del_LockN ( Lock* lk )
 {
    tl_assert(HG_(is_sane_LockN)(lk));
    tl_assert(lk->hbso);
@@ -236,7 +236,7 @@ static void del_LockN ( Lock* lk )
 /* Update 'lk' to reflect that 'thr' now has a write-acquisition of
    it.  This is done strictly: only combinations resulting from
    correct program and libpthread behaviour are allowed. */
-static void lockN_acquire_writer ( Lock* lk, Thread* thr ) 
+static void lockN_acquire_writer ( Lock* lk, Thread* thr )
 {
    tl_assert(HG_(is_sane_LockN)(lk));
    tl_assert(HG_(is_sane_Thread)(thr));
@@ -281,7 +281,7 @@ static void lockN_acquire_writer ( Lock* lk, Thread* thr )
       case LK_rdwr:
          tl_assert(lk->heldBy == NULL && !lk->heldW); /* must be unheld */
          goto case_LK_nonRec;
-      default: 
+      default:
          tl_assert(0);
   }
   tl_assert(HG_(is_sane_LockN)(lk));
@@ -294,7 +294,7 @@ static void lockN_acquire_reader ( Lock* lk, Thread* thr )
    /* can only add reader to a reader-writer lock. */
    tl_assert(lk->kind == LK_rdwr);
    /* lk must be free or already r-held. */
-   tl_assert(lk->heldBy == NULL 
+   tl_assert(lk->heldBy == NULL
              || (lk->heldBy != NULL && !lk->heldW));
 
    stats__lockN_acquires++;
@@ -425,7 +425,7 @@ static void pp_admin_threads ( Int d )
    space(d); VG_(printf)("admin_threads (%d records) {\n", n);
    for (i = 0, t = admin_threads;  t;  i++, t = t->admin) {
       if (0) {
-         space(n); 
+         space(n);
          VG_(printf)("admin_threads record %d of %d:\n", i, n);
       }
       pp_Thread(d+3, t);
@@ -463,21 +463,21 @@ static const HChar* show_LockKind ( LockKind lkk ) {
 /* Pretty Print lock lk.
    if show_lock_addrdescr, describes the (guest) lock address.
      (this description will be more complete with --read-var-info=yes).
-   if show_internal_data, shows also helgrind internal information. 
+   if show_internal_data, shows also helgrind internal information.
    d is the level at which output is indented. */
 static void pp_Lock ( Int d, Lock* lk,
                       Bool show_lock_addrdescr,
                       Bool show_internal_data)
 {
-   space(d+0); 
+   space(d+0);
    if (show_internal_data)
       VG_(printf)("Lock %p (ga %#lx) {\n", lk, lk->guestaddr);
    else
       VG_(printf)("Lock ga %#lx {\n", lk->guestaddr);
-   if (!show_lock_addrdescr 
+   if (!show_lock_addrdescr
        || !HG_(get_and_pp_addrdescr) ((Addr) lk->guestaddr))
       VG_(printf)("\n");
-      
+
    if (sHOW_ADMIN) {
       space(d+3); VG_(printf)("admin_n  %p\n",   lk->admin_next);
       space(d+3); VG_(printf)("admin_p  %p\n",   lk->admin_prev);
@@ -505,7 +505,7 @@ static void pp_Lock ( Int d, Lock* lk,
             VG_(printf)("%c%lu:thread #%d ",
                         lk->heldW ? 'W' : 'R',
                         count, thr->errmsg_index);
-            if (thr->coretid == VG_INVALID_THREADID) 
+            if (thr->coretid == VG_INVALID_THREADID)
                VG_(printf)("tid (exited) ");
             else
                VG_(printf)("tid %d ", thr->coretid);
@@ -528,7 +528,7 @@ static void pp_admin_locks ( Int d )
    space(d); VG_(printf)("admin_locks (%d records) {\n", n);
    for (i = 0, lk = admin_locks;  lk;  i++, lk = lk->admin_next) {
       if (0) {
-         space(n); 
+         space(n);
          VG_(printf)("admin_locks record %d of %d:\n", i, n);
       }
       pp_Lock(d+3, lk,
@@ -599,7 +599,7 @@ static void initialise_data_structures ( Thr* hbthr_root )
 
    tl_assert(sizeof(Addr) == sizeof(UWord));
    tl_assert(map_locks == NULL);
-   map_locks = VG_(newFM)( HG_(zalloc), "hg.ids.2", HG_(free), 
+   map_locks = VG_(newFM)( HG_(zalloc), "hg.ids.2", HG_(free),
                            NULL/*unboxed Word cmp*/);
    tl_assert(map_locks != NULL);
 
@@ -708,13 +708,13 @@ static void map_threads_delete ( ThreadId coretid )
 /* Make sure there is a lock table entry for the given (lock) guest
    address.  If not, create one of the stated 'kind' in unheld state.
    In any case, return the address of the existing or new Lock. */
-static 
+static
 Lock* map_locks_lookup_or_create ( LockKind lkk, Addr ga, ThreadId tid )
 {
    Bool  found;
    Lock* oldlock = NULL;
    tl_assert(HG_(is_sane_ThreadId)(tid));
-   found = VG_(lookupFM)( map_locks, 
+   found = VG_(lookupFM)( map_locks,
                           NULL, (UWord*)&oldlock, (UWord)ga );
    if (!found) {
       Lock* lock = mk_LockN(lkk, ga);
@@ -772,7 +772,7 @@ static void laog__sanity_check ( const HChar* who ); /* fwds */
          // Thread.lockset: each element is really a valid Lock
 
          // Thread.lockset: each Lock in set is actually held by that thread
-         for lk in Thread.lockset 
+         for lk in Thread.lockset
             lk == LockedBy(t)
 
          // Thread.csegid is a valid SegmentID
@@ -911,19 +911,19 @@ static void locks__sanity_check ( const HChar* who )
          Thread* thr;
          UWord   count;
          VG_(initIterBag)( lk->heldBy );
-         while (VG_(nextIterBag)( lk->heldBy, 
+         while (VG_(nextIterBag)( lk->heldBy,
                                   (UWord*)&thr, &count )) {
             // HG_(is_sane_LockN) above ensures these
             tl_assert(count >= 1);
             tl_assert(HG_(is_sane_Thread)(thr));
-            if (!HG_(elemWS)(univ_lsets, thr->locksetA, (UWord)lk)) 
+            if (!HG_(elemWS)(univ_lsets, thr->locksetA, (UWord)lk))
                BAD("6");
             // also check the w-only lockset
-            if (lk->heldW 
-                && !HG_(elemWS)(univ_lsets, thr->locksetW, (UWord)lk)) 
+            if (lk->heldW
+                && !HG_(elemWS)(univ_lsets, thr->locksetW, (UWord)lk))
                BAD("7");
             if ((!lk->heldW)
-                && HG_(elemWS)(univ_lsets, thr->locksetW, (UWord)lk)) 
+                && HG_(elemWS)(univ_lsets, thr->locksetW, (UWord)lk))
                BAD("8");
          }
          VG_(doneIterBag)( lk->heldBy );
@@ -1031,7 +1031,7 @@ static void shadow_mem_make_Untracked ( Thread* thr, Addr aIN, SizeT len )
    existing segment, bind together the SegmentID and Segment, and
    return both of them.  Also update 'thr' so it references the new
    Segment. */
-//zz static 
+//zz static
 //zz void evhH__start_new_segment_for_thread ( /*OUT*/SegmentID* new_segidP,
 //zz                                           /*OUT*/Segment** new_segP,
 //zz                                           Thread* thr )
@@ -1053,17 +1053,17 @@ static void shadow_mem_make_Untracked ( Thread* thr, Addr aIN, SizeT len )
 
 /* The lock at 'lock_ga' has acquired a writer.  Make all necessary
    updates, and also do all possible error checks. */
-static 
-void evhH__post_thread_w_acquires_lock ( Thread* thr, 
+static
+void evhH__post_thread_w_acquires_lock ( Thread* thr,
                                          LockKind lkk, Addr lock_ga )
 {
-   Lock* lk; 
+   Lock* lk;
 
    /* Basically what we need to do is call lockN_acquire_writer.
       However, that will barf if any 'invalid' lock states would
       result.  Therefore check before calling.  Side effect is that
       'HG_(is_sane_LockN)(lk)' is both a pre- and post-condition of this
-      routine. 
+      routine.
 
       Because this routine is only called after successful lock
       acquisition, we should not be asked to move the lock into any
@@ -1073,7 +1073,7 @@ void evhH__post_thread_w_acquires_lock ( Thread* thr,
    tl_assert(HG_(is_sane_Thread)(thr));
    /* Try to find the lock.  If we can't, then create a new one with
       kind 'lkk'. */
-   lk = map_locks_lookup_or_create( 
+   lk = map_locks_lookup_or_create(
            lkk, lock_ga, map_threads_reverse_lookup_SLOW(thr) );
    tl_assert( HG_(is_sane_LockN)(lk) );
 
@@ -1150,17 +1150,17 @@ void evhH__post_thread_w_acquires_lock ( Thread* thr,
 
 /* The lock at 'lock_ga' has acquired a reader.  Make all necessary
    updates, and also do all possible error checks. */
-static 
-void evhH__post_thread_r_acquires_lock ( Thread* thr, 
+static
+void evhH__post_thread_r_acquires_lock ( Thread* thr,
                                          LockKind lkk, Addr lock_ga )
 {
-   Lock* lk; 
+   Lock* lk;
 
    /* Basically what we need to do is call lockN_acquire_reader.
       However, that will barf if any 'invalid' lock states would
       result.  Therefore check before calling.  Side effect is that
       'HG_(is_sane_LockN)(lk)' is both a pre- and post-condition of this
-      routine. 
+      routine.
 
       Because this routine is only called after successful lock
       acquisition, we should not be asked to move the lock into any
@@ -1172,7 +1172,7 @@ void evhH__post_thread_r_acquires_lock ( Thread* thr,
       kind 'lkk'.  Only a reader-writer lock can be read-locked,
       hence the first assertion. */
    tl_assert(lkk == LK_rdwr);
-   lk = map_locks_lookup_or_create( 
+   lk = map_locks_lookup_or_create(
            lkk, lock_ga, map_threads_reverse_lookup_SLOW(thr) );
    tl_assert( HG_(is_sane_LockN)(lk) );
 
@@ -1225,7 +1225,7 @@ void evhH__post_thread_r_acquires_lock ( Thread* thr,
 
 /* The lock at 'lock_ga' is just about to be unlocked.  Make all
    necessary updates, and also do all possible error checks. */
-static 
+static
 void evhH__pre_thread_releases_lock ( Thread* thr,
                                       Addr lock_ga, Bool isRDWR )
 {
@@ -1307,8 +1307,8 @@ void evhH__pre_thread_releases_lock ( Thread* thr,
 
    if (n > 0) {
       tl_assert(lock->heldBy);
-      tl_assert(n == VG_(elemBag)( lock->heldBy, (UWord)thr )); 
-      /* We still hold the lock.  So either it's a recursive lock 
+      tl_assert(n == VG_(elemBag)( lock->heldBy, (UWord)thr ));
+      /* We still hold the lock.  So either it's a recursive lock
          or a rwlock which is currently r-held. */
       tl_assert(lock->kind == LK_mbRec
                 || (lock->kind == LK_rdwr && !lock->heldW));
@@ -1452,7 +1452,7 @@ void evh__new_mem_w_tid ( Addr a, SizeT len, ThreadId tid ) {
 }
 
 static
-void evh__new_mem_w_perms ( Addr a, SizeT len, 
+void evh__new_mem_w_perms ( Addr a, SizeT len,
                             Bool rr, Bool ww, Bool xx, ULong di_handle ) {
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__new_mem_w_perms(%p, %lu, %d,%d,%d)\n",
@@ -1748,11 +1748,11 @@ void evh__HG_PTHREAD_JOIN_POST ( ThreadId stay_tid, Thread* quit_thr )
 }
 
 static
-void evh__pre_mem_read ( CorePart part, ThreadId tid, const HChar* s, 
+void evh__pre_mem_read ( CorePart part, ThreadId tid, const HChar* s,
                          Addr a, SizeT size) {
    if (SHOW_EVENTS >= 2
        || (SHOW_EVENTS >= 1 && size != 1))
-      VG_(printf)("evh__pre_mem_read(ctid=%d, \"%s\", %p, %lu)\n", 
+      VG_(printf)("evh__pre_mem_read(ctid=%d, \"%s\", %p, %lu)\n",
                   (Int)tid, s, (void*)a, size );
    shadow_mem_cread_range( map_threads_lookup(tid), a, size);
    if (size >= SCE_BIGRANGE_T && (HG_(clo_sanity_flags) & SCE_BIGRANGE))
@@ -1764,7 +1764,7 @@ void evh__pre_mem_read_asciiz ( CorePart part, ThreadId tid,
                                 const HChar* s, Addr a ) {
    Int len;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__pre_mem_asciiz(ctid=%d, \"%s\", %p)\n", 
+      VG_(printf)("evh__pre_mem_asciiz(ctid=%d, \"%s\", %p)\n",
                   (Int)tid, s, (void*)a );
    // Don't segfault if the string starts in an obviously stupid
    // place.  Actually we should check the whole string, not just
@@ -1782,7 +1782,7 @@ static
 void evh__pre_mem_write ( CorePart part, ThreadId tid, const HChar* s,
                           Addr a, SizeT size ) {
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__pre_mem_write(ctid=%d, \"%s\", %p, %lu)\n", 
+      VG_(printf)("evh__pre_mem_write(ctid=%d, \"%s\", %p, %lu)\n",
                   (Int)tid, s, (void*)a, size );
    shadow_mem_cwrite_range( map_threads_lookup(tid), a, size);
    if (size >= SCE_BIGRANGE_T && (HG_(clo_sanity_flags) & SCE_BIGRANGE))
@@ -1792,7 +1792,7 @@ void evh__pre_mem_write ( CorePart part, ThreadId tid, const HChar* s,
 static
 void evh__new_mem_heap ( Addr a, SizeT len, Bool is_inited ) {
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__new_mem_heap(%p, %lu, inited=%d)\n", 
+      VG_(printf)("evh__new_mem_heap(%p, %lu, inited=%d)\n",
                   (void*)a, len, (Int)is_inited );
    // We ignore the initialisation state (is_inited); that's ok.
    shadow_mem_make_New(get_current_Thread(), a, len);
@@ -1902,11 +1902,11 @@ void evh__mem_help_cwrite_N(Addr a, SizeT size) {
    show where it was first locked.  Intercepting lock initialisations
    is not necessary for the basic operation of the race checker. */
 static
-void evh__HG_PTHREAD_MUTEX_INIT_POST( ThreadId tid, 
+void evh__HG_PTHREAD_MUTEX_INIT_POST( ThreadId tid,
                                       void* mutex, Word mbRec )
 {
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__hg_PTHREAD_MUTEX_INIT_POST(ctid=%d, mbRec=%ld, %p)\n", 
+      VG_(printf)("evh__hg_PTHREAD_MUTEX_INIT_POST(ctid=%d, mbRec=%ld, %p)\n",
                   (Int)tid, mbRec, (void*)mutex );
    tl_assert(mbRec == 0 || mbRec == 1);
    map_locks_lookup_or_create( mbRec ? LK_mbRec : LK_nonRec,
@@ -1923,7 +1923,7 @@ void evh__HG_PTHREAD_MUTEX_DESTROY_PRE( ThreadId tid, void* mutex,
    Lock*   lk;
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__hg_PTHREAD_MUTEX_DESTROY_PRE"
-                  "(ctid=%d, %p, isInit=%d)\n", 
+                  "(ctid=%d, %p, isInit=%d)\n",
                   (Int)tid, (void*)mutex, (Int)mutex_is_init );
 
    thr = map_threads_maybe_lookup( tid );
@@ -1961,7 +1961,7 @@ void evh__HG_PTHREAD_MUTEX_DESTROY_PRE( ThreadId tid, void* mutex,
       }
       tl_assert( !lk->heldBy );
       tl_assert( HG_(is_sane_LockN)(lk) );
-      
+
       if (HG_(clo_track_lockorders))
          laog__handle_one_lock_deletion(lk);
       map_locks_delete( lk->guestaddr );
@@ -1981,7 +1981,7 @@ static void evh__HG_PTHREAD_MUTEX_LOCK_PRE ( ThreadId tid,
    Thread* thr;
    Lock*   lk;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__hg_PTHREAD_MUTEX_LOCK_PRE(ctid=%d, mutex=%p)\n", 
+      VG_(printf)("evh__hg_PTHREAD_MUTEX_LOCK_PRE(ctid=%d, mutex=%p)\n",
                   (Int)tid, (void*)mutex );
 
    tl_assert(isTryLock == 0 || isTryLock == 1);
@@ -1995,7 +1995,7 @@ static void evh__HG_PTHREAD_MUTEX_LOCK_PRE ( ThreadId tid,
                                    "pthread_rwlock_t* argument " );
    }
 
-   if ( lk 
+   if ( lk
         && isTryLock == 0
         && (lk->kind == LK_nonRec || lk->kind == LK_rdwr)
         && lk->heldBy
@@ -2021,14 +2021,14 @@ static void evh__HG_PTHREAD_MUTEX_LOCK_POST ( ThreadId tid, void* mutex )
    // only called if the real library call succeeded - so mutex is sane
    Thread* thr;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_PTHREAD_MUTEX_LOCK_POST(ctid=%d, mutex=%p)\n", 
+      VG_(printf)("evh__HG_PTHREAD_MUTEX_LOCK_POST(ctid=%d, mutex=%p)\n",
                   (Int)tid, (void*)mutex );
 
    thr = map_threads_maybe_lookup( tid );
    tl_assert(thr); /* cannot fail - Thread* must already exist */
 
-   evhH__post_thread_w_acquires_lock( 
-      thr, 
+   evhH__post_thread_w_acquires_lock(
+      thr,
       LK_mbRec, /* if not known, create new lock with this LockKind */
       (Addr)mutex
    );
@@ -2039,7 +2039,7 @@ static void evh__HG_PTHREAD_MUTEX_UNLOCK_PRE ( ThreadId tid, void* mutex )
    // 'mutex' may be invalid - not checked by wrapper
    Thread* thr;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_PTHREAD_MUTEX_UNLOCK_PRE(ctid=%d, mutex=%p)\n", 
+      VG_(printf)("evh__HG_PTHREAD_MUTEX_UNLOCK_PRE(ctid=%d, mutex=%p)\n",
                   (Int)tid, (void*)mutex );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2053,7 +2053,7 @@ static void evh__HG_PTHREAD_MUTEX_UNLOCK_POST ( ThreadId tid, void* mutex )
    // only called if the real library call succeeded - so mutex is sane
    Thread* thr;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__hg_PTHREAD_MUTEX_UNLOCK_POST(ctid=%d, mutex=%p)\n", 
+      VG_(printf)("evh__hg_PTHREAD_MUTEX_UNLOCK_POST(ctid=%d, mutex=%p)\n",
                   (Int)tid, (void*)mutex );
    thr = map_threads_maybe_lookup( tid );
    tl_assert(thr); /* cannot fail - Thread* must already exist */
@@ -2069,7 +2069,7 @@ static void evh__HG_PTHREAD_MUTEX_UNLOCK_POST ( ThreadId tid, void* mutex )
 /* All a bit of a kludge.  Pretend we're really dealing with ordinary
    pthread_mutex_t's instead, for the most part. */
 
-static void evh__HG_PTHREAD_SPIN_INIT_OR_UNLOCK_PRE( ThreadId tid, 
+static void evh__HG_PTHREAD_SPIN_INIT_OR_UNLOCK_PRE( ThreadId tid,
                                                      void* slock )
 {
    Thread* thr;
@@ -2080,7 +2080,7 @@ static void evh__HG_PTHREAD_SPIN_INIT_OR_UNLOCK_PRE( ThreadId tid,
 
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__hg_PTHREAD_SPIN_INIT_OR_UNLOCK_PRE"
-                  "(ctid=%d, slock=%p)\n", 
+                  "(ctid=%d, slock=%p)\n",
                   (Int)tid, (void*)slock );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2097,7 +2097,7 @@ static void evh__HG_PTHREAD_SPIN_INIT_OR_UNLOCK_PRE( ThreadId tid,
    }
 }
 
-static void evh__HG_PTHREAD_SPIN_INIT_OR_UNLOCK_POST( ThreadId tid, 
+static void evh__HG_PTHREAD_SPIN_INIT_OR_UNLOCK_POST( ThreadId tid,
                                                       void* slock )
 {
    Lock* lk;
@@ -2107,7 +2107,7 @@ static void evh__HG_PTHREAD_SPIN_INIT_OR_UNLOCK_POST( ThreadId tid,
 
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__hg_PTHREAD_SPIN_INIT_OR_UNLOCK_POST"
-                  "(ctid=%d, slock=%p)\n", 
+                  "(ctid=%d, slock=%p)\n",
                   (Int)tid, (void*)slock );
 
    lk = map_locks_maybe_lookup( (Addr)slock );
@@ -2116,19 +2116,19 @@ static void evh__HG_PTHREAD_SPIN_INIT_OR_UNLOCK_POST( ThreadId tid,
    }
 }
 
-static void evh__HG_PTHREAD_SPIN_LOCK_PRE( ThreadId tid, 
+static void evh__HG_PTHREAD_SPIN_LOCK_PRE( ThreadId tid,
                                            void* slock, Word isTryLock )
 {
    evh__HG_PTHREAD_MUTEX_LOCK_PRE( tid, slock, isTryLock );
 }
 
-static void evh__HG_PTHREAD_SPIN_LOCK_POST( ThreadId tid, 
+static void evh__HG_PTHREAD_SPIN_LOCK_POST( ThreadId tid,
                                             void* slock )
 {
    evh__HG_PTHREAD_MUTEX_LOCK_POST( tid, slock );
 }
 
-static void evh__HG_PTHREAD_SPIN_DESTROY_PRE( ThreadId tid, 
+static void evh__HG_PTHREAD_SPIN_DESTROY_PRE( ThreadId tid,
                                               void* slock )
 {
    evh__HG_PTHREAD_MUTEX_DESTROY_PRE( tid, slock, 0/*!isInit*/ );
@@ -2156,7 +2156,7 @@ static void evh__HG_PTHREAD_SPIN_DESTROY_PRE( ThreadId tid,
    need to keep track of the number of waiters in order to do
    consistency tracking. */
 typedef
-   struct { 
+   struct {
       SO*   so;       /* libhb-allocated SO */
       void* mx_ga;    /* addr of associated mutex, if any */
       UWord nWaiters; /* # threads waiting on the CV */
@@ -2254,7 +2254,7 @@ static void evh__HG_PTHREAD_COND_SIGNAL_PRE ( ThreadId tid, void* cond )
    //Lock*     lk;
 
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_PTHREAD_COND_SIGNAL_PRE(ctid=%d, cond=%p)\n", 
+      VG_(printf)("evh__HG_PTHREAD_COND_SIGNAL_PRE(ctid=%d, cond=%p)\n",
                   (Int)tid, (void*)cond );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2266,7 +2266,7 @@ static void evh__HG_PTHREAD_COND_SIGNAL_PRE ( ThreadId tid, void* cond )
 
    // error-if: mutex is bogus
    // error-if: mutex is not locked
-   // Hmm.  POSIX doesn't actually say that it's an error to call 
+   // Hmm.  POSIX doesn't actually say that it's an error to call
    // pthread_cond_signal with the associated mutex being unlocked.
    // Although it does say that it should be "if consistent scheduling
    // is desired."  For that reason, print "dubious" if the lock isn't
@@ -2311,7 +2311,7 @@ static void evh__HG_PTHREAD_COND_SIGNAL_PRE ( ThreadId tid, void* cond )
          // know the (CV,MX) binding until a pthread_cond_wait or bcast
          // shows us what it is, and if that may not have happened yet.
          // So just keep quiet in this circumstance.
-         //HG_(record_error_Misc)( thr, 
+         //HG_(record_error_Misc)( thr,
          //   "pthread_cond_{signal,broadcast}: "
          //   "no or invalid mutex associated with cond");
       }
@@ -2332,7 +2332,7 @@ static Bool evh__HG_PTHREAD_COND_WAIT_PRE ( ThreadId tid,
 
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__hg_PTHREAD_COND_WAIT_PRE"
-                  "(ctid=%d, cond=%p, mutex=%p)\n", 
+                  "(ctid=%d, cond=%p, mutex=%p)\n",
                   (Int)tid, (void*)cond, (void*)mutex );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2345,8 +2345,8 @@ static Bool evh__HG_PTHREAD_COND_WAIT_PRE ( ThreadId tid,
       is wrong. */
    if (lk == NULL) {
       lk_valid = False;
-      HG_(record_error_Misc)( 
-         thr, 
+      HG_(record_error_Misc)(
+         thr,
          "pthread_cond_{timed}wait called with invalid mutex" );
    } else {
       tl_assert( HG_(is_sane_LockN)(lk) );
@@ -2358,7 +2358,7 @@ static Bool evh__HG_PTHREAD_COND_WAIT_PRE ( ThreadId tid,
       } else
          if (lk->heldBy == NULL) {
          lk_valid = False;
-         HG_(record_error_Misc)( 
+         HG_(record_error_Misc)(
             thr, "pthread_cond_{timed}wait called with un-held mutex");
       } else
       if (lk->heldBy != NULL
@@ -2446,7 +2446,7 @@ static void evh__HG_PTHREAD_COND_INIT_POST ( ThreadId tid,
 
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__HG_PTHREAD_COND_INIT_POST"
-                  "(ctid=%d, cond=%p, cond_attr=%p)\n", 
+                  "(ctid=%d, cond=%p, cond_attr=%p)\n",
                   (Int)tid, (void*)cond, (void*) cond_attr );
 
    cvi = map_cond_to_CVInfo_lookup_or_alloc( cond );
@@ -2463,7 +2463,7 @@ static void evh__HG_PTHREAD_COND_DESTROY_PRE ( ThreadId tid,
       leaks. */
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__HG_PTHREAD_COND_DESTROY_PRE"
-                  "(ctid=%d, cond=%p, cond_is_init=%d)\n", 
+                  "(ctid=%d, cond=%p, cond_is_init=%d)\n",
                   (Int)tid, (void*)cond, (Int)cond_is_init );
 
    map_cond_to_CVInfo_delete( tid, cond, cond_is_init );
@@ -2479,7 +2479,7 @@ static
 void evh__HG_PTHREAD_RWLOCK_INIT_POST( ThreadId tid, void* rwl )
 {
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__hg_PTHREAD_RWLOCK_INIT_POST(ctid=%d, %p)\n", 
+      VG_(printf)("evh__hg_PTHREAD_RWLOCK_INIT_POST(ctid=%d, %p)\n",
                   (Int)tid, (void*)rwl );
    map_locks_lookup_or_create( LK_rdwr, (Addr)rwl, tid );
    if (HG_(clo_sanity_flags) & SCE_LOCKS)
@@ -2492,7 +2492,7 @@ void evh__HG_PTHREAD_RWLOCK_DESTROY_PRE( ThreadId tid, void* rwl )
    Thread* thr;
    Lock*   lk;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__hg_PTHREAD_RWLOCK_DESTROY_PRE(ctid=%d, %p)\n", 
+      VG_(printf)("evh__hg_PTHREAD_RWLOCK_DESTROY_PRE(ctid=%d, %p)\n",
                   (Int)tid, (void*)rwl );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2522,7 +2522,7 @@ void evh__HG_PTHREAD_RWLOCK_DESTROY_PRE( ThreadId tid, void* rwl )
       }
       tl_assert( !lk->heldBy );
       tl_assert( HG_(is_sane_LockN)(lk) );
-      
+
       if (HG_(clo_track_lockorders))
          laog__handle_one_lock_deletion(lk);
       map_locks_delete( lk->guestaddr );
@@ -2533,7 +2533,7 @@ void evh__HG_PTHREAD_RWLOCK_DESTROY_PRE( ThreadId tid, void* rwl )
       all__sanity_check("evh__hg_PTHREAD_RWLOCK_DESTROY_PRE");
 }
 
-static 
+static
 void evh__HG_PTHREAD_RWLOCK_LOCK_PRE ( ThreadId tid,
                                        void* rwl,
                                        Word isW, Word isTryLock )
@@ -2543,7 +2543,7 @@ void evh__HG_PTHREAD_RWLOCK_LOCK_PRE ( ThreadId tid,
    Thread* thr;
    Lock*   lk;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__hg_PTHREAD_RWLOCK_LOCK_PRE(ctid=%d, isW=%d, %p)\n", 
+      VG_(printf)("evh__hg_PTHREAD_RWLOCK_LOCK_PRE(ctid=%d, isW=%d, %p)\n",
                   (Int)tid, (Int)isW, (void*)rwl );
 
    tl_assert(isW == 0 || isW == 1); /* assured us by wrapper */
@@ -2552,31 +2552,31 @@ void evh__HG_PTHREAD_RWLOCK_LOCK_PRE ( ThreadId tid,
    tl_assert(thr); /* cannot fail - Thread* must already exist */
 
    lk = map_locks_maybe_lookup( (Addr)rwl );
-   if ( lk 
+   if ( lk
         && (lk->kind == LK_nonRec || lk->kind == LK_mbRec) ) {
       /* Wrong kind of lock.  Duh.  */
-      HG_(record_error_Misc)( 
+      HG_(record_error_Misc)(
          thr, "pthread_rwlock_{rd,rw}lock with a "
               "pthread_mutex_t* argument " );
    }
 }
 
-static 
+static
 void evh__HG_PTHREAD_RWLOCK_LOCK_POST ( ThreadId tid, void* rwl, Word isW )
 {
    // only called if the real library call succeeded - so mutex is sane
    Thread* thr;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__hg_PTHREAD_RWLOCK_LOCK_POST(ctid=%d, isW=%d, %p)\n", 
+      VG_(printf)("evh__hg_PTHREAD_RWLOCK_LOCK_POST(ctid=%d, isW=%d, %p)\n",
                   (Int)tid, (Int)isW, (void*)rwl );
 
    tl_assert(isW == 0 || isW == 1); /* assured us by wrapper */
    thr = map_threads_maybe_lookup( tid );
    tl_assert(thr); /* cannot fail - Thread* must already exist */
 
-   (isW ? evhH__post_thread_w_acquires_lock 
-        : evhH__post_thread_r_acquires_lock)( 
-      thr, 
+   (isW ? evhH__post_thread_w_acquires_lock
+        : evhH__post_thread_r_acquires_lock)(
+      thr,
       LK_rdwr, /* if not known, create new lock with this LockKind */
       (Addr)rwl
    );
@@ -2587,7 +2587,7 @@ static void evh__HG_PTHREAD_RWLOCK_UNLOCK_PRE ( ThreadId tid, void* rwl )
    // 'rwl' may be invalid - not checked by wrapper
    Thread* thr;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_PTHREAD_RWLOCK_UNLOCK_PRE(ctid=%d, rwl=%p)\n", 
+      VG_(printf)("evh__HG_PTHREAD_RWLOCK_UNLOCK_PRE(ctid=%d, rwl=%p)\n",
                   (Int)tid, (void*)rwl );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2601,7 +2601,7 @@ static void evh__HG_PTHREAD_RWLOCK_UNLOCK_POST ( ThreadId tid, void* rwl )
    // only called if the real library call succeeded - so mutex is sane
    Thread* thr;
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__hg_PTHREAD_RWLOCK_UNLOCK_POST(ctid=%d, rwl=%p)\n", 
+      VG_(printf)("evh__hg_PTHREAD_RWLOCK_UNLOCK_POST(ctid=%d, rwl=%p)\n",
                   (Int)tid, (void*)rwl );
    thr = map_threads_maybe_lookup( tid );
    tl_assert(thr); /* cannot fail - Thread* must already exist */
@@ -2663,7 +2663,7 @@ static void push_SO_for_sem ( void* sem, SO* so ) {
    XArray* xa;
    tl_assert(so);
    map_sem_to_SO_stack_INIT();
-   if (VG_(lookupFM)( map_sem_to_SO_stack, 
+   if (VG_(lookupFM)( map_sem_to_SO_stack,
                       &keyW, (UWord*)&xa, (UWord)sem )) {
       tl_assert(keyW == (UWord)sem);
       tl_assert(xa);
@@ -2680,10 +2680,10 @@ static SO* mb_pop_SO_for_sem ( void* sem ) {
    XArray*  xa;
    SO* so;
    map_sem_to_SO_stack_INIT();
-   if (VG_(lookupFM)( map_sem_to_SO_stack, 
+   if (VG_(lookupFM)( map_sem_to_SO_stack,
                       &keyW, (UWord*)&xa, (UWord)sem )) {
       /* xa is the stack for this semaphore. */
-      Word sz; 
+      Word sz;
       tl_assert(keyW == (UWord)sem);
       sz = VG_(sizeXA)( xa );
       tl_assert(sz >= 0);
@@ -2705,7 +2705,7 @@ static void evh__HG_POSIX_SEM_DESTROY_PRE ( ThreadId tid, void* sem )
    SO*   so;
 
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_POSIX_SEM_DESTROY_PRE(ctid=%d, sem=%p)\n", 
+      VG_(printf)("evh__HG_POSIX_SEM_DESTROY_PRE(ctid=%d, sem=%p)\n",
                   (Int)tid, (void*)sem );
 
    map_sem_to_SO_stack_INIT();
@@ -2727,14 +2727,14 @@ static void evh__HG_POSIX_SEM_DESTROY_PRE ( ThreadId tid, void* sem )
    }
 }
 
-static 
+static
 void evh__HG_POSIX_SEM_INIT_POST ( ThreadId tid, void* sem, UWord value )
 {
    SO*     so;
    Thread* thr;
 
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_POSIX_SEM_INIT_POST(ctid=%d, sem=%p, value=%lu)\n", 
+      VG_(printf)("evh__HG_POSIX_SEM_INIT_POST(ctid=%d, sem=%p, value=%lu)\n",
                   (Int)tid, (void*)sem, value );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2783,7 +2783,7 @@ static void evh__HG_POSIX_SEM_POST_PRE ( ThreadId tid, void* sem )
    Thr*    hbthr;
 
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_POSIX_SEM_POST_PRE(ctid=%d, sem=%p)\n", 
+      VG_(printf)("evh__HG_POSIX_SEM_POST_PRE(ctid=%d, sem=%p)\n",
                   (Int)tid, (void*)sem );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2811,7 +2811,7 @@ static void evh__HG_POSIX_SEM_WAIT_POST ( ThreadId tid, void* sem )
    Thr*    hbthr;
 
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_POSIX_SEM_WAIT_POST(ctid=%d, sem=%p)\n", 
+      VG_(printf)("evh__HG_POSIX_SEM_WAIT_POST(ctid=%d, sem=%p)\n",
                   (Int)tid, (void*)sem );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2913,7 +2913,7 @@ static void evh__HG_PTHREAD_BARRIER_INIT_PRE ( ThreadId tid,
 
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__HG_PTHREAD_BARRIER_INIT_PRE"
-                  "(tid=%d, barrier=%p, count=%lu, resizable=%lu)\n", 
+                  "(tid=%d, barrier=%p, count=%lu, resizable=%lu)\n",
                   (Int)tid, (void*)barrier, count, resizable );
 
    thr = map_threads_maybe_lookup( tid );
@@ -2971,7 +2971,7 @@ static void evh__HG_PTHREAD_BARRIER_DESTROY_PRE ( ThreadId tid,
       resource leaks. */
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__HG_PTHREAD_BARRIER_DESTROY_PRE"
-                  "(tid=%d, barrier=%p)\n", 
+                  "(tid=%d, barrier=%p)\n",
                   (Int)tid, (void*)barrier );
 
    thr = map_threads_maybe_lookup( tid );
@@ -3090,7 +3090,7 @@ static void evh__HG_PTHREAD_BARRIER_WAIT_PRE ( ThreadId tid,
 
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__HG_PTHREAD_BARRIER_WAIT_PRE"
-                  "(tid=%d, barrier=%p)\n", 
+                  "(tid=%d, barrier=%p)\n",
                   (Int)tid, (void*)barrier );
 
    thr = map_threads_maybe_lookup( tid );
@@ -3133,7 +3133,7 @@ static void evh__HG_PTHREAD_BARRIER_RESIZE_PRE ( ThreadId tid,
 
    if (SHOW_EVENTS >= 1)
       VG_(printf)("evh__HG_PTHREAD_BARRIER_RESIZE_PRE"
-                  "(tid=%d, barrier=%p, newcount=%lu)\n", 
+                  "(tid=%d, barrier=%p, newcount=%lu)\n",
                   (Int)tid, (void*)barrier, newcount );
 
    thr = map_threads_maybe_lookup( tid );
@@ -3252,7 +3252,7 @@ void evh__HG_USERSO_SEND_PRE ( ThreadId tid, UWord usertag )
    SO*     so;
 
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_USERSO_SEND_PRE(ctid=%d, usertag=%#lx)\n", 
+      VG_(printf)("evh__HG_USERSO_SEND_PRE(ctid=%d, usertag=%#lx)\n",
                   (Int)tid, usertag );
 
    thr = map_threads_maybe_lookup( tid );
@@ -3277,7 +3277,7 @@ void evh__HG_USERSO_RECV_POST ( ThreadId tid, UWord usertag )
    SO*     so;
 
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_USERSO_RECV_POST(ctid=%d, usertag=%#lx)\n", 
+      VG_(printf)("evh__HG_USERSO_RECV_POST(ctid=%d, usertag=%#lx)\n",
                   (Int)tid, usertag );
 
    thr = map_threads_maybe_lookup( tid );
@@ -3301,7 +3301,7 @@ void evh__HG_USERSO_FORGET_ALL ( ThreadId tid, UWord usertag )
       and all resources associated with SO are freed.  Importantly,
       that frees up any VTSs stored in SO. */
    if (SHOW_EVENTS >= 1)
-      VG_(printf)("evh__HG_USERSO_FORGET_ALL(ctid=%d, usertag=%#lx)\n", 
+      VG_(printf)("evh__HG_USERSO_FORGET_ALL(ctid=%d, usertag=%#lx)\n",
                   (Int)tid, usertag );
 
    map_usertag_to_SO_delete( usertag );
@@ -3322,7 +3322,7 @@ void evh__HG_USERSO_FORGET_ALL ( ThreadId tid, UWord usertag )
    is repeatedly acquiring and releasing Ln, and there is no ordering
    error in what it is doing.  Hence it repeatly:
 
-   (1) searches laog to see if Ln --*--> {L1,L2,L3}, which always 
+   (1) searches laog to see if Ln --*--> {L1,L2,L3}, which always
        produces the answer No (because there is no error).
 
    (2) adds edges {L1,L2,L3} --> Ln to laog, which are already present
@@ -3382,10 +3382,10 @@ static void laog__init ( void )
    tl_assert(!laog_exposition);
    tl_assert(HG_(clo_track_lockorders));
 
-   laog = VG_(newFM)( HG_(zalloc), "hg.laog__init.1", 
+   laog = VG_(newFM)( HG_(zalloc), "hg.laog__init.1",
                       HG_(free), NULL/*unboxedcmp*/ );
 
-   laog_exposition = VG_(newFM)( HG_(zalloc), "hg.laog__init.2", HG_(free), 
+   laog_exposition = VG_(newFM)( HG_(zalloc), "hg.laog__init.2", HG_(free),
                                  cmp_LAOGLinkExposition );
    tl_assert(laog);
    tl_assert(laog_exposition);
@@ -3426,7 +3426,7 @@ static void univ_laog_do_GC ( void ) {
    const UWord univ_laog_cardinality = HG_(cardinalityWSU)( univ_laog);
 
    Bool *univ_laog_seen = HG_(zalloc) ( "hg.gc_univ_laog.1",
-                                        (Int) univ_laog_cardinality 
+                                        (Int) univ_laog_cardinality
                                         * sizeof(Bool) );
    // univ_laog_seen[*] set to 0 (False) by zalloc.
 
@@ -3472,7 +3472,7 @@ static void univ_laog_do_GC ( void ) {
    // Sol 3: always garbage collect at current cardinality + 1.
    //   This solution was the fastest of the 3 solutions, and caused no memory
    //   exhaustion in the big application.
-   // 
+   //
    // With regards to cost introduced by gc: on the t2t perf test (doing only
    // lock/unlock operations), t2t 50 10 2 was about 25% faster than the
    // version with garbage collection. With t2t 50 20 2, my machine started
@@ -3481,7 +3481,7 @@ static void univ_laog_do_GC ( void ) {
    // difference performance is insignificant (~ 0.1 s).
    // Of course, it might be that real life programs are not well represented
    // by t2t.
-   
+
    // If ever we want to have a more sophisticated control
    // (e.g. clo options to control the percentage increase or fixed increased),
    // we should do it here, eg.
@@ -3566,7 +3566,7 @@ static void laog__add_edge ( Lock* src, Lock* dst ) {
       if (VG_(lookupFM)( laog_exposition, NULL, NULL, (UWord)&expo )) {
          /* we already have it; do nothing */
       } else {
-         LAOGLinkExposition* expo2 = HG_(zalloc)("hg.lae.3", 
+         LAOGLinkExposition* expo2 = HG_(zalloc)("hg.lae.3",
                                                sizeof(LAOGLinkExposition));
          expo2->src_ga = src->guestaddr;
          expo2->dst_ga = dst->guestaddr;
@@ -3605,14 +3605,14 @@ static void laog__del_edge ( Lock* src, Lock* dst ) {
    /* Remove the exposition of src,dst (if present) */
    {
       LAOGLinkExposition *fm_expo;
-      
+
       LAOGLinkExposition expo;
       expo.src_ga = src->guestaddr;
       expo.dst_ga = dst->guestaddr;
       expo.src_ec = NULL;
       expo.dst_ec = NULL;
 
-      if (VG_(delFromFM) (laog_exposition, 
+      if (VG_(delFromFM) (laog_exposition,
                           (UWord*)&fm_expo, NULL, (UWord)&expo )) {
          HG_(free) (fm_expo);
       }
@@ -3670,15 +3670,15 @@ static void laog__sanity_check ( const HChar* who ) {
       tl_assert(links);
       HG_(getPayloadWS)( &ws_words, &ws_size, univ_laog, links->inns );
       for (i = 0; i < ws_size; i++) {
-         if ( ! HG_(elemWS)( univ_laog, 
-                             laog__succs( (Lock*)ws_words[i] ), 
+         if ( ! HG_(elemWS)( univ_laog,
+                             laog__succs( (Lock*)ws_words[i] ),
                              (UWord)me ))
             goto bad;
       }
       HG_(getPayloadWS)( &ws_words, &ws_size, univ_laog, links->outs );
       for (i = 0; i < ws_size; i++) {
-         if ( ! HG_(elemWS)( univ_laog, 
-                             laog__preds( (Lock*)ws_words[i] ), 
+         if ( ! HG_(elemWS)( univ_laog,
+                             laog__preds( (Lock*)ws_words[i] ),
                              (UWord)me ))
             goto bad;
       }
@@ -3756,7 +3756,7 @@ Lock* laog__do_dfs_from_to ( Lock* src, WordSetID dsts /* univ_lsets */ )
    complaint if so.  Also, update the ordering graph appropriately.
 */
 __attribute__((noinline))
-static void laog__pre_thread_acquires_lock ( 
+static void laog__pre_thread_acquires_lock (
                Thread* thr, /* NB: BEFORE lock is added */
                Lock*   lk
             )
@@ -3799,7 +3799,7 @@ static void laog__pre_thread_acquires_lock (
          tl_assert(found->dst_ga == key.dst_ga);
          tl_assert(found->src_ec);
          tl_assert(found->dst_ec);
-         HG_(record_error_LockOrder)( 
+         HG_(record_error_LockOrder)(
             thr, lk, other,
                  found->src_ec, found->dst_ec, other->acquired_at );
       } else {
@@ -3848,7 +3848,7 @@ static void laog__pre_thread_acquires_lock (
             lk is being taken), and the stack trace where other was acquired:
             Effectively, the variable 'other' contains a lock currently
             held by this thread, with its 'acquired_at'. */
-                    
+
          HG_(record_error_LockOrder)(
             thr, lk, other,
                  NULL, NULL, other->acquired_at );
@@ -3940,7 +3940,7 @@ static void laog__handle_one_lock_deletion ( Lock* lk )
       LAOGLinks *links;
       Lock* linked_lk;
 
-      if (VG_(delFromFM) (laog, 
+      if (VG_(delFromFM) (laog,
                           (UWord*)&linked_lk, (UWord*)&links, (UWord)lk)) {
          tl_assert (linked_lk == lk);
          HG_(free) (links);
@@ -4003,7 +4003,7 @@ static void delete_MallocMeta ( MallocMeta* md ) {
 /* Allocate a client block and set up the metadata for it. */
 
 static
-void* handle_alloc ( ThreadId tid, 
+void* handle_alloc ( ThreadId tid,
                      SizeT szB, SizeT alignB, Bool is_zeroed )
 {
    Addr        p;
@@ -4051,12 +4051,12 @@ static void* hg_cli____builtin_new ( ThreadId tid, SizeT n ) {
 }
 static void* hg_cli____builtin_vec_new ( ThreadId tid, SizeT n ) {
    if (((SSizeT)n) < 0) return NULL;
-   return handle_alloc ( tid, n, VG_(clo_alignment), 
+   return handle_alloc ( tid, n, VG_(clo_alignment),
                          /*is_zeroed*/False );
 }
 static void* hg_cli__memalign ( ThreadId tid, SizeT align, SizeT n ) {
    if (((SSizeT)n) < 0) return NULL;
-   return handle_alloc ( tid, n, align, 
+   return handle_alloc ( tid, n, align,
                          /*is_zeroed*/False );
 }
 static void* hg_cli__calloc ( ThreadId tid, SizeT nmemb, SizeT size1 ) {
@@ -4119,7 +4119,7 @@ static void* hg_cli__realloc ( ThreadId tid, void* payloadV, SizeT new_size )
    md = (MallocMeta*) VG_(HT_lookup)( hg_mallocmeta_table, (UWord)payload );
    if (!md)
       return NULL; /* apparently realloc-ing a bogus address.  Oh well. */
-  
+
    tl_assert(md->payload == payload);
 
    if (md->szB == new_size) {
@@ -4180,7 +4180,7 @@ static void* hg_cli__realloc ( ThreadId tid, void* payloadV, SizeT new_size )
       VG_(HT_add_node)( hg_mallocmeta_table, (VgHashNode*)md_new );
 
       return (void*)p_new;
-   }  
+   }
 }
 
 static SizeT hg_cli_malloc_usable_size ( ThreadId tid, void* p )
@@ -4286,7 +4286,7 @@ static IRExpr* mk_And1 ( IRSB* sbOut, IRExpr* arg1, IRExpr* arg2 )
    return mkexpr(res);
 }
 
-static void instrument_mem_access ( IRSB*   sbOut, 
+static void instrument_mem_access ( IRSB*   sbOut,
                                     IRExpr* addr,
                                     Int     szB,
                                     Bool    isStore,
@@ -4366,7 +4366,7 @@ static void instrument_mem_access ( IRSB*   sbOut,
             hAddr = &evh__mem_help_cread_8;
             argv = mkIRExprVec_1( addr );
             break;
-         default: 
+         default:
             tl_assert(szB > 8 && szB <= 512); /* stay sane */
             regparms = 2;
             hName = "evh__mem_help_cread_N";
@@ -4423,7 +4423,7 @@ static void instrument_mem_access ( IRSB*   sbOut,
       addStmtToIRSB(
          sbOut,
          assign(diff,
-                tyAddr == Ity_I32 
+                tyAddr == Ity_I32
                    ? binop(Iop_Add32, mkexpr(addr_minus_sp), mkU32(rz_szB))
                    : binop(Iop_Add64, mkexpr(addr_minus_sp), mkU64(rz_szB)))
       );
@@ -4433,7 +4433,7 @@ static void instrument_mem_access ( IRSB*   sbOut,
       addStmtToIRSB(
          sbOut,
          assign(guardA,
-                tyAddr == Ity_I32 
+                tyAddr == Ity_I32
                    ? binop(Iop_CmpLT32U, mkU32(THRESH), mkexpr(diff))
                    : binop(Iop_CmpLT64U, mkU64(THRESH), mkexpr(diff)))
       );
@@ -4543,6 +4543,7 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
          case Ist_Put:
          case Ist_PutI:
          case Ist_Exit:
+         case Ist_Flush:
             /* None of these can contain any memory references. */
             break;
 
@@ -4568,6 +4569,9 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
          case Ist_MBE:
             switch (st->Ist.MBE.event) {
                case Imbe_Fence:
+               case Imbe_LFence:
+               case Imbe_SFence:
+               case Imbe_Drain:
                case Imbe_CancelReservation:
                   break; /* not interesting */
                default:
@@ -4629,9 +4633,9 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
 
          case Ist_Store:
             if (!inLDSO) {
-               instrument_mem_access( 
-                  bbOut, 
-                  st->Ist.Store.addr, 
+               instrument_mem_access(
+                  bbOut,
+                  st->Ist.Store.addr,
                   sizeofIRType(typeOfIRExpr(bbIn->tyenv, st->Ist.Store.data)),
                   True/*isStore*/,
                   sizeofIRType(hWordTy), goff_sp,
@@ -4695,7 +4699,7 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
                dataSize = d->mSize;
                if (d->mFx == Ifx_Read || d->mFx == Ifx_Modify) {
                   if (!inLDSO) {
-                     instrument_mem_access( 
+                     instrument_mem_access(
                         bbOut, d->mAddr, dataSize, False/*!isStore*/,
                         sizeofIRType(hWordTy), goff_sp, NULL/*no-guard*/
                      );
@@ -4703,7 +4707,7 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
                }
                if (d->mFx == Ifx_Write || d->mFx == Ifx_Modify) {
                   if (!inLDSO) {
-                     instrument_mem_access( 
+                     instrument_mem_access(
                         bbOut, d->mAddr, dataSize, True/*isStore*/,
                         sizeofIRType(hWordTy), goff_sp, NULL/*no-guard*/
                      );
@@ -4745,7 +4749,7 @@ static WordFM* map_pthread_t_to_Thread = NULL; /* pthread_t -> Thread* */
 
 static void map_pthread_t_to_Thread_INIT ( void ) {
    if (UNLIKELY(map_pthread_t_to_Thread == NULL)) {
-      map_pthread_t_to_Thread = VG_(newFM)( HG_(zalloc), "hg.mpttT.1", 
+      map_pthread_t_to_Thread = VG_(newFM)( HG_(zalloc), "hg.mpttT.1",
                                             HG_(free), NULL );
       tl_assert(map_pthread_t_to_Thread != NULL);
    }
@@ -4755,7 +4759,7 @@ static void map_pthread_t_to_Thread_INIT ( void ) {
    the Ada task termination semantic as implemented by the
    gcc gnat Ada runtime. */
 typedef
-   struct { 
+   struct {
       void* dependent; // Ada Task Control Block of the Dependent
       void* master;    // ATCB of the master
       Word  master_level; // level of dependency between master and dependent
@@ -4773,7 +4777,7 @@ static void gnat_dmmls_INIT (void)
 }
 static void print_monitor_help ( void )
 {
-   VG_(gdb_printf) 
+   VG_(gdb_printf)
       (
 "\n"
 "helgrind monitor commands:\n"
@@ -4795,8 +4799,8 @@ static Bool handle_gdb_monitor_command (ThreadId tid, HChar *req)
    /* NB: if possible, avoid introducing a new command below which
       starts with the same first letter(s) as an already existing
       command. This ensures a shorter abbreviation for the user. */
-   switch (VG_(keyword_id) 
-           ("help info", 
+   switch (VG_(keyword_id)
+           ("help info",
             wcmd, kwd_report_duplicated_matches)) {
    case -2: /* multiple matches */
       return True;
@@ -4807,11 +4811,11 @@ static Bool handle_gdb_monitor_command (ThreadId tid, HChar *req)
       return True;
    case  1: /* info */
       wcmd = VG_(strtok_r) (NULL, " ", &ssaveptr);
-      switch (kwdid = VG_(keyword_id) 
+      switch (kwdid = VG_(keyword_id)
               ("locks",
                wcmd, kwd_report_all)) {
       case -2:
-      case -1: 
+      case -1:
          break;
       case 0: // locks
          {
@@ -4830,13 +4834,13 @@ static Bool handle_gdb_monitor_command (ThreadId tid, HChar *req)
          tl_assert(0);
       }
       return True;
-   default: 
+   default:
       tl_assert(0);
       return False;
    }
 }
 
-static 
+static
 Bool hg_handle_client_request ( ThreadId tid, UWord* args, UWord* ret)
 {
    if (!VG_IS_TOOL_USERREQ('H','G',args[0])
@@ -4872,7 +4876,7 @@ Bool hg_handle_client_request ( ThreadId tid, UWord* args, UWord* ret)
          SizeT pszB = 0;
          if (0) VG_(printf)("VG_USERREQ__HG_CLEAN_MEMORY_HEAPBLOCK(%#lx)\n",
                             args[1]);
-         if (HG_(mm_find_containing_block)(NULL, NULL, 
+         if (HG_(mm_find_containing_block)(NULL, NULL,
                                            &payload, &pszB, args[1])) {
             if (pszB > 0) {
                evh__die_mem(payload, pszB);
@@ -4950,7 +4954,7 @@ Bool hg_handle_client_request ( ThreadId tid, UWord* args, UWord* ret)
          VG_(printf)("NOTIFY_JOIN_COMPLETE (tid %d): quitter = %p\n", (Int)tid,
                      (void*)args[1]);
          map_pthread_t_to_Thread_INIT();
-         found = VG_(lookupFM)( map_pthread_t_to_Thread, 
+         found = VG_(lookupFM)( map_pthread_t_to_Thread,
                                 NULL, (UWord*)&thr_q, (UWord)args[1] );
           /* Can this fail?  It would mean that our pthread_join
              wrapper observed a successful join on args[1] yet that
@@ -4961,7 +4965,7 @@ Bool hg_handle_client_request ( ThreadId tid, UWord* args, UWord* ret)
          tl_assert(found);
          if (found) {
             if (0)
-            VG_(printf)(".................... quitter Thread* = %p\n", 
+            VG_(printf)(".................... quitter Thread* = %p\n",
                         thr_q);
             evh__HG_PTHREAD_JOIN_POST( tid, thr_q );
          }
@@ -5064,7 +5068,7 @@ Bool hg_handle_client_request ( ThreadId tid, UWord* args, UWord* ret)
          valid for this operation. */
       case _VG_USERREQ__HG_PTHREAD_COND_WAIT_PRE: {
          Bool mutex_is_valid
-            = evh__HG_PTHREAD_COND_WAIT_PRE( tid, (void*)args[1], 
+            = evh__HG_PTHREAD_COND_WAIT_PRE( tid, (void*)args[1],
                                                   (void*)args[2] );
          *ret = mutex_is_valid ? 1 : 0;
          break;
@@ -5256,9 +5260,9 @@ static Bool hg_process_cmd_line_option ( const HChar* arg )
    /* "stuvwx" --> stuvwx (binary) */
    else if VG_STR_CLO(arg, "--hg-sanity-flags", tmp_str) {
       Int j;
-   
+
       if (6 != VG_(strlen)(tmp_str)) {
-         VG_(message)(Vg_UserMsg, 
+         VG_(message)(Vg_UserMsg,
                       "--hg-sanity-flags argument must have 6 digits\n");
          return False;
       }
@@ -5287,7 +5291,7 @@ static Bool hg_process_cmd_line_option ( const HChar* arg )
    else if VG_BOOL_CLO(arg, "--check-stack-refs",
                             HG_(clo_check_stack_refs)) {}
 
-   else 
+   else
       return VG_(replacement_malloc_process_cmd_line_option)(arg);
 
    return True;
@@ -5394,14 +5398,14 @@ static void hg_print_stats (void)
 static void hg_fini ( Int exitcode )
 {
    if (VG_(clo_verbosity) == 1 && !VG_(clo_xml)) {
-      VG_(message)(Vg_UserMsg, 
+      VG_(message)(Vg_UserMsg,
                    "For counts of detected and suppressed errors, "
                    "rerun with: -v\n");
    }
 
    if (VG_(clo_verbosity) == 1 && !VG_(clo_xml)
        && HG_(clo_history_level) >= 2) {
-      VG_(umsg)( 
+      VG_(umsg)(
          "Use --history-level=approx or =none to gain increased speed, at\n" );
       VG_(umsg)(
          "the cost of reduced accuracy of conflicting-access information\n");
@@ -5456,7 +5460,7 @@ static void hg_post_clo_init ( void )
    Thr* hbthr_root;
 
    /////////////////////////////////////////////
-   hbthr_root = libhb_init( for_libhb__get_stacktrace, 
+   hbthr_root = libhb_init( for_libhb__get_stacktrace,
                             for_libhb__get_EC );
    /////////////////////////////////////////////
 

--- a/lackey/lk_main.c
+++ b/lackey/lk_main.c
@@ -38,7 +38,7 @@
 // * --detailed-counts: do more detailed counts:  number of loads, stores
 //                      and ALU operations of different sizes.
 // * --trace-mem=yes:   trace all (data) memory accesses.
-// * --trace-superblocks=yes:   
+// * --trace-superblocks=yes:
 //                      trace all superblock entries.  Mostly of interest
 //                      to the Valgrind developers.
 //
@@ -203,14 +203,14 @@ static Bool lk_process_cmd_line_option(const HChar* arg)
    else if VG_BOOL_CLO(arg, "--trace-superblocks", clo_trace_sbs) {}
    else
       return False;
-   
+
    tl_assert(clo_fnname);
    tl_assert(clo_fnname[0]);
    return True;
 }
 
 static void lk_print_usage(void)
-{  
+{
    VG_(printf)(
 "    --basic-counts=no|yes     count instructions, jumps, etc. [yes]\n"
 "    --detailed-counts=no|yes  count loads, stores and alu ops [no]\n"
@@ -222,7 +222,7 @@ static void lk_print_usage(void)
 }
 
 static void lk_print_debug_usage(void)
-{  
+{
    VG_(printf)(
 "    (none)\n"
    );
@@ -293,7 +293,7 @@ static void add_one_inverted_Jcc_untaken(void)
 /*------------------------------------------------------------*/
 
 typedef
-   IRExpr 
+   IRExpr
    IRAtom;
 
 /* --- Operations --- */
@@ -369,7 +369,7 @@ static void instrument_detail(IRSB* sb, Op op, IRType type, IRAtom* guard)
 
    argv = mkIRExprVec_1( mkIRExpr_HWord( (HWord)&detailCounts[op][typeIx] ) );
    di = unsafeIRDirty_0_N( 1, "increment_detail",
-                              VG_(fnptr_to_fnentry)( &increment_detail ), 
+                              VG_(fnptr_to_fnentry)( &increment_detail ),
                               argv);
    if (guard) di->guard = guard;
    addStmtToIRSB( sb, IRStmt_Dirty(di) );
@@ -398,7 +398,7 @@ static void print_details ( void )
 
 #define MAX_DSIZE    512
 
-typedef 
+typedef
    enum { Event_Ir, Event_Dr, Event_Dw, Event_Dm }
    EventKind;
 
@@ -481,7 +481,7 @@ static void flushEvents(IRSB* sb)
    for (i = 0; i < events_used; i++) {
 
       ev = &events[i];
-      
+
       // Decide on helper fn to call and args to pass it.
       switch (ev->ekind) {
          case Event_Ir: helperName = "trace_instr";
@@ -501,7 +501,7 @@ static void flushEvents(IRSB* sb)
 
       // Add the helper.
       argv = mkIRExprVec_2( ev->addr, mkIRExpr_HWord( ev->size ) );
-      di   = unsafeIRDirty_0_N( /*regparms*/2, 
+      di   = unsafeIRDirty_0_N( /*regparms*/2,
                                 helperName, VG_(fnptr_to_fnentry)( helperAddr ),
                                 argv );
       if (ev->guard) {
@@ -645,8 +645,8 @@ static void lk_post_clo_init(void)
 
 static
 IRSB* lk_instrument ( VgCallbackClosure* closure,
-                      IRSB* sbIn, 
-                      VexGuestLayout* layout, 
+                      IRSB* sbIn,
+                      VexGuestLayout* layout,
                       VexGuestExtents* vge,
                       VexArchInfo* archinfo_host,
                       IRType gWordTy, IRType hWordTy )
@@ -677,7 +677,7 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
 
    if (clo_basic_counts) {
       /* Count this superblock. */
-      di = unsafeIRDirty_0_N( 0, "add_one_SB_entered", 
+      di = unsafeIRDirty_0_N( 0, "add_one_SB_entered",
                                  VG_(fnptr_to_fnentry)( &add_one_SB_entered ),
                                  mkIRExprVec_0() );
       addStmtToIRSB( sbOut, IRStmt_Dirty(di) );
@@ -685,10 +685,10 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
 
    if (clo_trace_sbs) {
       /* Print this superblock's address. */
-      di = unsafeIRDirty_0_N( 
-              0, "trace_superblock", 
+      di = unsafeIRDirty_0_N(
+              0, "trace_superblock",
               VG_(fnptr_to_fnentry)( &trace_superblock ),
-              mkIRExprVec_1( mkIRExpr_HWord( vge->base[0] ) ) 
+              mkIRExprVec_1( mkIRExpr_HWord( vge->base[0] ) )
            );
       addStmtToIRSB( sbOut, IRStmt_Dirty(di) );
    }
@@ -703,18 +703,19 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
 
       if (clo_basic_counts) {
          /* Count one VEX statement. */
-         di = unsafeIRDirty_0_N( 0, "add_one_IRStmt", 
-                                    VG_(fnptr_to_fnentry)( &add_one_IRStmt ), 
+         di = unsafeIRDirty_0_N( 0, "add_one_IRStmt",
+                                    VG_(fnptr_to_fnentry)( &add_one_IRStmt ),
                                     mkIRExprVec_0() );
          addStmtToIRSB( sbOut, IRStmt_Dirty(di) );
       }
-      
+
       switch (st->tag) {
          case Ist_NoOp:
          case Ist_AbiHint:
          case Ist_Put:
          case Ist_PutI:
          case Ist_MBE:
+         case Ist_Flush:
             addStmtToIRSB( sbOut, st );
             break;
 
@@ -726,7 +727,7 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
 
                /* Count guest instruction. */
                di = unsafeIRDirty_0_N( 0, "add_one_guest_instr",
-                                          VG_(fnptr_to_fnentry)( &add_one_guest_instr ), 
+                                          VG_(fnptr_to_fnentry)( &add_one_guest_instr ),
                                           mkIRExprVec_0() );
                addStmtToIRSB( sbOut, IRStmt_Dirty(di) );
 
@@ -744,12 +745,12 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
                 */
                tl_assert(clo_fnname);
                tl_assert(clo_fnname[0]);
-               if (VG_(get_fnname_if_entry)(st->Ist.IMark.addr, 
+               if (VG_(get_fnname_if_entry)(st->Ist.IMark.addr,
                                             fnname, sizeof(fnname))
                    && 0 == VG_(strcmp)(fnname, clo_fnname)) {
-                  di = unsafeIRDirty_0_N( 
-                          0, "add_one_func_call", 
-                             VG_(fnptr_to_fnentry)( &add_one_func_call ), 
+                  di = unsafeIRDirty_0_N(
+                          0, "add_one_func_call",
+                             VG_(fnptr_to_fnentry)( &add_one_func_call ),
                              mkIRExprVec_0() );
                   addStmtToIRSB( sbOut, IRStmt_Dirty(di) );
                }
@@ -933,8 +934,8 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
 
                /* Count Jcc */
                if (!condition_inverted)
-                  di = unsafeIRDirty_0_N( 0, "add_one_Jcc", 
-                                          VG_(fnptr_to_fnentry)( &add_one_Jcc ), 
+                  di = unsafeIRDirty_0_N( 0, "add_one_Jcc",
+                                          VG_(fnptr_to_fnentry)( &add_one_Jcc ),
                                           mkIRExprVec_0() );
                else
                   di = unsafeIRDirty_0_N( 0, "add_one_inverted_Jcc",
@@ -953,7 +954,7 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
             if (clo_basic_counts) {
                /* Count non-taken Jcc */
                if (!condition_inverted)
-                  di = unsafeIRDirty_0_N( 0, "add_one_Jcc_untaken", 
+                  di = unsafeIRDirty_0_N( 0, "add_one_Jcc_untaken",
                                           VG_(fnptr_to_fnentry)(
                                              &add_one_Jcc_untaken ),
                                           mkIRExprVec_0() );
@@ -975,7 +976,7 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
 
    if (clo_basic_counts) {
       /* Count this basic block. */
-      di = unsafeIRDirty_0_N( 0, "add_one_SB_completed", 
+      di = unsafeIRDirty_0_N( 0, "add_one_SB_completed",
                                  VG_(fnptr_to_fnentry)( &add_one_SB_completed ),
                                  mkIRExprVec_0() );
       addStmtToIRSB( sbOut, IRStmt_Dirty(di) );
@@ -994,7 +995,7 @@ static void lk_fini(Int exitcode)
    HChar percentify_buf[5]; /* Two digits, '%' and 0. */
    const int percentify_size = sizeof(percentify_buf) - 1;
    const int percentify_decs = 0;
-   
+
    tl_assert(clo_fnname);
    tl_assert(clo_fnname[0]);
 
@@ -1012,14 +1013,14 @@ static void lk_fini(Int exitcode)
          percentify_decs, percentify_size, percentify_buf);
       VG_(umsg)("  taken:         %'llu (%s)\n",
          taken_Jccs, percentify_buf);
-      
+
       VG_(umsg)("\n");
       VG_(umsg)("Executed:\n");
       VG_(umsg)("  SBs entered:   %'llu\n", n_SBs_entered);
       VG_(umsg)("  SBs completed: %'llu\n", n_SBs_completed);
       VG_(umsg)("  guest instrs:  %'llu\n", n_guest_instrs);
       VG_(umsg)("  IRStmts:       %'llu\n", n_IRStmts);
-      
+
       VG_(umsg)("\n");
       VG_(umsg)("Ratios:\n");
       tl_assert(n_SBs_entered); // Paranoia time.

--- a/memcheck/mc_translate.c
+++ b/memcheck/mc_translate.c
@@ -8,7 +8,7 @@
    This file is part of MemCheck, a heavyweight Valgrind tool for
    detecting memory errors.
 
-   Copyright (C) 2000-2013 Julian Seward 
+   Copyright (C) 2000-2013 Julian Seward
       jseward@acm.org
 
    This program is free software; you can redistribute it and/or
@@ -75,7 +75,7 @@
    Here is as good a place as any to record exactly when V bits are and
    should be checked, why, and what function is responsible.
 
-   
+
    Memcheck complains when an undefined value is used:
 
    1. In the condition of a conditional branch.  Because it could cause
@@ -231,7 +231,7 @@ typedef
    each original tmp, or INVALID_IRTEMP if none is so far assigned.
    It is necessary to support making multiple assignments to a shadow
    -- specifically, after testing a shadow for definedness, it needs
-   to be made defined.  But IR's SSA property disallows this.  
+   to be made defined.  But IR's SSA property disallows this.
 
    (2) (more important reason): Therefore, when a shadow needs to get
    a new value, a new temporary is created, the value is assigned to
@@ -240,7 +240,7 @@ typedef
    A corollary is that if the tmpMap maps a given tmp to
    IRTemp_INVALID and we are hoping to read that shadow tmp, it means
    there's a read-before-write error in the original tmps.  The IR
-   sanity checker should catch all such anomalies, however.  
+   sanity checker should catch all such anomalies, however.
 */
 
 /* Create a new IRTemp of type 'ty' and kind 'kind', and add it to
@@ -378,8 +378,8 @@ static IRType shadowTypeV ( IRType ty )
       case Ity_I1:
       case Ity_I8:
       case Ity_I16:
-      case Ity_I32: 
-      case Ity_I64: 
+      case Ity_I32:
+      case Ity_I64:
       case Ity_I128: return ty;
       case Ity_F32:  return Ity_I32;
       case Ity_D32:  return Ity_I32;
@@ -389,7 +389,7 @@ static IRType shadowTypeV ( IRType ty )
       case Ity_D128: return Ity_I128;
       case Ity_V128: return Ity_V128;
       case Ity_V256: return Ity_V256;
-      default: ppIRType(ty); 
+      default: ppIRType(ty);
                VG_(tool_panic)("memcheck:shadowTypeV");
    }
 }
@@ -426,7 +426,7 @@ static inline void stmt ( HChar cat, MCEnv* mce, IRStmt* st ) {
 }
 
 /* assign value to tmp */
-static inline 
+static inline
 void assign ( HChar cat, MCEnv* mce, IRTemp tmp, IRExpr* expr ) {
    stmt(cat, mce, IRStmt_WrTmp(tmp,expr));
 }
@@ -462,7 +462,7 @@ static IRAtom* assignNew ( HChar cat, MCEnv* mce, IRType ty, IRExpr* e )
    switch (cat) {
       case 'V': k = VSh;  break;
       case 'B': k = BSh;  break;
-      case 'C': k = Orig; break; 
+      case 'C': k = Orig; break;
                 /* happens when we are making up new "orig"
                    expressions, for IRCAS handling */
       default: tl_assert(0);
@@ -681,9 +681,9 @@ static IRAtom* mkImproveOR8 ( MCEnv* mce, IRAtom* data, IRAtom* vbits )
    tl_assert(isShadowAtom(mce, vbits));
    tl_assert(sameKindedAtoms(data, vbits));
    return assignNew(
-             'V', mce, Ity_I8, 
-             binop(Iop_Or8, 
-                   assignNew('V', mce, Ity_I8, unop(Iop_Not8, data)), 
+             'V', mce, Ity_I8,
+             binop(Iop_Or8,
+                   assignNew('V', mce, Ity_I8, unop(Iop_Not8, data)),
                    vbits) );
 }
 
@@ -693,9 +693,9 @@ static IRAtom* mkImproveOR16 ( MCEnv* mce, IRAtom* data, IRAtom* vbits )
    tl_assert(isShadowAtom(mce, vbits));
    tl_assert(sameKindedAtoms(data, vbits));
    return assignNew(
-             'V', mce, Ity_I16, 
-             binop(Iop_Or16, 
-                   assignNew('V', mce, Ity_I16, unop(Iop_Not16, data)), 
+             'V', mce, Ity_I16,
+             binop(Iop_Or16,
+                   assignNew('V', mce, Ity_I16, unop(Iop_Not16, data)),
                    vbits) );
 }
 
@@ -705,9 +705,9 @@ static IRAtom* mkImproveOR32 ( MCEnv* mce, IRAtom* data, IRAtom* vbits )
    tl_assert(isShadowAtom(mce, vbits));
    tl_assert(sameKindedAtoms(data, vbits));
    return assignNew(
-             'V', mce, Ity_I32, 
-             binop(Iop_Or32, 
-                   assignNew('V', mce, Ity_I32, unop(Iop_Not32, data)), 
+             'V', mce, Ity_I32,
+             binop(Iop_Or32,
+                   assignNew('V', mce, Ity_I32, unop(Iop_Not32, data)),
                    vbits) );
 }
 
@@ -717,9 +717,9 @@ static IRAtom* mkImproveOR64 ( MCEnv* mce, IRAtom* data, IRAtom* vbits )
    tl_assert(isShadowAtom(mce, vbits));
    tl_assert(sameKindedAtoms(data, vbits));
    return assignNew(
-             'V', mce, Ity_I64, 
-             binop(Iop_Or64, 
-                   assignNew('V', mce, Ity_I64, unop(Iop_Not64, data)), 
+             'V', mce, Ity_I64,
+             binop(Iop_Or64,
+                   assignNew('V', mce, Ity_I64, unop(Iop_Not64, data)),
                    vbits) );
 }
 
@@ -729,9 +729,9 @@ static IRAtom* mkImproveORV128 ( MCEnv* mce, IRAtom* data, IRAtom* vbits )
    tl_assert(isShadowAtom(mce, vbits));
    tl_assert(sameKindedAtoms(data, vbits));
    return assignNew(
-             'V', mce, Ity_V128, 
-             binop(Iop_OrV128, 
-                   assignNew('V', mce, Ity_V128, unop(Iop_NotV128, data)), 
+             'V', mce, Ity_V128,
+             binop(Iop_OrV128,
+                   assignNew('V', mce, Ity_V128, unop(Iop_NotV128, data)),
                    vbits) );
 }
 
@@ -741,9 +741,9 @@ static IRAtom* mkImproveORV256 ( MCEnv* mce, IRAtom* data, IRAtom* vbits )
    tl_assert(isShadowAtom(mce, vbits));
    tl_assert(sameKindedAtoms(data, vbits));
    return assignNew(
-             'V', mce, Ity_V256, 
-             binop(Iop_OrV256, 
-                   assignNew('V', mce, Ity_V256, unop(Iop_NotV256, data)), 
+             'V', mce, Ity_V256,
+             binop(Iop_OrV256,
+                   assignNew('V', mce, Ity_V256, unop(Iop_NotV256, data)),
                    vbits) );
 }
 
@@ -753,7 +753,7 @@ static IRAtom* mkImproveORV256 ( MCEnv* mce, IRAtom* data, IRAtom* vbits )
    is undefined (value == 1) the resulting expression has all bits set to
    1. Otherwise, all bits are 0. */
 
-static IRAtom* mkPCastTo( MCEnv* mce, IRType dst_ty, IRAtom* vbits ) 
+static IRAtom* mkPCastTo( MCEnv* mce, IRType dst_ty, IRAtom* vbits )
 {
    IRType  src_ty;
    IRAtom* tmp1;
@@ -809,7 +809,7 @@ static IRAtom* mkPCastTo( MCEnv* mce, IRType dst_ty, IRAtom* vbits )
       // Generates
       //   UifU(vbits[127:64],vbits[127:64]) : UifU(vbits[127:64],vbits[63:0])
       //   == vbits[127:64] : UifU(vbits[127:64],vbits[63:0])
-      IRAtom* lohi64 
+      IRAtom* lohi64
          = mkUifUV128(mce, hi64hi64, vbits);
       // Generates UifU(vbits[127:64],vbits[63:0])
       IRAtom* lo64
@@ -829,16 +829,16 @@ static IRAtom* mkPCastTo( MCEnv* mce, IRType dst_ty, IRAtom* vbits )
       case Ity_I1:
          tmp1 = vbits;
          break;
-      case Ity_I8: 
+      case Ity_I8:
          tmp1 = assignNew('V', mce, Ity_I1, unop(Iop_CmpNEZ8, vbits));
          break;
-      case Ity_I16: 
+      case Ity_I16:
          tmp1 = assignNew('V', mce, Ity_I1, unop(Iop_CmpNEZ16, vbits));
          break;
-      case Ity_I32: 
+      case Ity_I32:
          tmp1 = assignNew('V', mce, Ity_I1, unop(Iop_CmpNEZ32, vbits));
          break;
-      case Ity_I64: 
+      case Ity_I64:
          tmp1 = assignNew('V', mce, Ity_I1, unop(Iop_CmpNEZ64, vbits));
          break;
       case Ity_I128: {
@@ -847,7 +847,7 @@ static IRAtom* mkPCastTo( MCEnv* mce, IRType dst_ty, IRAtom* vbits )
          IRAtom* tmp2 = assignNew('V', mce, Ity_I64, unop(Iop_128HIto64, vbits));
          IRAtom* tmp3 = assignNew('V', mce, Ity_I64, unop(Iop_128to64, vbits));
          IRAtom* tmp4 = assignNew('V', mce, Ity_I64, binop(Iop_Or64, tmp2, tmp3));
-         tmp1         = assignNew('V', mce, Ity_I1, 
+         tmp1         = assignNew('V', mce, Ity_I1,
                                        unop(Iop_CmpNEZ64, tmp4));
          break;
       }
@@ -860,13 +860,13 @@ static IRAtom* mkPCastTo( MCEnv* mce, IRType dst_ty, IRAtom* vbits )
    switch (dst_ty) {
       case Ity_I1:
          return tmp1;
-      case Ity_I8: 
+      case Ity_I8:
          return assignNew('V', mce, Ity_I8, unop(Iop_1Sto8, tmp1));
-      case Ity_I16: 
+      case Ity_I16:
          return assignNew('V', mce, Ity_I16, unop(Iop_1Sto16, tmp1));
-      case Ity_I32: 
+      case Ity_I32:
          return assignNew('V', mce, Ity_I32, unop(Iop_1Sto32, tmp1));
-      case Ity_I64: 
+      case Ity_I64:
          return assignNew('V', mce, Ity_I64, unop(Iop_1Sto64, tmp1));
       case Ity_V128:
          tmp1 = assignNew('V', mce, Ity_I64,  unop(Iop_1Sto64, tmp1));
@@ -883,7 +883,7 @@ static IRAtom* mkPCastTo( MCEnv* mce, IRType dst_ty, IRAtom* vbits )
          tmp1 = assignNew('V', mce, Ity_V256, binop(Iop_V128HLtoV256,
                                                     tmp1, tmp1));
          return tmp1;
-      default: 
+      default:
          ppIRType(dst_ty);
          VG_(tool_panic)("mkPCastTo(2)");
    }
@@ -902,7 +902,7 @@ static IRAtom* mkPCastXXtoXXlsb ( MCEnv* mce, IRAtom* varg, IRType ty )
       IRAtom* pcdTo64 = mkPCastTo(mce, Ity_I64, varg128);
       // Now introduce zeros (defined bits) in the top 63 places
       // generates: Def--(63)--Def PCast-to-I1(varg128)
-      IRAtom* d63pc 
+      IRAtom* d63pc
          = assignNew('V', mce, Ity_I64, binop(Iop_And64, pcdTo64, mkU64(1)));
       // generates: Def--(64)--Def
       IRAtom* d64
@@ -917,8 +917,8 @@ static IRAtom* mkPCastXXtoXXlsb ( MCEnv* mce, IRAtom* varg, IRType ty )
       // PCast to 64
       IRAtom* pcd = mkPCastTo(mce, Ity_I64, varg);
       // Zero (Def) out the top 63 bits
-      IRAtom* res 
-         = assignNew('V', mce, Ity_I64, binop(Iop_And64, pcd, mkU64(1)));   
+      IRAtom* res
+         = assignNew('V', mce, Ity_I64, binop(Iop_And64, pcd, mkU64(1)));
       return res;
    }
    /*NOTREACHED*/
@@ -926,7 +926,7 @@ static IRAtom* mkPCastXXtoXXlsb ( MCEnv* mce, IRAtom* varg, IRType ty )
 }
 
 /* --------- Accurate interpretation of CmpEQ/CmpNE. --------- */
-/* 
+/*
    Normally, we can do CmpEQ/CmpNE by doing UifU on the arguments, and
    PCasting to Ity_U1.  However, sometimes it is necessary to be more
    accurate.  The insight is that the result is defined if two
@@ -948,15 +948,15 @@ static IRAtom* mkPCastXXtoXXlsb ( MCEnv* mce, IRAtom* varg, IRType ty )
    )
 
    where
-     vec contains 0 (defined) bits where the corresponding arg bits 
+     vec contains 0 (defined) bits where the corresponding arg bits
      are defined but different, and 1 bits otherwise.
 
      vec = Or<sz>( vxx,   // 0 iff bit defined
                    vyy,   // 0 iff bit defined
                    Not<sz>(Xor<sz>( xx, yy )) // 0 iff bits different
                  )
-                    
-     If any bit of vec is 0, the result is defined and so the 
+
+     If any bit of vec is 0, the result is defined and so the
      improvement term should produce 0...0, else it should produce
      1...1.
 
@@ -970,7 +970,7 @@ static IRAtom* mkPCastXXtoXXlsb ( MCEnv* mce, IRAtom* varg, IRType ty )
 */
 static IRAtom* expensiveCmpEQorNE ( MCEnv*  mce,
                                     IRType  ty,
-                                    IRAtom* vxx, IRAtom* vyy, 
+                                    IRAtom* vxx, IRAtom* vyy,
                                     IRAtom* xx,  IRAtom* yy )
 {
    IRAtom *naive, *vec, *improvement_term;
@@ -983,7 +983,7 @@ static IRAtom* expensiveCmpEQorNE ( MCEnv*  mce,
    tl_assert(isOriginalAtom(mce,yy));
    tl_assert(sameKindedAtoms(vxx,xx));
    tl_assert(sameKindedAtoms(vyy,yy));
- 
+
    switch (ty) {
       case Ity_I16:
          opOR   = Iop_Or16;
@@ -1016,17 +1016,17 @@ static IRAtom* expensiveCmpEQorNE ( MCEnv*  mce,
          VG_(tool_panic)("expensiveCmpEQorNE");
    }
 
-   naive 
+   naive
       = mkPCastTo(mce,ty,
                   assignNew('V', mce, ty, binop(opUIFU, vxx, vyy)));
 
-   vec 
+   vec
       = assignNew(
-           'V', mce,ty, 
+           'V', mce,ty,
            binop( opOR,
                   assignNew('V', mce,ty, binop(opOR, vxx, vyy)),
                   assignNew(
-                     'V', mce,ty, 
+                     'V', mce,ty,
                      unop( opNOT,
                            assignNew('V', mce,ty, binop(opXOR, xx, yy))))));
 
@@ -1054,7 +1054,7 @@ static IRAtom* expensiveCmpEQorNE ( MCEnv*  mce,
 
    and similarly the unsigned variant.  The default interpretation is:
 
-      CmpORD32{S,U}#(x,y,x#,y#) = PCast(x# `UifU` y#)  
+      CmpORD32{S,U}#(x,y,x#,y#) = PCast(x# `UifU` y#)
                                   & (7<<1)
 
    The "& (7<<1)" reflects the fact that all result bits except 3,2,1
@@ -1091,7 +1091,7 @@ static Bool isZeroU64 ( IRAtom* e )
 
 static IRAtom* doCmpORD ( MCEnv*  mce,
                           IROp    cmp_op,
-                          IRAtom* xxhash, IRAtom* yyhash, 
+                          IRAtom* xxhash, IRAtom* yyhash,
                           IRAtom* xx,     IRAtom* yy )
 {
    Bool   m64    = cmp_op == Iop_CmpORD64S || cmp_op == Iop_CmpORD64U;
@@ -1118,7 +1118,7 @@ static IRAtom* doCmpORD ( MCEnv*  mce,
              || cmp_op == Iop_CmpORD64S || cmp_op == Iop_CmpORD64U);
 
    if (0) {
-      ppIROp(cmp_op); VG_(printf)(" "); 
+      ppIROp(cmp_op); VG_(printf)(" ");
       ppIRExpr(xx); VG_(printf)(" "); ppIRExpr( yy ); VG_(printf)("\n");
    }
 
@@ -1134,7 +1134,7 @@ static IRAtom* doCmpORD ( MCEnv*  mce,
                'V', mce,ty,
                binop(
                   opAND,
-                  mkPCastTo(mce,ty, xxhash), 
+                  mkPCastTo(mce,ty, xxhash),
                   threeLeft1
                )),
             assignNew(
@@ -1150,9 +1150,9 @@ static IRAtom* doCmpORD ( MCEnv*  mce,
    } else {
       /* standard interpretation */
       sevenLeft1 = m64 ? mkU64(7<<1) : mkU32(7<<1);
-      return 
-         binop( 
-            opAND, 
+      return
+         binop(
+            opAND,
             mkPCastTo( mce,ty,
                        mkUifU(mce,ty, xxhash,yyhash)),
             sevenLeft1
@@ -1339,7 +1339,7 @@ static void complainIfUndefined ( MCEnv* mce, IRAtom* atom, IRExpr *guard )
    tl_assert( (MC_(clo_mc_level) == 3 && origin != NULL)
               || (MC_(clo_mc_level) == 2 && origin == NULL) );
 
-   di = unsafeIRDirty_0_N( nargs/*regparms*/, nm, 
+   di = unsafeIRDirty_0_N( nargs/*regparms*/, nm,
                            VG_(fnptr_to_fnentry)( fn ), args );
    di->guard = cond; // and cond is PCast-to-1(atom#)
 
@@ -1367,7 +1367,7 @@ static void complainIfUndefined ( MCEnv* mce, IRAtom* atom, IRExpr *guard )
       if (guard == NULL) {
          // guard is 'always True', hence update unconditionally
          newShadowTmpV(mce, atom->Iex.RdTmp.tmp);
-         assign('V', mce, findShadowTmpV(mce, atom->Iex.RdTmp.tmp), 
+         assign('V', mce, findShadowTmpV(mce, atom->Iex.RdTmp.tmp),
                           definedOfType(ty));
       } else {
          // update the temp only conditionally.  Do this by copying
@@ -1392,7 +1392,7 @@ static void complainIfUndefined ( MCEnv* mce, IRAtom* atom, IRExpr *guard )
 /* Examine the always-defined sections declared in layout to see if
    the (offset,size) section is within one.  Note, is is an error to
    partially fall into such a region: (offset,size) should either be
-   completely in such a region or completely not-in such a region.  
+   completely in such a region or completely not-in such a region.
 */
 static Bool isAlwaysDefd ( MCEnv* mce, Int offset, Int size )
 {
@@ -1427,7 +1427,7 @@ static Bool isAlwaysDefd ( MCEnv* mce, Int offset, Int size )
    We assume here, that the definedness of GUARD has already been checked.
 */
 static
-void do_shadow_PUT ( MCEnv* mce,  Int offset, 
+void do_shadow_PUT ( MCEnv* mce,  Int offset,
                      IRAtom* atom, IRAtom* vatom, IRExpr *guard )
 {
    IRType ty;
@@ -1437,7 +1437,7 @@ void do_shadow_PUT ( MCEnv* mce,  Int offset,
    // that they depend on, which includes GETs of the shadow registers.
    if (MC_(clo_mc_level) == 1)
       return;
-   
+
    if (atom) {
       tl_assert(!vatom);
       tl_assert(isOriginalAtom(mce, atom));
@@ -1472,7 +1472,7 @@ void do_shadow_PUT ( MCEnv* mce,  Int offset,
 
 
 /* Return an expression which contains the V bits corresponding to the
-   given GETI (passed in in pieces). 
+   given GETI (passed in in pieces).
 */
 static
 void do_shadow_PUTI ( MCEnv* mce, IRPutI *puti)
@@ -1490,7 +1490,7 @@ void do_shadow_PUTI ( MCEnv* mce, IRPutI *puti)
    // that they depend on, which includes GETIs of the shadow registers.
    if (MC_(clo_mc_level) == 1)
       return;
-   
+
    tl_assert(isOriginalAtom(mce,atom));
    vatom = expr2vbits( mce, atom );
    tl_assert(sameKindedAtoms(atom, vatom));
@@ -1507,8 +1507,8 @@ void do_shadow_PUTI ( MCEnv* mce, IRPutI *puti)
    } else {
       /* Do a cloned version of the Put that refers to the shadow
          area. */
-      IRRegArray* new_descr 
-         = mkIRRegArray( descr->base + mce->layout->total_sizeB, 
+      IRRegArray* new_descr
+         = mkIRRegArray( descr->base + mce->layout->total_sizeB,
                          tyS, descr->nElems);
       stmt( 'V', mce, IRStmt_PutI( mkIRPutI(new_descr, ix, bias, vatom) ));
    }
@@ -1516,9 +1516,9 @@ void do_shadow_PUTI ( MCEnv* mce, IRPutI *puti)
 
 
 /* Return an expression which contains the V bits corresponding to the
-   given GET (passed in in pieces). 
+   given GET (passed in in pieces).
 */
-static 
+static
 IRExpr* shadow_GET ( MCEnv* mce, Int offset, IRType ty )
 {
    IRType tyS = shadowTypeV(ty);
@@ -1537,10 +1537,10 @@ IRExpr* shadow_GET ( MCEnv* mce, Int offset, IRType ty )
 
 
 /* Return an expression which contains the V bits corresponding to the
-   given GETI (passed in in pieces). 
+   given GETI (passed in in pieces).
 */
 static
-IRExpr* shadow_GETI ( MCEnv* mce, 
+IRExpr* shadow_GETI ( MCEnv* mce,
                       IRRegArray* descr, IRAtom* ix, Int bias )
 {
    IRType ty   = descr->elemTy;
@@ -1555,8 +1555,8 @@ IRExpr* shadow_GETI ( MCEnv* mce,
    } else {
       /* return a cloned version of the Get that refers to the shadow
          area. */
-      IRRegArray* new_descr 
-         = mkIRRegArray( descr->base + mce->layout->total_sizeB, 
+      IRRegArray* new_descr
+         = mkIRRegArray( descr->base + mce->layout->total_sizeB,
                          tyS, descr->nElems);
       return IRExpr_GetI( new_descr, ix, bias );
    }
@@ -1569,7 +1569,7 @@ IRExpr* shadow_GETI ( MCEnv* mce,
 /*------------------------------------------------------------*/
 
 /* Lazy propagation of undefinedness from two values, resulting in the
-   specified shadow type. 
+   specified shadow type.
 */
 static
 IRAtom* mkLazy2 ( MCEnv* mce, IRType finalVty, IRAtom* va1, IRAtom* va2 )
@@ -1620,7 +1620,7 @@ IRAtom* mkLazy2 ( MCEnv* mce, IRType finalVty, IRAtom* va1, IRAtom* va2 )
 
 /* 3-arg version of the above. */
 static
-IRAtom* mkLazy3 ( MCEnv* mce, IRType finalVty, 
+IRAtom* mkLazy3 ( MCEnv* mce, IRType finalVty,
                   IRAtom* va1, IRAtom* va2, IRAtom* va3 )
 {
    IRAtom* at;
@@ -1637,7 +1637,7 @@ IRAtom* mkLazy3 ( MCEnv* mce, IRType finalVty,
 
    /* I32 x I64 x I64 -> I64 */
    /* Standard FP idiom: rm x FParg1 x FParg2 -> FPresult */
-   if (t1 == Ity_I32 && t2 == Ity_I64 && t3 == Ity_I64 
+   if (t1 == Ity_I32 && t2 == Ity_I64 && t3 == Ity_I64
        && finalVty == Ity_I64) {
       if (0) VG_(printf)("mkLazy3: I32 x I64 x I64 -> I64\n");
       /* Widen 1st arg to I64.  Since 1st arg is typically a rounding
@@ -1670,7 +1670,7 @@ IRAtom* mkLazy3 ( MCEnv* mce, IRType finalVty,
    }
 
    /* I32 x I64 x I64 -> I32 */
-   if (t1 == Ity_I32 && t2 == Ity_I64 && t3 == Ity_I64 
+   if (t1 == Ity_I32 && t2 == Ity_I64 && t3 == Ity_I64
        && finalVty == Ity_I32) {
       if (0) VG_(printf)("mkLazy3: I32 x I64 x I64 -> I32\n");
       at = mkPCastTo(mce, Ity_I64, va1);
@@ -1682,7 +1682,7 @@ IRAtom* mkLazy3 ( MCEnv* mce, IRType finalVty,
 
    /* I32 x I32 x I32 -> I32 */
    /* 32-bit FP idiom, as (eg) happens on ARM */
-   if (t1 == Ity_I32 && t2 == Ity_I32 && t3 == Ity_I32 
+   if (t1 == Ity_I32 && t2 == Ity_I32 && t3 == Ity_I32
        && finalVty == Ity_I32) {
       if (0) VG_(printf)("mkLazy3: I32 x I32 x I32 -> I32\n");
       at = va1;
@@ -1754,7 +1754,7 @@ IRAtom* mkLazy3 ( MCEnv* mce, IRType finalVty,
 
 /* 4-arg version of the above. */
 static
-IRAtom* mkLazy4 ( MCEnv* mce, IRType finalVty, 
+IRAtom* mkLazy4 ( MCEnv* mce, IRType finalVty,
                   IRAtom* va1, IRAtom* va2, IRAtom* va3, IRAtom* va4 )
 {
    IRAtom* at;
@@ -1823,10 +1823,10 @@ IRAtom* mkLazy4 ( MCEnv* mce, IRType finalVty,
 /* Do the lazy propagation game from a null-terminated vector of
    atoms.  This is presumably the arguments to a helper call, so the
    IRCallee info is also supplied in order that we can know which
-   arguments should be ignored (via the .mcx_mask field). 
+   arguments should be ignored (via the .mcx_mask field).
 */
 static
-IRAtom* mkLazyN ( MCEnv* mce, 
+IRAtom* mkLazyN ( MCEnv* mce,
                   IRAtom** exprvec, IRType finalVtype, IRCallee* cee )
 {
    Int     i;
@@ -1863,7 +1863,7 @@ IRAtom* mkLazyN ( MCEnv* mce,
          /* calculate the arg's definedness, and pessimistically merge
             it in. */
          here = mkPCastTo( mce, mergeTy, expr2vbits(mce, exprvec[i]) );
-         curr = mergeTy64 
+         curr = mergeTy64
                    ? mkUifU64(mce, here, curr)
                    : mkUifU32(mce, here, curr);
       }
@@ -1881,7 +1881,7 @@ static
 IRAtom* expensiveAddSub ( MCEnv*  mce,
                           Bool    add,
                           IRType  ty,
-                          IRAtom* qaa, IRAtom* qbb, 
+                          IRAtom* qaa, IRAtom* qbb,
                           IRAtom* aa,  IRAtom* bb )
 {
    IRAtom *a_min, *b_min, *a_max, *b_max;
@@ -1916,12 +1916,12 @@ IRAtom* expensiveAddSub ( MCEnv*  mce,
    }
 
    // a_min = aa & ~qaa
-   a_min = assignNew('V', mce,ty, 
+   a_min = assignNew('V', mce,ty,
                      binop(opAND, aa,
                                   assignNew('V', mce,ty, unop(opNOT, qaa))));
 
    // b_min = bb & ~qbb
-   b_min = assignNew('V', mce,ty, 
+   b_min = assignNew('V', mce,ty,
                      binop(opAND, bb,
                                   assignNew('V', mce,ty, unop(opNOT, qbb))));
 
@@ -1937,8 +1937,8 @@ IRAtom* expensiveAddSub ( MCEnv*  mce,
       assignNew('V', mce,ty,
          binop( opOR,
                 assignNew('V', mce,ty, binop(opOR, qaa, qbb)),
-                assignNew('V', mce,ty, 
-                   binop( opXOR, 
+                assignNew('V', mce,ty,
+                   binop( opXOR,
                           assignNew('V', mce,ty, binop(opADD, a_min, b_min)),
                           assignNew('V', mce,ty, binop(opADD, a_max, b_max))
                    )
@@ -1951,8 +1951,8 @@ IRAtom* expensiveAddSub ( MCEnv*  mce,
       assignNew('V', mce,ty,
          binop( opOR,
                 assignNew('V', mce,ty, binop(opOR, qaa, qbb)),
-                assignNew('V', mce,ty, 
-                   binop( opXOR, 
+                assignNew('V', mce,ty,
+                   binop( opXOR,
                           assignNew('V', mce,ty, binop(opSUB, a_min, b_max)),
                           assignNew('V', mce,ty, binop(opSUB, a_max, b_min))
                    )
@@ -2044,7 +2044,7 @@ IRAtom* expensiveCountTrailingZeroes ( MCEnv* mce, IROp czop,
 static IRAtom* scalarShift ( MCEnv*  mce,
                              IRType  ty,
                              IROp    original_op,
-                             IRAtom* qaa, IRAtom* qbb, 
+                             IRAtom* qaa, IRAtom* qbb,
                              IRAtom* aa,  IRAtom* bb )
 {
    tl_assert(isShadowAtom(mce,qaa));
@@ -2053,7 +2053,7 @@ static IRAtom* scalarShift ( MCEnv*  mce,
    tl_assert(isOriginalAtom(mce,bb));
    tl_assert(sameKindedAtoms(qaa,aa));
    tl_assert(sameKindedAtoms(qbb,bb));
-   return 
+   return
       assignNew(
          'V', mce, ty,
          mkUifU( mce, ty,
@@ -2149,21 +2149,21 @@ static IRAtom* mkPCast8x4 ( MCEnv* mce, IRAtom* at )
    Lowest-lane-only versions are more complex:
 
    binary32F0x4(x,y)  ==> SetV128lo32(
-                             x#, 
-                             PCast32(V128to32(UifUV128(x#,y#))) 
+                             x#,
+                             PCast32(V128to32(UifUV128(x#,y#)))
                           )
 
    This is perhaps not so obvious.  In particular, it's faster to
    do a V128-bit UifU and then take the bottom 32 bits than the more
    obvious scheme of taking the bottom 32 bits of each operand
-   and doing a 32-bit UifU.  Basically since UifU is fast and 
+   and doing a 32-bit UifU.  Basically since UifU is fast and
    chopping lanes off vector values is slow.
 
    Finally:
 
    unary32F0x4(x)     ==> SetV128lo32(
-                             x#, 
-                             PCast32(V128to32(x#)) 
+                             x#,
+                             PCast32(V128to32(x#))
                           )
 
    Where:
@@ -2424,7 +2424,7 @@ IRAtom* binary32Fx8_w_rm ( MCEnv* mce, IRAtom* vRM,
    bits.  "same shape" means that the lane numbers and widths are the
    same as with OP.
 
-   For example, Vanilla(Iop_QNarrowBin32Sto16Ux8) 
+   For example, Vanilla(Iop_QNarrowBin32Sto16Ux8)
                   = Iop_NarrowBin32to16x8,
    that is, narrow 8 lanes of 32 bits to 8 lanes of 16 bits, by
    dumping the top half of each lane.
@@ -2474,14 +2474,14 @@ IROp vanillaNarrowingOpOfShape ( IROp qnarrowOp )
       case Iop_QNarrowUn16Sto8Sx8:
       case Iop_QNarrowUn16Sto8Ux8:
          return Iop_NarrowUn16to8x8;
-      default: 
+      default:
          ppIROp(qnarrowOp);
          VG_(tool_panic)("vanillaNarrowOpOfShape");
    }
 }
 
 static
-IRAtom* vectorNarrowBinV128 ( MCEnv* mce, IROp narrow_op, 
+IRAtom* vectorNarrowBinV128 ( MCEnv* mce, IROp narrow_op,
                               IRAtom* vatom1, IRAtom* vatom2)
 {
    IRAtom *at1, *at2, *at3;
@@ -2507,7 +2507,7 @@ IRAtom* vectorNarrowBinV128 ( MCEnv* mce, IROp narrow_op,
 }
 
 static
-IRAtom* vectorNarrowBin64 ( MCEnv* mce, IROp narrow_op, 
+IRAtom* vectorNarrowBin64 ( MCEnv* mce, IROp narrow_op,
                             IRAtom* vatom1, IRAtom* vatom2)
 {
    IRAtom *at1, *at2, *at3;
@@ -2599,7 +2599,7 @@ IRAtom* binary8Ix32 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifUV256(mce, vatom1, vatom2);
    at = mkPCast8x32(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2608,7 +2608,7 @@ IRAtom* binary16Ix16 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifUV256(mce, vatom1, vatom2);
    at = mkPCast16x16(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2617,7 +2617,7 @@ IRAtom* binary32Ix8 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifUV256(mce, vatom1, vatom2);
    at = mkPCast32x8(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2626,7 +2626,7 @@ IRAtom* binary64Ix4 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifUV256(mce, vatom1, vatom2);
    at = mkPCast64x4(mce, at);
-   return at;   
+   return at;
 }
 
 /* --- V128-bit versions --- */
@@ -2637,7 +2637,7 @@ IRAtom* binary8Ix16 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifUV128(mce, vatom1, vatom2);
    at = mkPCast8x16(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2646,7 +2646,7 @@ IRAtom* binary16Ix8 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifUV128(mce, vatom1, vatom2);
    at = mkPCast16x8(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2655,7 +2655,7 @@ IRAtom* binary32Ix4 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifUV128(mce, vatom1, vatom2);
    at = mkPCast32x4(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2664,7 +2664,7 @@ IRAtom* binary64Ix2 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifUV128(mce, vatom1, vatom2);
    at = mkPCast64x2(mce, at);
-   return at;   
+   return at;
 }
 
 /* --- 64-bit versions --- */
@@ -2675,7 +2675,7 @@ IRAtom* binary8Ix8 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifU64(mce, vatom1, vatom2);
    at = mkPCast8x8(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2684,7 +2684,7 @@ IRAtom* binary16Ix4 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifU64(mce, vatom1, vatom2);
    at = mkPCast16x4(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2693,7 +2693,7 @@ IRAtom* binary32Ix2 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifU64(mce, vatom1, vatom2);
    at = mkPCast32x2(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2713,7 +2713,7 @@ IRAtom* binary8Ix4 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifU32(mce, vatom1, vatom2);
    at = mkPCast8x4(mce, at);
-   return at;   
+   return at;
 }
 
 static
@@ -2722,7 +2722,7 @@ IRAtom* binary16Ix2 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
    IRAtom* at;
    at = mkUifU32(mce, vatom1, vatom2);
    at = mkPCast16x2(mce, at);
-   return at;   
+   return at;
 }
 
 
@@ -2730,10 +2730,10 @@ IRAtom* binary16Ix2 ( MCEnv* mce, IRAtom* vatom1, IRAtom* vatom2 )
 /*--- Generate shadow values from all kinds of IRExprs.    ---*/
 /*------------------------------------------------------------*/
 
-static 
+static
 IRAtom* expr2vbits_Qop ( MCEnv* mce,
                          IROp op,
-                         IRAtom* atom1, IRAtom* atom2, 
+                         IRAtom* atom1, IRAtom* atom2,
                          IRAtom* atom3, IRAtom* atom4 )
 {
    IRAtom* vatom1 = expr2vbits( mce, atom1 );
@@ -2778,7 +2778,7 @@ IRAtom* expr2vbits_Qop ( MCEnv* mce,
 }
 
 
-static 
+static
 IRAtom* expr2vbits_Triop ( MCEnv* mce,
                            IROp op,
                            IRAtom* atom1, IRAtom* atom2, IRAtom* atom3 )
@@ -2896,7 +2896,7 @@ IRAtom* expr2vbits_Triop ( MCEnv* mce,
 }
 
 
-static 
+static
 IRAtom* expr2vbits_Binop ( MCEnv* mce,
                            IROp op,
                            IRAtom* atom1, IRAtom* atom2 )
@@ -3066,7 +3066,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
       case Iop_PwMax32Fx2:
       case Iop_PwMin32Fx2:
          return assignNew('V', mce, Ity_I64,
-                          binop(Iop_PwMax32Ux2, 
+                          binop(Iop_PwMax32Ux2,
                                 mkPCast32x2(mce, vatom1),
                                 mkPCast32x2(mce, vatom2)));
 
@@ -3250,7 +3250,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
 
       /* For the rounding variants of bi-di vector x vector shifts, the
          rounding adjustment can cause undefinedness to propagate through
-         the entire lane, in the worst case.  Too complex to handle 
+         the entire lane, in the worst case.  Too complex to handle
          properly .. just UifU the arguments and then PCast them.
          Suboptimal but safe. */
       case Iop_Rsh8Sx16:
@@ -3396,7 +3396,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
       case Iop_CmpLE64Fx2:
       case Iop_CmpEQ64Fx2:
       case Iop_CmpUN64Fx2:
-         return binary64Fx2(mce, vatom1, vatom2);      
+         return binary64Fx2(mce, vatom1, vatom2);
 
       case Iop_Sub64F0x2:
       case Iop_Mul64F0x2:
@@ -3408,7 +3408,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
       case Iop_CmpEQ64F0x2:
       case Iop_CmpUN64F0x2:
       case Iop_Add64F0x2:
-         return binary64F0x2(mce, vatom1, vatom2);      
+         return binary64F0x2(mce, vatom1, vatom2);
 
       case Iop_Min32Fx4:
       case Iop_Max32Fx4:
@@ -3420,7 +3420,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
       case Iop_CmpGE32Fx4:
       case Iop_RecipStep32Fx4:
       case Iop_RSqrtStep32Fx4:
-         return binary32Fx4(mce, vatom1, vatom2);      
+         return binary32Fx4(mce, vatom1, vatom2);
 
       case Iop_Sub32Fx2:
       case Iop_Mul32Fx2:
@@ -3432,7 +3432,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
       case Iop_Add32Fx2:
       case Iop_RecipStep32Fx2:
       case Iop_RSqrtStep32Fx2:
-         return binary32Fx2(mce, vatom1, vatom2);      
+         return binary32Fx2(mce, vatom1, vatom2);
 
       case Iop_Sub32F0x4:
       case Iop_Mul32F0x4:
@@ -3444,7 +3444,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
       case Iop_CmpEQ32F0x4:
       case Iop_CmpUN32F0x4:
       case Iop_Add32F0x4:
-         return binary32F0x4(mce, vatom1, vatom2);      
+         return binary32F0x4(mce, vatom1, vatom2);
 
       case Iop_QShlNsatSU8x16:
       case Iop_QShlNsatUU8x16:
@@ -3540,7 +3540,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
          // Generates: Def--(63)--Def PCast-to-I1(narrowed)
          IRAtom* qV = mkPCastXXtoXXlsb(mce, shVnarrowed, Ity_I64);
          // and assemble the result
-         return assignNew('V', mce, Ity_V128, 
+         return assignNew('V', mce, Ity_V128,
                           binop(Iop_64HLtoV128, qV, shVnarrowed));
       }
 
@@ -3672,10 +3672,10 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
          32x4 -> 16x8 laneage, discarding the upper half of each lane.
          Simply apply same op to the V bits, since this really no more
          than a data steering operation. */
-      case Iop_NarrowBin32to16x8: 
-      case Iop_NarrowBin16to8x16: 
+      case Iop_NarrowBin32to16x8:
+      case Iop_NarrowBin16to8x16:
       case Iop_NarrowBin64to32x4:
-         return assignNew('V', mce, Ity_V128, 
+         return assignNew('V', mce, Ity_V128,
                                     binop(op, vatom1, vatom2));
 
       case Iop_ShrV128:
@@ -3917,13 +3917,13 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
 
       case Iop_Add32:
          if (mce->bogusLiterals || mce->useLLVMworkarounds)
-            return expensiveAddSub(mce,True,Ity_I32, 
+            return expensiveAddSub(mce,True,Ity_I32,
                                    vatom1,vatom2, atom1,atom2);
          else
             goto cheap_AddSub32;
       case Iop_Sub32:
          if (mce->bogusLiterals)
-            return expensiveAddSub(mce,False,Ity_I32, 
+            return expensiveAddSub(mce,False,Ity_I32,
                                    vatom1,vatom2, atom1,atom2);
          else
             goto cheap_AddSub32;
@@ -3940,13 +3940,13 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
 
       case Iop_Add64:
          if (mce->bogusLiterals || mce->useLLVMworkarounds)
-            return expensiveAddSub(mce,True,Ity_I64, 
+            return expensiveAddSub(mce,True,Ity_I64,
                                    vatom1,vatom2, atom1,atom2);
          else
             goto cheap_AddSub64;
       case Iop_Sub64:
          if (mce->bogusLiterals)
-            return expensiveAddSub(mce,False,Ity_I64, 
+            return expensiveAddSub(mce,False,Ity_I64,
                                    vatom1,vatom2, atom1,atom2);
          else
             goto cheap_AddSub64;
@@ -3965,7 +3965,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
       case Iop_Add8:
          return mkLeft8(mce, mkUifU8(mce, vatom1,vatom2));
 
-      case Iop_CmpEQ64: 
+      case Iop_CmpEQ64:
       case Iop_CmpNE64:
          if (mce->bogusLiterals)
             goto expensive_cmp64;
@@ -3977,11 +3977,11 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
          return expensiveCmpEQorNE(mce,Ity_I64, vatom1,vatom2, atom1,atom2 );
 
       cheap_cmp64:
-      case Iop_CmpLE64S: case Iop_CmpLE64U: 
+      case Iop_CmpLE64S: case Iop_CmpLE64U:
       case Iop_CmpLT64U: case Iop_CmpLT64S:
          return mkPCastTo(mce, Ity_I1, mkUifU64(mce, vatom1,vatom2));
 
-      case Iop_CmpEQ32: 
+      case Iop_CmpEQ32:
       case Iop_CmpNE32:
          if (mce->bogusLiterals)
             goto expensive_cmp32;
@@ -3993,7 +3993,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
          return expensiveCmpEQorNE(mce,Ity_I32, vatom1,vatom2, atom1,atom2 );
 
       cheap_cmp32:
-      case Iop_CmpLE32S: case Iop_CmpLE32U: 
+      case Iop_CmpLE32S: case Iop_CmpLE32U:
       case Iop_CmpLT32U: case Iop_CmpLT32S:
          return mkPCastTo(mce, Ity_I1, mkUifU32(mce, vatom1,vatom2));
 
@@ -4027,47 +4027,47 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
          return scalarShift( mce, Ity_I8, op, vatom1,vatom2, atom1,atom2 );
 
       case Iop_AndV256:
-         uifu = mkUifUV256; difd = mkDifDV256; 
+         uifu = mkUifUV256; difd = mkDifDV256;
          and_or_ty = Ity_V256; improve = mkImproveANDV256; goto do_And_Or;
       case Iop_AndV128:
-         uifu = mkUifUV128; difd = mkDifDV128; 
+         uifu = mkUifUV128; difd = mkDifDV128;
          and_or_ty = Ity_V128; improve = mkImproveANDV128; goto do_And_Or;
       case Iop_And64:
-         uifu = mkUifU64; difd = mkDifD64; 
+         uifu = mkUifU64; difd = mkDifD64;
          and_or_ty = Ity_I64; improve = mkImproveAND64; goto do_And_Or;
       case Iop_And32:
-         uifu = mkUifU32; difd = mkDifD32; 
+         uifu = mkUifU32; difd = mkDifD32;
          and_or_ty = Ity_I32; improve = mkImproveAND32; goto do_And_Or;
       case Iop_And16:
-         uifu = mkUifU16; difd = mkDifD16; 
+         uifu = mkUifU16; difd = mkDifD16;
          and_or_ty = Ity_I16; improve = mkImproveAND16; goto do_And_Or;
       case Iop_And8:
-         uifu = mkUifU8; difd = mkDifD8; 
+         uifu = mkUifU8; difd = mkDifD8;
          and_or_ty = Ity_I8; improve = mkImproveAND8; goto do_And_Or;
 
       case Iop_OrV256:
-         uifu = mkUifUV256; difd = mkDifDV256; 
+         uifu = mkUifUV256; difd = mkDifDV256;
          and_or_ty = Ity_V256; improve = mkImproveORV256; goto do_And_Or;
       case Iop_OrV128:
-         uifu = mkUifUV128; difd = mkDifDV128; 
+         uifu = mkUifUV128; difd = mkDifDV128;
          and_or_ty = Ity_V128; improve = mkImproveORV128; goto do_And_Or;
       case Iop_Or64:
-         uifu = mkUifU64; difd = mkDifD64; 
+         uifu = mkUifU64; difd = mkDifD64;
          and_or_ty = Ity_I64; improve = mkImproveOR64; goto do_And_Or;
       case Iop_Or32:
-         uifu = mkUifU32; difd = mkDifD32; 
+         uifu = mkUifU32; difd = mkDifD32;
          and_or_ty = Ity_I32; improve = mkImproveOR32; goto do_And_Or;
       case Iop_Or16:
-         uifu = mkUifU16; difd = mkDifD16; 
+         uifu = mkUifU16; difd = mkDifD16;
          and_or_ty = Ity_I16; improve = mkImproveOR16; goto do_And_Or;
       case Iop_Or8:
-         uifu = mkUifU8; difd = mkDifD8; 
+         uifu = mkUifU8; difd = mkDifD8;
          and_or_ty = Ity_I8; improve = mkImproveOR8; goto do_And_Or;
 
       do_And_Or:
          return
          assignNew(
-            'V', mce, 
+            'V', mce,
             and_or_ty,
             difd(mce, uifu(mce, vatom1, vatom2),
                       difd(mce, improve(mce, atom1, vatom1),
@@ -4229,7 +4229,7 @@ IRAtom* expr2vbits_Binop ( MCEnv* mce,
 }
 
 
-static 
+static
 IRExpr* expr2vbits_Unop ( MCEnv* mce, IROp op, IRAtom* atom )
 {
    /* For the widening operations {8,16,32}{U,S}to{16,32,64}, the
@@ -4329,7 +4329,7 @@ IRExpr* expr2vbits_Unop ( MCEnv* mce, IROp op, IRAtom* atom )
       case Iop_I64UtoD128: /* unsigned I64 -> D128 */
          return mkPCastTo(mce, Ity_I128, vatom);
 
-      case Iop_F32toF64: 
+      case Iop_F32toF64:
       case Iop_I32StoF64:
       case Iop_I32UtoF64:
       case Iop_NegF64:
@@ -4666,14 +4666,14 @@ IRAtom* expr2vbits_Load_WRK ( MCEnv* mce,
    /* Here's the call. */
    IRDirty* di;
    if (ret_via_outparam) {
-      di = unsafeIRDirty_1_N( datavbits, 
-                              2/*regparms*/, 
-                              hname, VG_(fnptr_to_fnentry)( helper ), 
+      di = unsafeIRDirty_1_N( datavbits,
+                              2/*regparms*/,
+                              hname, VG_(fnptr_to_fnentry)( helper ),
                               mkIRExprVec_2( IRExpr_VECRET(), addrAct ) );
    } else {
-      di = unsafeIRDirty_1_N( datavbits, 
-                              1/*regparms*/, 
-                              hname, VG_(fnptr_to_fnentry)( helper ), 
+      di = unsafeIRDirty_1_N( datavbits,
+                              1/*regparms*/,
+                              hname, VG_(fnptr_to_fnentry)( helper ),
                               mkIRExprVec_1( addrAct ) );
    }
 
@@ -4751,7 +4751,7 @@ IRAtom* expr2vbits_Load_guarded_General ( MCEnv* mce,
          tyWide = ty;
          break;
       case Iop_16Uto32: case Iop_16Sto32: case Iop_8Uto32: case Iop_8Sto32:
-         tyWide = Ity_I32; 
+         tyWide = Ity_I32;
          break;
       default:
          VG_(tool_panic)("memcheck:expr2vbits_Load_guarded_General");
@@ -4778,7 +4778,7 @@ IRAtom* expr2vbits_Load_guarded_General ( MCEnv* mce,
            : assignNew('V', mce, tyWide, unop(vwiden, iftrue1));
    /* These are the V bits we will return if the load doesn't take
       place. */
-   IRAtom* iffalse 
+   IRAtom* iffalse
       = valt;
    /* Prepare the cond for the ITE.  Convert a NULL cond into
       something that iropt knows how to fold out later. */
@@ -4796,8 +4796,8 @@ IRAtom* expr2vbits_Load_guarded_General ( MCEnv* mce,
    like expr2vbits_Load.  It is assumed that definedness of GUARD has
    already been checked at the call site. */
 static
-IRAtom* expr2vbits_Load_guarded_Simple ( MCEnv* mce, 
-                                         IREndness end, IRType ty, 
+IRAtom* expr2vbits_Load_guarded_Simple ( MCEnv* mce,
+                                         IREndness end, IRType ty,
                                          IRAtom* addr, UInt bias,
                                          IRAtom *guard )
 {
@@ -4808,15 +4808,15 @@ IRAtom* expr2vbits_Load_guarded_Simple ( MCEnv* mce,
 
 
 static
-IRAtom* expr2vbits_ITE ( MCEnv* mce, 
+IRAtom* expr2vbits_ITE ( MCEnv* mce,
                          IRAtom* cond, IRAtom* iftrue, IRAtom* iffalse )
 {
    IRAtom *vbitsC, *vbits0, *vbits1;
    IRType ty;
    /* Given ITE(cond, iftrue,  iffalse),  generate
             ITE(cond, iftrue#, iffalse#) `UifU` PCast(cond#)
-      That is, steer the V bits like the originals, but trash the 
-      result if the steering value is undefined.  This gives 
+      That is, steer the V bits like the originals, but trash the
+      result if the steering value is undefined.  This gives
       lazy propagation. */
    tl_assert(isOriginalAtom(mce, cond));
    tl_assert(isOriginalAtom(mce, iftrue));
@@ -4828,10 +4828,10 @@ IRAtom* expr2vbits_ITE ( MCEnv* mce,
    ty = typeOfIRExpr(mce->sb->tyenv, vbits0);
 
    return
-      mkUifU(mce, ty, assignNew('V', mce, ty, 
+      mkUifU(mce, ty, assignNew('V', mce, ty,
                                      IRExpr_ITE(cond, vbits1, vbits0)),
                       mkPCastTo(mce, ty, vbitsC) );
-}      
+}
 
 /* --------- This is the main expression-handling function. --------- */
 
@@ -4844,7 +4844,7 @@ IRExpr* expr2vbits ( MCEnv* mce, IRExpr* e )
          return shadow_GET( mce, e->Iex.Get.offset, e->Iex.Get.ty );
 
       case Iex_GetI:
-         return shadow_GETI( mce, e->Iex.GetI.descr, 
+         return shadow_GETI( mce, e->Iex.GetI.descr,
                                   e->Iex.GetI.ix, e->Iex.GetI.bias );
 
       case Iex_RdTmp:
@@ -4881,20 +4881,20 @@ IRExpr* expr2vbits ( MCEnv* mce, IRExpr* e )
 
       case Iex_Load:
          return expr2vbits_Load( mce, e->Iex.Load.end,
-                                      e->Iex.Load.ty, 
-                                      e->Iex.Load.addr, 0/*addr bias*/, 
+                                      e->Iex.Load.ty,
+                                      e->Iex.Load.addr, 0/*addr bias*/,
                                       NULL/* guard == "always True"*/ );
 
       case Iex_CCall:
-         return mkLazyN( mce, e->Iex.CCall.args, 
+         return mkLazyN( mce, e->Iex.CCall.args,
                               e->Iex.CCall.retty,
                               e->Iex.CCall.cee );
 
       case Iex_ITE:
-         return expr2vbits_ITE( mce, e->Iex.ITE.cond, e->Iex.ITE.iftrue, 
+         return expr2vbits_ITE( mce, e->Iex.ITE.cond, e->Iex.ITE.iftrue,
                                      e->Iex.ITE.iffalse);
 
-      default: 
+      default:
          VG_(printf)("\n");
          ppIRExpr(e);
          VG_(printf)("\n");
@@ -4936,10 +4936,10 @@ IRExpr* zwidenToHostWord ( MCEnv* mce, IRAtom* vatom )
          case Ity_I32:
             return assignNew('V', mce, tyH, unop(Iop_32Uto64, vatom));
          case Ity_I16:
-            return assignNew('V', mce, tyH, unop(Iop_32Uto64, 
+            return assignNew('V', mce, tyH, unop(Iop_32Uto64,
                    assignNew('V', mce, Ity_I32, unop(Iop_16Uto32, vatom))));
          case Ity_I8:
-            return assignNew('V', mce, tyH, unop(Iop_32Uto64, 
+            return assignNew('V', mce, tyH, unop(Iop_32Uto64,
                    assignNew('V', mce, Ity_I32, unop(Iop_8Uto32, vatom))));
          default:
             goto unhandled;
@@ -4964,8 +4964,8 @@ IRExpr* zwidenToHostWord ( MCEnv* mce, IRAtom* vatom )
    checked for definedness; the caller of this function must do that
    if necessary.
 */
-static 
-void do_shadow_Store ( MCEnv* mce, 
+static
+void do_shadow_Store ( MCEnv* mce,
                        IREndness end,
                        IRAtom* addr, UInt bias,
                        IRAtom* data, IRAtom* vdata,
@@ -5087,36 +5087,36 @@ void do_shadow_Store ( MCEnv* mce,
       eBiasQ0 = tyAddr==Ity_I32 ? mkU32(bias+offQ0) : mkU64(bias+offQ0);
       addrQ0  = assignNew('V', mce, tyAddr, binop(mkAdd, addr, eBiasQ0) );
       vdataQ0 = assignNew('V', mce, Ity_I64, unop(Iop_V256to64_0, vdata));
-      diQ0    = unsafeIRDirty_0_N( 
-                   1/*regparms*/, 
-                   hname, VG_(fnptr_to_fnentry)( helper ), 
+      diQ0    = unsafeIRDirty_0_N(
+                   1/*regparms*/,
+                   hname, VG_(fnptr_to_fnentry)( helper ),
                    mkIRExprVec_2( addrQ0, vdataQ0 )
                 );
 
       eBiasQ1 = tyAddr==Ity_I32 ? mkU32(bias+offQ1) : mkU64(bias+offQ1);
       addrQ1  = assignNew('V', mce, tyAddr, binop(mkAdd, addr, eBiasQ1) );
       vdataQ1 = assignNew('V', mce, Ity_I64, unop(Iop_V256to64_1, vdata));
-      diQ1    = unsafeIRDirty_0_N( 
-                   1/*regparms*/, 
-                   hname, VG_(fnptr_to_fnentry)( helper ), 
+      diQ1    = unsafeIRDirty_0_N(
+                   1/*regparms*/,
+                   hname, VG_(fnptr_to_fnentry)( helper ),
                    mkIRExprVec_2( addrQ1, vdataQ1 )
                 );
 
       eBiasQ2 = tyAddr==Ity_I32 ? mkU32(bias+offQ2) : mkU64(bias+offQ2);
       addrQ2  = assignNew('V', mce, tyAddr, binop(mkAdd, addr, eBiasQ2) );
       vdataQ2 = assignNew('V', mce, Ity_I64, unop(Iop_V256to64_2, vdata));
-      diQ2    = unsafeIRDirty_0_N( 
-                   1/*regparms*/, 
-                   hname, VG_(fnptr_to_fnentry)( helper ), 
+      diQ2    = unsafeIRDirty_0_N(
+                   1/*regparms*/,
+                   hname, VG_(fnptr_to_fnentry)( helper ),
                    mkIRExprVec_2( addrQ2, vdataQ2 )
                 );
 
       eBiasQ3 = tyAddr==Ity_I32 ? mkU32(bias+offQ3) : mkU64(bias+offQ3);
       addrQ3  = assignNew('V', mce, tyAddr, binop(mkAdd, addr, eBiasQ3) );
       vdataQ3 = assignNew('V', mce, Ity_I64, unop(Iop_V256to64_3, vdata));
-      diQ3    = unsafeIRDirty_0_N( 
-                   1/*regparms*/, 
-                   hname, VG_(fnptr_to_fnentry)( helper ), 
+      diQ3    = unsafeIRDirty_0_N(
+                   1/*regparms*/,
+                   hname, VG_(fnptr_to_fnentry)( helper ),
                    mkIRExprVec_2( addrQ3, vdataQ3 )
                 );
 
@@ -5132,7 +5132,7 @@ void do_shadow_Store ( MCEnv* mce,
       stmt( 'V', mce, IRStmt_Dirty(diQ2) );
       stmt( 'V', mce, IRStmt_Dirty(diQ3) );
 
-   } 
+   }
    else if (UNLIKELY(ty == Ity_V128)) {
 
       /* V128-bit case */
@@ -5156,17 +5156,17 @@ void do_shadow_Store ( MCEnv* mce,
       eBiasLo64 = tyAddr==Ity_I32 ? mkU32(bias+offLo64) : mkU64(bias+offLo64);
       addrLo64  = assignNew('V', mce, tyAddr, binop(mkAdd, addr, eBiasLo64) );
       vdataLo64 = assignNew('V', mce, Ity_I64, unop(Iop_V128to64, vdata));
-      diLo64    = unsafeIRDirty_0_N( 
-                     1/*regparms*/, 
-                     hname, VG_(fnptr_to_fnentry)( helper ), 
+      diLo64    = unsafeIRDirty_0_N(
+                     1/*regparms*/,
+                     hname, VG_(fnptr_to_fnentry)( helper ),
                      mkIRExprVec_2( addrLo64, vdataLo64 )
                   );
       eBiasHi64 = tyAddr==Ity_I32 ? mkU32(bias+offHi64) : mkU64(bias+offHi64);
       addrHi64  = assignNew('V', mce, tyAddr, binop(mkAdd, addr, eBiasHi64) );
       vdataHi64 = assignNew('V', mce, Ity_I64, unop(Iop_V128HIto64, vdata));
-      diHi64    = unsafeIRDirty_0_N( 
-                     1/*regparms*/, 
-                     hname, VG_(fnptr_to_fnentry)( helper ), 
+      diHi64    = unsafeIRDirty_0_N(
+                     1/*regparms*/,
+                     hname, VG_(fnptr_to_fnentry)( helper ),
                      mkIRExprVec_2( addrHi64, vdataHi64 )
                   );
       if (guard) diLo64->guard = guard;
@@ -5194,15 +5194,15 @@ void do_shadow_Store ( MCEnv* mce,
          /* We can't do this with regparm 2 on 32-bit platforms, since
             the back ends aren't clever enough to handle 64-bit
             regparm args.  Therefore be different. */
-         di = unsafeIRDirty_0_N( 
-                 1/*regparms*/, 
-                 hname, VG_(fnptr_to_fnentry)( helper ), 
+         di = unsafeIRDirty_0_N(
+                 1/*regparms*/,
+                 hname, VG_(fnptr_to_fnentry)( helper ),
                  mkIRExprVec_2( addrAct, vdata )
               );
       } else {
-         di = unsafeIRDirty_0_N( 
-                 2/*regparms*/, 
-                 hname, VG_(fnptr_to_fnentry)( helper ), 
+         di = unsafeIRDirty_0_N(
+                 2/*regparms*/,
+                 hname, VG_(fnptr_to_fnentry)( helper ),
                  mkIRExprVec_2( addrAct,
                                 zwidenToHostWord( mce, vdata ))
               );
@@ -5293,7 +5293,7 @@ void do_shadow_Dirty ( MCEnv* mce, IRDirty* d )
             tl_assert(gSz >= 0);
             if (gSz == 0) break;
             n = gSz <= 8 ? gSz : 8;
-            /* update 'curr' with UifU of the state slice 
+            /* update 'curr' with UifU of the state slice
                gOff .. gOff+n-1 */
             tySrc = szToITy( n );
 
@@ -5340,7 +5340,7 @@ void do_shadow_Dirty ( MCEnv* mce, IRDirty* d )
          but nevertheless choose an endianness which is hopefully
          native to the platform. */
       while (toDo >= 4) {
-         here = mkPCastTo( 
+         here = mkPCastTo(
                    mce, Ity_I32,
                    expr2vbits_Load_guarded_Simple(
                       mce, end, Ity_I32, d->mAddr, d->mSize - toDo, d->guard )
@@ -5350,7 +5350,7 @@ void do_shadow_Dirty ( MCEnv* mce, IRDirty* d )
       }
       /* chew off 16-bit chunks */
       while (toDo >= 2) {
-         here = mkPCastTo( 
+         here = mkPCastTo(
                    mce, Ity_I32,
                    expr2vbits_Load_guarded_Simple(
                       mce, end, Ity_I16, d->mAddr, d->mSize - toDo, d->guard )
@@ -5360,7 +5360,7 @@ void do_shadow_Dirty ( MCEnv* mce, IRDirty* d )
       }
       /* chew off the remaining 8-bit chunk, if any */
       if (toDo == 1) {
-         here = mkPCastTo( 
+         here = mkPCastTo(
                    mce, Ity_I32,
                    expr2vbits_Load_guarded_Simple(
                       mce, end, Ity_I8, d->mAddr, d->mSize - toDo, d->guard )
@@ -5404,7 +5404,7 @@ void do_shadow_Dirty ( MCEnv* mce, IRDirty* d )
             tl_assert(gSz >= 0);
             if (gSz == 0) break;
             n = gSz <= 8 ? gSz : 8;
-            /* Write suitably-casted 'curr' to the state slice 
+            /* Write suitably-casted 'curr' to the state slice
                gOff .. gOff+n-1 */
             tyDst = szToITy( n );
             do_shadow_PUT( mce, gOff,
@@ -5454,7 +5454,7 @@ void do_shadow_Dirty ( MCEnv* mce, IRDirty* d )
    become undefined ("writable").  Generate code to call a helper to
    notify the A/V bit machinery of this fact.
 
-   We call 
+   We call
    void MC_(helperc_MAKE_STACK_UNINIT) ( Addr base, UWord len,
                                                     Addr nia );
 */
@@ -5483,7 +5483,7 @@ void do_AbiHint ( MCEnv* mce, IRExpr* base, Int len, IRExpr* nia )
 /* ------ Dealing with IRCAS (big and complex) ------ */
 
 /* FWDS */
-static IRAtom* gen_load_b  ( MCEnv* mce, Int szB, 
+static IRAtom* gen_load_b  ( MCEnv* mce, Int szB,
                              IRAtom* baseaddr, Int offset );
 static IRAtom* gen_maxU32  ( MCEnv* mce, IRAtom* b1, IRAtom* b2 );
 static void    gen_store_b ( MCEnv* mce, Int szB,
@@ -5606,7 +5606,7 @@ void do_shadow_CAS ( MCEnv* mce, IRCAS* cas )
       result is defined.  Why?  Details follow.
 
       x86/amd64 contains various forms of locked insns:
-      * lock prefix before all basic arithmetic insn; 
+      * lock prefix before all basic arithmetic insn;
         eg lock xorl %reg1,(%reg2)
       * atomic exchange reg-mem
       * compare-and-swaps
@@ -5731,7 +5731,7 @@ static void do_shadow_CAS_single ( MCEnv* mce, IRCAS* cas )
    voldLo
       = assignNew(
            'V', mce, elemTy,
-           expr2vbits_Load( 
+           expr2vbits_Load(
               mce,
               cas->end, elemTy, cas->addr, 0/*Addr bias*/,
               NULL/*always happens*/
@@ -5791,7 +5791,7 @@ static void do_shadow_CAS_double ( MCEnv* mce, IRCAS* cas )
    elemTy = typeOfIRExpr(mce->sb->tyenv, cas->expdLo);
    switch (elemTy) {
       case Ity_I8:
-         opCasCmpEQ = Iop_CasCmpEQ8; opOr = Iop_Or8; opXor = Iop_Xor8; 
+         opCasCmpEQ = Iop_CasCmpEQ8; opOr = Iop_Or8; opXor = Iop_Xor8;
          elemSzB = 1; zero = mkU8(0);
          break;
       case Ity_I16:
@@ -5860,7 +5860,7 @@ static void do_shadow_CAS_double ( MCEnv* mce, IRCAS* cas )
    voldHi
       = assignNew(
            'V', mce, elemTy,
-           expr2vbits_Load( 
+           expr2vbits_Load(
               mce,
               cas->end, elemTy, cas->addr, memOffsHi/*Addr bias*/,
               NULL/*always happens*/
@@ -5868,7 +5868,7 @@ static void do_shadow_CAS_double ( MCEnv* mce, IRCAS* cas )
    voldLo
       = assignNew(
            'V', mce, elemTy,
-           expr2vbits_Load( 
+           expr2vbits_Load(
               mce,
               cas->end, elemTy, cas->addr, memOffsLo/*Addr bias*/,
               NULL/*always happens*/
@@ -5902,7 +5902,7 @@ static void do_shadow_CAS_double ( MCEnv* mce, IRCAS* cas )
       expd_eq_old = xHL == 0;
    */
    xHi = assignNew('C', mce, elemTy,
-                   binop(opXor, cas->expdHi, mkexpr(cas->oldHi))); 
+                   binop(opXor, cas->expdHi, mkexpr(cas->oldHi)));
    xLo = assignNew('C', mce, elemTy,
                    binop(opXor, cas->expdLo, mkexpr(cas->oldLo)));
    xHL = assignNew('C', mce, elemTy,
@@ -6104,19 +6104,19 @@ static Bool checkForBogusLiterals ( /*FLAT*/ IRStmt* st )
                return False;
             case Iex_Const:
                return isBogusAtom(e);
-            case Iex_Unop: 
+            case Iex_Unop:
                return isBogusAtom(e->Iex.Unop.arg)
                       || e->Iex.Unop.op == Iop_GetMSBs8x16;
             case Iex_GetI:
                return isBogusAtom(e->Iex.GetI.ix);
-            case Iex_Binop: 
+            case Iex_Binop:
                return isBogusAtom(e->Iex.Binop.arg1)
                       || isBogusAtom(e->Iex.Binop.arg2);
-            case Iex_Triop: 
+            case Iex_Triop:
                return isBogusAtom(e->Iex.Triop.details->arg1)
                       || isBogusAtom(e->Iex.Triop.details->arg2)
                       || isBogusAtom(e->Iex.Triop.details->arg3);
-            case Iex_Qop: 
+            case Iex_Qop:
                return isBogusAtom(e->Iex.Qop.details->arg1)
                       || isBogusAtom(e->Iex.Qop.details->arg2)
                       || isBogusAtom(e->Iex.Qop.details->arg3)
@@ -6125,14 +6125,14 @@ static Bool checkForBogusLiterals ( /*FLAT*/ IRStmt* st )
                return isBogusAtom(e->Iex.ITE.cond)
                       || isBogusAtom(e->Iex.ITE.iftrue)
                       || isBogusAtom(e->Iex.ITE.iffalse);
-            case Iex_Load: 
+            case Iex_Load:
                return isBogusAtom(e->Iex.Load.addr);
             case Iex_CCall:
                for (i = 0; e->Iex.CCall.args[i]; i++)
                   if (isBogusAtom(e->Iex.CCall.args[i]))
                      return True;
                return False;
-            default: 
+            default:
                goto unhandled;
          }
       case Ist_Dirty:
@@ -6152,10 +6152,10 @@ static Bool checkForBogusLiterals ( /*FLAT*/ IRStmt* st )
       case Ist_Put:
          return isBogusAtom(st->Ist.Put.data);
       case Ist_PutI:
-         return isBogusAtom(st->Ist.PutI.details->ix) 
+         return isBogusAtom(st->Ist.PutI.details->ix)
                 || isBogusAtom(st->Ist.PutI.details->data);
       case Ist_Store:
-         return isBogusAtom(st->Ist.Store.addr) 
+         return isBogusAtom(st->Ist.Store.addr)
                 || isBogusAtom(st->Ist.Store.data);
       case Ist_StoreG: {
          IRStoreG* sg = st->Ist.StoreG.details;
@@ -6176,6 +6176,8 @@ static Bool checkForBogusLiterals ( /*FLAT*/ IRStmt* st )
       case Ist_IMark:
       case Ist_MBE:
          return False;
+      case Ist_Flush:
+          return isBogusAtom(st->Ist.Flush.addr);
       case Ist_CAS:
          cas = st->Ist.CAS.details;
          return isBogusAtom(cas->addr)
@@ -6188,7 +6190,7 @@ static Bool checkForBogusLiterals ( /*FLAT*/ IRStmt* st )
                 || (st->Ist.LLSC.storedata
                        ? isBogusAtom(st->Ist.LLSC.storedata)
                        : False);
-      default: 
+      default:
       unhandled:
          ppIRStmt(st);
          VG_(tool_panic)("hasBogusLiterals");
@@ -6197,8 +6199,8 @@ static Bool checkForBogusLiterals ( /*FLAT*/ IRStmt* st )
 
 
 IRSB* MC_(instrument) ( VgCallbackClosure* closure,
-                        IRSB* sb_in, 
-                        VexGuestLayout* layout, 
+                        IRSB* sb_in,
+                        VexGuestLayout* layout,
                         VexGuestExtents* vge,
                         VexArchInfo* archinfo_host,
                         IRType gWordTy, IRType hWordTy )
@@ -6372,7 +6374,7 @@ IRSB* MC_(instrument) ( VgCallbackClosure* closure,
 
       if (MC_(clo_mc_level) == 3) {
          /* See comments on case Ist_CAS below. */
-         if (st->tag != Ist_CAS) 
+         if (st->tag != Ist_CAS)
             schemeS( &mce, st );
       }
 
@@ -6381,12 +6383,12 @@ IRSB* MC_(instrument) ( VgCallbackClosure* closure,
       switch (st->tag) {
 
          case Ist_WrTmp:
-            assign( 'V', &mce, findShadowTmpV(&mce, st->Ist.WrTmp.tmp), 
+            assign( 'V', &mce, findShadowTmpV(&mce, st->Ist.WrTmp.tmp),
                                expr2vbits( &mce, st->Ist.WrTmp.data) );
             break;
 
          case Ist_Put:
-            do_shadow_PUT( &mce, 
+            do_shadow_PUT( &mce,
                            st->Ist.Put.offset,
                            st->Ist.Put.data,
                            NULL /* shadow atom */, NULL /* guard */ );
@@ -6421,6 +6423,7 @@ IRSB* MC_(instrument) ( VgCallbackClosure* closure,
 
          case Ist_NoOp:
          case Ist_MBE:
+         case Ist_Flush:
             break;
 
          case Ist_Dirty:
@@ -6542,11 +6545,11 @@ static Bool sameIRValue ( IRExpr* e1, IRExpr* e2 )
       case Iex_Const:
          return eqIRConst( e1->Iex.Const.con, e2->Iex.Const.con );
       case Iex_Binop:
-         return e1->Iex.Binop.op == e2->Iex.Binop.op 
+         return e1->Iex.Binop.op == e2->Iex.Binop.op
                 && sameIRValue(e1->Iex.Binop.arg1, e2->Iex.Binop.arg1)
                 && sameIRValue(e1->Iex.Binop.arg2, e2->Iex.Binop.arg2);
       case Iex_Unop:
-         return e1->Iex.Unop.op == e2->Iex.Unop.op 
+         return e1->Iex.Unop.op == e2->Iex.Unop.op
                 && sameIRValue(e1->Iex.Unop.arg, e2->Iex.Unop.arg);
       case Iex_RdTmp:
          return e1->Iex.RdTmp.tmp == e2->Iex.RdTmp.tmp;
@@ -6571,7 +6574,7 @@ static Bool sameIRValue ( IRExpr* e1, IRExpr* e2 )
          /* fallthrough */
       default:
          VG_(printf)("mc_translate.c: sameIRValue: unhandled: ");
-         ppIRExpr(e1); 
+         ppIRExpr(e1);
          VG_(tool_panic)("memcheck:sameIRValue");
          return False;
    }
@@ -6580,7 +6583,7 @@ static Bool sameIRValue ( IRExpr* e1, IRExpr* e2 )
 /* See if 'pairs' already has an entry for (entry, guard).  Return
    True if so.  If not, add an entry. */
 
-static 
+static
 Bool check_or_add ( XArray* /*of Pair*/ pairs, IRExpr* guard, void* entry )
 {
    Pair  p;
@@ -6634,7 +6637,7 @@ IRSB* MC_(final_tidy) ( IRSB* sb_in )
       tl_assert(guard);
       if (0) { ppIRExpr(guard); VG_(printf)("\n"); }
       cee = di->cee;
-      if (!is_helperc_value_checkN_fail( cee->name )) 
+      if (!is_helperc_value_checkN_fail( cee->name ))
          continue;
        /* Ok, we have a call to helperc_value_check0/1/4/8_fail with
           guard 'guard'.  Check if we have already seen a call to this
@@ -6690,8 +6693,8 @@ static IRAtom* gen_maxU32 ( MCEnv* mce, IRAtom* b1, IRAtom* b2 )
    return the otag.  The loaded size is SZB.  If GUARD evaluates to
    False at run time then the returned otag is zero.
 */
-static IRAtom* gen_guarded_load_b ( MCEnv* mce, Int szB, 
-                                    IRAtom* baseaddr, 
+static IRAtom* gen_guarded_load_b ( MCEnv* mce, Int szB,
+                                    IRAtom* baseaddr,
                                     Int offset, IRExpr* guard )
 {
    void*    hFun;
@@ -6793,7 +6796,7 @@ IRAtom* expr2ori_Load_guarded_General ( MCEnv* mce,
                                      addr, bias, guard));
    /* These are the bits we will return if the load doesn't take
       place. */
-   IRAtom* iffalse 
+   IRAtom* iffalse
       = balt;
    /* Prepare the cond for the ITE.  Convert a NULL cond into
       something that iropt knows how to fold out later. */
@@ -6888,7 +6891,7 @@ static IRAtom* schemeE ( MCEnv* mce, IRExpr* e )
          IRRegArray* descr_b;
          IRAtom      *t1, *t2, *t3, *t4;
          IRRegArray* descr      = e->Iex.GetI.descr;
-         IRType equivIntTy 
+         IRType equivIntTy
             = MC_(get_otrack_reg_array_equiv_int_type)(descr);
          /* If this array is unshadowable for whatever reason, use the
             usual approximation. */
@@ -6904,8 +6907,8 @@ static IRAtom* schemeE ( MCEnv* mce, IRExpr* e )
             no harm in being completely general here, since iropt will
             remove any useless code), and fold it in, giving a final
             value t4. */
-         t1 = assignNew( 'B', mce, equivIntTy, 
-                          IRExpr_GetI( descr_b, e->Iex.GetI.ix, 
+         t1 = assignNew( 'B', mce, equivIntTy,
+                          IRExpr_GetI( descr_b, e->Iex.GetI.ix,
                                                 e->Iex.GetI.bias ));
          t2 = narrowTo32( mce, t1 );
          t3 = schemeE( mce, e->Iex.GetI.ix );
@@ -6993,9 +6996,9 @@ static IRAtom* schemeE ( MCEnv* mce, IRExpr* e )
       case Iex_RdTmp:
          return mkexpr( findShadowTmpB( mce, e->Iex.RdTmp.tmp ));
       case Iex_Get: {
-         Int b_offset = MC_(get_otrack_shadow_offset)( 
+         Int b_offset = MC_(get_otrack_shadow_offset)(
                            e->Iex.Get.offset,
-                           sizeofIRType(e->Iex.Get.ty) 
+                           sizeofIRType(e->Iex.Get.ty)
                         );
          tl_assert(b_offset >= -1
                    && b_offset <= mce->layout->total_sizeB -4);
@@ -7008,7 +7011,7 @@ static IRAtom* schemeE ( MCEnv* mce, IRExpr* e )
       }
       default:
          VG_(printf)("mc_translate.c: schemeE: unhandled: ");
-         ppIRExpr(e); 
+         ppIRExpr(e);
          VG_(tool_panic)("memcheck:schemeE");
    }
 }
@@ -7066,7 +7069,7 @@ static void do_origins_Dirty ( MCEnv* mce, IRDirty* d )
             tl_assert(gSz >= 0);
             if (gSz == 0) break;
             n = gSz <= 4 ? gSz : 4;
-            /* update 'curr' with maxU32 of the state slice 
+            /* update 'curr' with maxU32 of the state slice
                gOff .. gOff+n-1 */
             b_offset = MC_(get_otrack_shadow_offset)(gOff, 4);
             if (b_offset != -1) {
@@ -7347,7 +7350,7 @@ static void schemeS ( MCEnv* mce, IRStmt* st )
             and mark the result temporary as defined. */
          if (st->Ist.LLSC.storedata == NULL) {
             /* Load Linked */
-            IRType resTy 
+            IRType resTy
                = typeOfIRTemp(mce->sb->tyenv, st->Ist.LLSC.result);
             IRExpr* vanillaLoad
                = IRExpr_Load(st->Ist.LLSC.end, resTy, st->Ist.LLSC.addr);
@@ -7378,7 +7381,7 @@ static void schemeS ( MCEnv* mce, IRStmt* st )
               );
          if (b_offset >= 0) {
             /* FIXME: this isn't an atom! */
-            stmt( 'B', mce, IRStmt_Put(b_offset + 2*mce->layout->total_sizeB, 
+            stmt( 'B', mce, IRStmt_Put(b_offset + 2*mce->layout->total_sizeB,
                                        schemeE( mce, st->Ist.Put.data )) );
          }
          break;
@@ -7393,11 +7396,12 @@ static void schemeS ( MCEnv* mce, IRStmt* st )
       case Ist_NoOp:
       case Ist_Exit:
       case Ist_IMark:
+      case Ist_Flush:
          break;
 
       default:
          VG_(printf)("mc_translate.c: schemeS: unhandled: ");
-         ppIRStmt(st); 
+         ppIRStmt(st);
          VG_(tool_panic)("memcheck:schemeS");
    }
 }

--- a/pmemcheck/tests/address_specific/flush_align.vgtest
+++ b/pmemcheck/tests/address_specific/flush_align.vgtest
@@ -1,2 +1,2 @@
 prog: flush_align
-vgopts: -q --print-summary=no --log-stores=yes
+vgopts: --isa-rec=no -q --print-summary=no --log-stores=yes

--- a/pmemcheck/tests/address_specific/region_coalescing.vgtest
+++ b/pmemcheck/tests/address_specific/region_coalescing.vgtest
@@ -1,2 +1,2 @@
 prog: region_coalescing
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/address_specific/region_manipulation.vgtest
+++ b/pmemcheck/tests/address_specific/region_manipulation.vgtest
@@ -1,2 +1,2 @@
 prog: region_manipulation
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/address_specific/remove_aligned_region.vgtest
+++ b/pmemcheck/tests/address_specific/remove_aligned_region.vgtest
@@ -1,2 +1,2 @@
 prog: remove_aligned_region
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/address_specific/remove_regions.vgtest
+++ b/pmemcheck/tests/address_specific/remove_regions.vgtest
@@ -1,2 +1,2 @@
 prog: remove_regions
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/cas.vgtest
+++ b/pmemcheck/tests/cas.vgtest
@@ -1,2 +1,2 @@
 prog: cas
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/const_store.vgtest
+++ b/pmemcheck/tests/const_store.vgtest
@@ -1,2 +1,2 @@
 prog: const_store
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/flush_check.vgtest
+++ b/pmemcheck/tests/flush_check.vgtest
@@ -1,2 +1,2 @@
 prog: flush_check
-vgopts: -q --flush-check=yes --flush-align=yes
+vgopts: --isa-rec=no -q --flush-check=yes --flush-align=yes

--- a/pmemcheck/tests/isa_check.c
+++ b/pmemcheck/tests/isa_check.c
@@ -15,8 +15,10 @@
 #include "common.h"
 #include <xmmintrin.h>
 
-//#define	_mm_clflush(addr)\
-//	asm volatile("clflush %0" : "+m" (*(volatile char *)addr));
+#define	_mm_clflushopt(addr)\
+	asm volatile(".byte 0x66; clflush %0" : "+m" (*(volatile char *)addr));
+#define	_mm_clwb(addr)\
+	asm volatile(".byte 0x66, 0x0f, 0xae, 0x30" : "+m" (*(volatile char *)addr));
 #define	_mm_sfence()\
 	asm volatile(".byte 0x0f, 0xae, 0xf8");
 #define	_mm_pcommit()\
@@ -44,7 +46,19 @@ int main ( void )
     _mm_clflush(base);
     _mm_sfence();
 
+    i64p += 8;
+    *i64p = 4;
+    _mm_clflushopt(i64p);
+    /* flush should be registered as "invalid" */
+    _mm_clflush(i64p);
     _mm_pcommit();
-    _mm_sfence();
+
+    i64p += 8;
+    *i64p = 4;
+    _mm_clwb(i64p);
+    /* flush should be registered as "invalid" */
+    _mm_clflushopt(i64p);
+    _mm_pcommit();
+
     return 0;
 }

--- a/pmemcheck/tests/isa_check.stderr.exp
+++ b/pmemcheck/tests/isa_check.stderr.exp
@@ -1,14 +1,20 @@
-Number of stores not made persistent: 1
+Number of stores not made persistent: 2
 Stores not made persistent properly:
-[0]    at 0x........: main (flush_check.c:27)
+[0]    at 0x........: main (isa_check.c:50)
 	Address: 0x........	size: 8	state: COMMITTED
-Total memory not made persistent: 8
-
-Number of redundantly flushed stores: 3
-Stores flushed multiple times:
-[0]    at 0x........: main (flush_check.c:27)
+[1]    at 0x........: main (isa_check.c:57)
 	Address: 0x........	size: 8	state: FLUSHED
-[1]    at 0x........: main (flush_check.c:27)
+Total memory not made persistent: 16
+
+Number of redundantly flushed stores: 5
+Stores flushed multiple times:
+[0]    at 0x........: main (isa_check.c:37)
 	Address: 0x........	size: 8	state: FENCED
-[2]    at 0x........: main (flush_check.c:27)
+[1]    at 0x........: main (isa_check.c:37)
+	Address: 0x........	size: 8	state: FENCED
+[2]    at 0x........: main (isa_check.c:37)
 	Address: 0x........	size: 8	state: COMMITTED
+[3]    at 0x........: main (isa_check.c:50)
+	Address: 0x........	size: 8	state: FLUSHED
+[4]    at 0x........: main (isa_check.c:57)
+	Address: 0x........	size: 8	state: FLUSHED

--- a/pmemcheck/tests/isa_check.vgtest
+++ b/pmemcheck/tests/isa_check.vgtest
@@ -1,2 +1,2 @@
 prog: isa_check
-vgopts:  --flush-check=yes --flush-align=yes
+vgopts: -q --flush-check=yes --flush-align=yes

--- a/pmemcheck/tests/logging_related/logging.vgtest
+++ b/pmemcheck/tests/logging_related/logging.vgtest
@@ -1,2 +1,2 @@
 prog: logging
-vgopts: -q --log-stores=yes --print-summary=no --flush-align=yes
+vgopts: --isa-rec=no -q --log-stores=yes --print-summary=no --flush-align=yes

--- a/pmemcheck/tests/logging_related/register_file.vgtest
+++ b/pmemcheck/tests/logging_related/register_file.vgtest
@@ -1,2 +1,2 @@
 prog: register_file
-vgopts: -q --log-stores=yes --print-summary=no
+vgopts: --isa-rec=no -q --log-stores=yes --print-summary=no

--- a/pmemcheck/tests/missed_flush.vgtest
+++ b/pmemcheck/tests/missed_flush.vgtest
@@ -1,2 +1,2 @@
 prog: missed_flush
-vgopts: -q --flush-check=yes --flush-align=yes
+vgopts: --isa-rec=no -q --flush-check=yes --flush-align=yes

--- a/pmemcheck/tests/multiple_stores.vgtest
+++ b/pmemcheck/tests/multiple_stores.vgtest
@@ -1,2 +1,2 @@
 prog: multiple_stores
-vgopts: -q --mult-stores=yes
+vgopts: --isa-rec=no -q --mult-stores=yes

--- a/pmemcheck/tests/nt_stores.vgtest
+++ b/pmemcheck/tests/nt_stores.vgtest
@@ -1,2 +1,2 @@
 prog: nt_stores
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/set_clean.vgtest
+++ b/pmemcheck/tests/set_clean.vgtest
@@ -1,2 +1,2 @@
 prog: set_clean
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/small_stacktrace/trans_mt.vgtest
+++ b/pmemcheck/tests/small_stacktrace/trans_mt.vgtest
@@ -1,2 +1,2 @@
 prog: trans_mt
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/small_stacktrace/trans_mt_cross.vgtest
+++ b/pmemcheck/tests/small_stacktrace/trans_mt_cross.vgtest
@@ -1,2 +1,2 @@
 prog: trans_mt_cross
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/sse_stores.vgtest
+++ b/pmemcheck/tests/sse_stores.vgtest
@@ -1,2 +1,2 @@
 prog: sse_stores
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/state_machine.vgtest
+++ b/pmemcheck/tests/state_machine.vgtest
@@ -1,2 +1,2 @@
 prog: state_machine
-vgopts: -q --flush-align=yes
+vgopts: --isa-rec=no -q --flush-align=yes

--- a/pmemcheck/tests/state_machine2.vgtest
+++ b/pmemcheck/tests/state_machine2.vgtest
@@ -1,2 +1,2 @@
 prog: state_machine2
-vgopts: -q --flush-align=yes
+vgopts: --isa-rec=no -q --flush-align=yes

--- a/pmemcheck/tests/state_no_flush_align.vgtest
+++ b/pmemcheck/tests/state_no_flush_align.vgtest
@@ -1,2 +1,2 @@
 prog: state_no_flush_align
-vgopts: -q --flush-align=no
+vgopts: --isa-rec=no -q --flush-align=no

--- a/pmemcheck/tests/tmp_store.vgtest
+++ b/pmemcheck/tests/tmp_store.vgtest
@@ -1,2 +1,2 @@
 prog: tmp_store
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_cache_flush.vgtest
+++ b/pmemcheck/tests/trans_cache_flush.vgtest
@@ -1,2 +1,2 @@
 prog: trans_cache_flush
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_cache_overl.vgtest
+++ b/pmemcheck/tests/trans_cache_overl.vgtest
@@ -1,2 +1,2 @@
 prog: trans_cache_overl
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_excl.vgtest
+++ b/pmemcheck/tests/trans_excl.vgtest
@@ -1,2 +1,2 @@
 prog: trans_excl
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_expl.vgtest
+++ b/pmemcheck/tests/trans_expl.vgtest
@@ -1,2 +1,2 @@
 prog: trans_expl
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_impl.vgtest
+++ b/pmemcheck/tests/trans_impl.vgtest
@@ -1,2 +1,2 @@
 prog: trans_impl
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_impl_nest.vgtest
+++ b/pmemcheck/tests/trans_impl_nest.vgtest
@@ -1,2 +1,2 @@
 prog: trans_impl_nest
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_nest.vgtest
+++ b/pmemcheck/tests/trans_nest.vgtest
@@ -1,2 +1,2 @@
 prog: trans_nest
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_no_pmem.vgtest
+++ b/pmemcheck/tests/trans_no_pmem.vgtest
@@ -1,2 +1,2 @@
 prog: trans_no_pmem
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_only.vgtest
+++ b/pmemcheck/tests/trans_only.vgtest
@@ -1,2 +1,2 @@
 prog: trans_only
-vgopts: -q --tx_only=yes
+vgopts: --isa-rec=no -q --tx-only=yes


### PR DESCRIPTION
VEX now supports and discerns PCOMMI/CLFLUSH/CLFLUSHOPT/CLWB and different
types of fences.

Unfortunately my IDE removed trailing whitespaces, hence the high number of changed lines.
