### PR TITLE
common: finish new isa support implementation

### DIFF
--- a/VEX/priv/guest_amd64_toIR.c
+++ b/VEX/priv/guest_amd64_toIR.c
@@ -13490,26 +13490,33 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          delta += 1;
          /* Insert a memory fence.  It's sometimes important that these
             are carried through to the generated code. */
-         stmt( IRStmt_MBE(Imbe_Fence) );
+         stmt( IRStmt_MBE(Imbe_SFence) );
          DIP("sfence\n");
          goto decode_success;
       }
 
-      /* XXX - Imbe_SFence, Imbe_LFence */
-
       /* mindless duplication follows .. */
       /* 0F AE /5 = LFENCE -- flush pending operations to memory */
+      if (haveNo66noF2noF3(pfx)
+          && epartIsReg(getUChar(delta)) && gregLO3ofRM(getUChar(delta)) == 5
+          && sz == 4) {
+         delta += 1;
+         /* Insert a memory fence.  It's sometimes important that these
+            are carried through to the generated code. */
+         stmt( IRStmt_MBE(Imbe_LFence) );
+         DIP("lfence\n");
+         goto decode_success;
+      }
+
       /* 0F AE /6 = MFENCE -- flush pending operations to memory */
       if (haveNo66noF2noF3(pfx)
-          && epartIsReg(getUChar(delta))
-          && (gregLO3ofRM(getUChar(delta)) == 5
-              || gregLO3ofRM(getUChar(delta)) == 6)
+          && epartIsReg(getUChar(delta)) && gregLO3ofRM(getUChar(delta)) == 6
           && sz == 4) {
          delta += 1;
          /* Insert a memory fence.  It's sometimes important that these
             are carried through to the generated code. */
          stmt( IRStmt_MBE(Imbe_Fence) );
-         DIP("%sfence\n", gregLO3ofRM(getUChar(delta-1))==5 ? "l" : "m");
+         DIP("fence\n");
          goto decode_success;
       }
 
@@ -13541,10 +13548,12 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
          delta += alen;
 
-         stmt( IRStmt_Flush(mkexpr(addr)) );
+
 
          if (!have66(pfx))
-             stmt( IRStmt_MBE(Imbe_Fence) );
+             stmt( IRStmt_Flush(mkexpr(addr), Ifk_flush) );
+         else
+             stmt( IRStmt_Flush(mkexpr(addr), Ifk_flushopt) );
 
          /* Round addr down to the start of the containing block. */
          stmt( IRStmt_Put(
@@ -13576,7 +13585,7 @@ Long dis_ESC_0F__SSE2 ( Bool* decode_OK,
          addr = disAMode ( &alen, vbi, pfx, delta, dis_buf, 0 );
          delta += alen;
 
-         stmt( IRStmt_Flush(mkexpr(addr)) );
+         stmt( IRStmt_Flush(mkexpr(addr), Ifk_clwb) );
 
          /* Round addr down to the start of the containing block. */
          stmt( IRStmt_Put(

--- a/VEX/priv/host_amd64_defs.c
+++ b/VEX/priv/host_amd64_defs.c
@@ -3017,11 +3017,6 @@ Int emit_AMD64Instr ( /*MB_MOD*/Bool* is_profInc,
       *p++ = 0x0F; *p++ = 0xAE; *p++ = 0xF0;
       goto done;
 
-   case Ain_Pcommit:
-      /* pcommit */
-      *p++ = 0x66; *p++ = 0x0F; *p++ = 0xAE; *p++ = 0xF8;
-      goto done;
-
    case Ain_ACAS:
       /* lock */
       *p++ = 0xF0;

--- a/VEX/priv/host_amd64_isel.c
+++ b/VEX/priv/host_amd64_isel.c
@@ -4592,10 +4592,11 @@ static void iselStmt ( ISelEnv* env, IRStmt* stmt )
    case Ist_MBE:
       switch (stmt->Ist.MBE.event) {
          case Imbe_Fence:
+         case Imbe_SFence:
+         case Imbe_LFence:
             addInstr(env, AMD64Instr_MFence());
             return;
          case Imbe_Drain:
-            addInstr(env, AMD64Instr_Pcommit());
             return;
          default:
             break;

--- a/VEX/priv/ir_defs.c
+++ b/VEX/priv/ir_defs.c
@@ -1518,9 +1518,29 @@ void ppIRMBusEvent ( IRMBusEvent event )
          vex_printf("CancelReservation"); break;
       case Imbe_Drain:
          vex_printf("Drain"); break;
+      case Imbe_SFence:
+         vex_printf("SFence"); break;
+      case Imbe_LFence:
+         vex_printf("LFence"); break;
       default:
          vpanic("ppIRMBusEvent");
    }
+}
+
+void ppIRFlushEvent ( IRFlushKind flush_kind, IRExpr* e )
+{
+   switch (flush_kind) {
+      case Ifk_flush:
+         vex_printf("FLUSH("); break;
+      case Ifk_flushopt:
+         vex_printf("FLUSHOPT("); break;
+      case Ifk_clwb:
+         vex_printf("CLWB("); break;
+      default:
+         vpanic("ppIRFlushEvent");
+   }
+   ppIRExpr(e);
+   vex_printf(")");
 }
 
 void ppIRStmt ( IRStmt* s )
@@ -1606,9 +1626,7 @@ void ppIRStmt ( IRStmt* s )
          vex_printf(" } ");
          break;
       case Ist_Flush:
-         vex_printf( "FLUSH(");
-         ppIRExpr(s->Ist.Flush.addr);
-         vex_printf( ")");
+         ppIRFlushEvent(s->Ist.Flush.fk, s->Ist.Flush.addr);
          break;
       default: 
          vpanic("ppIRStmt");
@@ -2159,10 +2177,11 @@ IRStmt* IRStmt_Exit ( IRExpr* guard, IRJumpKind jk, IRConst* dst,
    s->Ist.Exit.offsIP = offsIP;
    return s;
 }
-IRStmt* IRStmt_Flush ( IRExpr* addr ) {
+IRStmt* IRStmt_Flush ( IRExpr* addr, IRFlushKind fk ) {
    IRStmt* s           = LibVEX_Alloc(sizeof(IRStmt));
    s->tag              = Ist_Flush;
    s->Ist.Flush.addr   = addr;
+   s->Ist.Flush.fk     = fk;
    return s;
 }
 
@@ -2413,7 +2432,8 @@ IRStmt* deepCopyIRStmt ( IRStmt* s )
                             deepCopyIRConst(s->Ist.Exit.dst),
                             s->Ist.Exit.offsIP);
       case Ist_Flush:
-         return IRStmt_Flush(deepCopyIRExpr(s->Ist.Flush.addr));
+         return IRStmt_Flush(deepCopyIRExpr(s->Ist.Flush.addr),
+                             s->Ist.Flush.fk);
       default:
          vpanic("deepCopyIRStmt");
    }
@@ -4410,6 +4430,7 @@ void tcStmt ( IRSB* bb, IRStmt* stmt, IRType gWordTy )
       case Ist_MBE:
          switch (stmt->Ist.MBE.event) {
             case Imbe_Fence: case Imbe_CancelReservation: case Imbe_Drain:
+            case Imbe_SFence: case Imbe_LFence:
                break;
             default: sanityCheckFail(bb,stmt,"IRStmt.MBE.event: unknown");
                break;

--- a/VEX/priv/ir_opt.c
+++ b/VEX/priv/ir_opt.c
@@ -514,7 +514,7 @@ static void flatten_Stmt ( IRSB* bb, IRStmt* st )
          break;
       case Ist_Flush:
          e1 = flatten_Expr(bb, st->Ist.Flush.addr);
-         addStmtToIRSB(bb, IRStmt_Flush(e1));
+         addStmtToIRSB(bb, IRStmt_Flush(e1, st->Ist.Flush.fk));
          break;
       default:
          vex_printf("\n");
@@ -2729,7 +2729,8 @@ static IRStmt* subst_and_fold_Stmt ( IRExpr** env, IRStmt* st )
       case Ist_Flush:
          vassert(isIRAtom(st->Ist.Flush.addr));
          return IRStmt_Flush(
-                   fold_Expr(env, subst_Expr(env, st->Ist.Flush.addr))
+                   fold_Expr(env, subst_Expr(env, st->Ist.Flush.addr)),
+                   st->Ist.Flush.fk
                 );
 
    default:
@@ -5537,7 +5538,8 @@ static IRStmt* atbSubst_Stmt ( ATmpInfo* env, IRStmt* st )
 
       case Ist_Flush:
          return IRStmt_Flush(
-                   atbSubst_Expr(env, st->Ist.Flush.addr)
+                   atbSubst_Expr(env, st->Ist.Flush.addr),
+                   st->Ist.Flush.fk
                 );
 
       default: 

--- a/VEX/pub/libvex_ir.h
+++ b/VEX/pub/libvex_ir.h
@@ -2410,7 +2410,13 @@ typedef
          back end, just as LL and SC themselves are. */
       Imbe_CancelReservation,
       /* Needed only on amd64.  It drains the iMC cache. */
-      Imbe_Drain
+      Imbe_Drain,
+      /* Might be interesting for some kinds of tools */
+      /* XXX it would probably be a good idea to add a new fence kind to the
+       MBE statement, this however needs a lot of changes - to be considered
+       in the long run.*/
+      Imbe_SFence,
+      Imbe_LFence
    }
    IRMBusEvent;
 
@@ -2522,6 +2528,20 @@ extern IRPutI* mkIRPutI ( IRRegArray* descr, IRExpr* ix,
 
 extern IRPutI* deepCopyIRPutI ( IRPutI* );
 
+/* --------------- Flush operations --------------- */
+
+/* For some analysis tools, the type of flush operation is important. This is
+   what this enum is for.
+ */
+typedef
+   enum {
+      Ifk_flush = 0,        /* normal CLFLUSH */
+      Ifk_flushopt,         /* CLFLUSHOPT */
+      Ifk_clwb,             /* CLWB */
+
+   } IRFlushKind;
+
+void ppIRFlushEvent ( IRFlushKind flush_kind, IRExpr* e );
 
 /* --------------- Guarded loads and stores --------------- */
 
@@ -2876,7 +2896,8 @@ typedef
             ppIRStmt output: FLUSH(<addr>), eg. FLUSH(t1)
          */
          struct {
-            IRExpr*   addr;     /* flush address */
+            IRExpr*     addr;       /* flush address */
+            IRFlushKind  fk;        /* flush kind */
          } Flush;
        } Ist;
    }
@@ -2899,7 +2920,7 @@ extern IRStmt* IRStmt_LLSC    ( IREndness end, IRTemp result,
                                 IRExpr* addr, IRExpr* storedata );
 extern IRStmt* IRStmt_Dirty   ( IRDirty* details );
 extern IRStmt* IRStmt_MBE     ( IRMBusEvent event );
-extern IRStmt* IRStmt_Flush   ( IRExpr* addr );
+extern IRStmt* IRStmt_Flush   ( IRExpr* addr, IRFlushKind fk );
 extern IRStmt* IRStmt_Exit    ( IRExpr* guard, IRJumpKind jk, IRConst* dst,
                                 Int offsIP );
 

--- a/cachegrind/cg_main.c
+++ b/cachegrind/cg_main.c
@@ -1109,6 +1109,7 @@ IRSB* cg_instrument ( VgCallbackClosure* closure,
          case Ist_Put:
          case Ist_PutI:
          case Ist_MBE:
+         case Ist_Flush:
             break;
 
          case Ist_IMark:

--- a/callgrind/main.c
+++ b/callgrind/main.c
@@ -1023,6 +1023,7 @@ IRSB* CLG_(instrument)( VgCallbackClosure* closure,
 	 case Ist_Put:
 	 case Ist_PutI:
 	 case Ist_MBE:
+	 case Ist_Flush:
 	    break;
 
 	 case Ist_IMark: {

--- a/drd/drd_load_store.c
+++ b/drd/drd_load_store.c
@@ -633,6 +633,9 @@ IRSB* DRD_(instrument)(VgCallbackClosure* const closure,
          switch (st->Ist.MBE.event)
          {
          case Imbe_Fence:
+         case Imbe_LFence:
+         case Imbe_SFence:
+         case Imbe_Drain:
             break; /* not interesting to DRD */
          case Imbe_CancelReservation:
             break; /* not interesting to DRD */
@@ -794,6 +797,7 @@ IRSB* DRD_(instrument)(VgCallbackClosure* const closure,
       case Ist_Put:
       case Ist_PutI:
       case Ist_Exit:
+      case Ist_Flush:
          /* None of these can contain any memory references. */
          addStmtToIRSB(bb, st);
          break;

--- a/exp-sgcheck/sg_main.c
+++ b/exp-sgcheck/sg_main.c
@@ -2213,6 +2213,7 @@ void sg_instrument_IRStmt ( /*MOD*/struct _SGEnv * env,
       case Ist_Put:
       case Ist_PutI:
       case Ist_MBE:
+      case Ist_Flush:
          /* None of these can contain any memory references. */
          break;
 

--- a/helgrind/hg_main.c
+++ b/helgrind/hg_main.c
@@ -4543,6 +4543,7 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
          case Ist_Put:
          case Ist_PutI:
          case Ist_Exit:
+         case Ist_Flush:
             /* None of these can contain any memory references. */
             break;
 
@@ -4568,6 +4569,9 @@ IRSB* hg_instrument ( VgCallbackClosure* closure,
          case Ist_MBE:
             switch (st->Ist.MBE.event) {
                case Imbe_Fence:
+               case Imbe_LFence:
+               case Imbe_SFence:
+               case Imbe_Drain:
                case Imbe_CancelReservation:
                   break; /* not interesting */
                default:

--- a/lackey/lk_main.c
+++ b/lackey/lk_main.c
@@ -715,6 +715,7 @@ IRSB* lk_instrument ( VgCallbackClosure* closure,
          case Ist_Put:
          case Ist_PutI:
          case Ist_MBE:
+         case Ist_Flush:
             addStmtToIRSB( sbOut, st );
             break;
 

--- a/memcheck/mc_translate.c
+++ b/memcheck/mc_translate.c
@@ -6176,6 +6176,8 @@ static Bool checkForBogusLiterals ( /*FLAT*/ IRStmt* st )
       case Ist_IMark:
       case Ist_MBE:
          return False;
+      case Ist_Flush:
+         return isBogusAtom(st->Ist.Flush.addr);
       case Ist_CAS:
          cas = st->Ist.CAS.details;
          return isBogusAtom(cas->addr)
@@ -6421,6 +6423,7 @@ IRSB* MC_(instrument) ( VgCallbackClosure* closure,
 
          case Ist_NoOp:
          case Ist_MBE:
+         case Ist_Flush:
             break;
 
          case Ist_Dirty:
@@ -7393,6 +7396,7 @@ static void schemeS ( MCEnv* mce, IRStmt* st )
       case Ist_NoOp:
       case Ist_Exit:
       case Ist_IMark:
+      case Ist_Flush:
          break;
 
       default:

--- a/pmemcheck/tests/address_specific/flush_align.vgtest
+++ b/pmemcheck/tests/address_specific/flush_align.vgtest
@@ -1,2 +1,2 @@
 prog: flush_align
-vgopts: -q --print-summary=no --log-stores=yes
+vgopts: --isa-rec=no -q --print-summary=no --log-stores=yes

--- a/pmemcheck/tests/address_specific/region_coalescing.vgtest
+++ b/pmemcheck/tests/address_specific/region_coalescing.vgtest
@@ -1,2 +1,2 @@
 prog: region_coalescing
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/address_specific/region_manipulation.vgtest
+++ b/pmemcheck/tests/address_specific/region_manipulation.vgtest
@@ -1,2 +1,2 @@
 prog: region_manipulation
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/address_specific/remove_aligned_region.vgtest
+++ b/pmemcheck/tests/address_specific/remove_aligned_region.vgtest
@@ -1,2 +1,2 @@
 prog: remove_aligned_region
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/address_specific/remove_regions.vgtest
+++ b/pmemcheck/tests/address_specific/remove_regions.vgtest
@@ -1,2 +1,2 @@
 prog: remove_regions
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/cas.vgtest
+++ b/pmemcheck/tests/cas.vgtest
@@ -1,2 +1,2 @@
 prog: cas
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/const_store.vgtest
+++ b/pmemcheck/tests/const_store.vgtest
@@ -1,2 +1,2 @@
 prog: const_store
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/flush_check.vgtest
+++ b/pmemcheck/tests/flush_check.vgtest
@@ -1,2 +1,2 @@
 prog: flush_check
-vgopts: -q --flush-check=yes --flush-align=yes
+vgopts: --isa-rec=no -q --flush-check=yes --flush-align=yes

--- a/pmemcheck/tests/isa_check.c
+++ b/pmemcheck/tests/isa_check.c
@@ -15,8 +15,10 @@
 #include "common.h"
 #include <xmmintrin.h>
 
-//#define	_mm_clflush(addr)\
-//	asm volatile("clflush %0" : "+m" (*(volatile char *)addr));
+#define	_mm_clflushopt(addr)\
+	asm volatile(".byte 0x66; clflush %0" : "+m" (*(volatile char *)addr));
+#define	_mm_clwb(addr)\
+	asm volatile(".byte 0x66, 0x0f, 0xae, 0x30" : "+m" (*(volatile char *)addr));
 #define	_mm_sfence()\
 	asm volatile(".byte 0x0f, 0xae, 0xf8");
 #define	_mm_pcommit()\
@@ -44,7 +46,19 @@ int main ( void )
     _mm_clflush(base);
     _mm_sfence();
 
+    i64p += 8;
+    *i64p = 4;
+    _mm_clflushopt(i64p);
+    /* flush should be registered as "invalid" */
+    _mm_clflush(i64p);
     _mm_pcommit();
-    _mm_sfence();
+
+    i64p += 8;
+    *i64p = 4;
+    _mm_clwb(i64p);
+    /* flush should be registered as "invalid" */
+    _mm_clflushopt(i64p);
+    _mm_pcommit();
+
     return 0;
 }

--- a/pmemcheck/tests/isa_check.stderr.exp
+++ b/pmemcheck/tests/isa_check.stderr.exp
@@ -1,14 +1,20 @@
-Number of stores not made persistent: 1
+Number of stores not made persistent: 2
 Stores not made persistent properly:
-[0]    at 0x........: main (flush_check.c:27)
+[0]    at 0x........: main (isa_check.c:50)
 	Address: 0x........	size: 8	state: COMMITTED
-Total memory not made persistent: 8
-
-Number of redundantly flushed stores: 3
-Stores flushed multiple times:
-[0]    at 0x........: main (flush_check.c:27)
+[1]    at 0x........: main (isa_check.c:57)
 	Address: 0x........	size: 8	state: FLUSHED
-[1]    at 0x........: main (flush_check.c:27)
+Total memory not made persistent: 16
+
+Number of redundantly flushed stores: 5
+Stores flushed multiple times:
+[0]    at 0x........: main (isa_check.c:37)
 	Address: 0x........	size: 8	state: FENCED
-[2]    at 0x........: main (flush_check.c:27)
+[1]    at 0x........: main (isa_check.c:37)
+	Address: 0x........	size: 8	state: FENCED
+[2]    at 0x........: main (isa_check.c:37)
 	Address: 0x........	size: 8	state: COMMITTED
+[3]    at 0x........: main (isa_check.c:50)
+	Address: 0x........	size: 8	state: FLUSHED
+[4]    at 0x........: main (isa_check.c:57)
+	Address: 0x........	size: 8	state: FLUSHED

--- a/pmemcheck/tests/isa_check.vgtest
+++ b/pmemcheck/tests/isa_check.vgtest
@@ -1,2 +1,2 @@
 prog: isa_check
-vgopts:  --flush-check=yes --flush-align=yes
+vgopts: -q --flush-check=yes --flush-align=yes

--- a/pmemcheck/tests/logging_related/logging.vgtest
+++ b/pmemcheck/tests/logging_related/logging.vgtest
@@ -1,2 +1,2 @@
 prog: logging
-vgopts: -q --log-stores=yes --print-summary=no --flush-align=yes
+vgopts: --isa-rec=no -q --log-stores=yes --print-summary=no --flush-align=yes

--- a/pmemcheck/tests/logging_related/register_file.vgtest
+++ b/pmemcheck/tests/logging_related/register_file.vgtest
@@ -1,2 +1,2 @@
 prog: register_file
-vgopts: -q --log-stores=yes --print-summary=no
+vgopts: --isa-rec=no -q --log-stores=yes --print-summary=no

--- a/pmemcheck/tests/missed_flush.vgtest
+++ b/pmemcheck/tests/missed_flush.vgtest
@@ -1,2 +1,2 @@
 prog: missed_flush
-vgopts: -q --flush-check=yes --flush-align=yes
+vgopts: --isa-rec=no -q --flush-check=yes --flush-align=yes

--- a/pmemcheck/tests/multiple_stores.vgtest
+++ b/pmemcheck/tests/multiple_stores.vgtest
@@ -1,2 +1,2 @@
 prog: multiple_stores
-vgopts: -q --mult-stores=yes
+vgopts: --isa-rec=no -q --mult-stores=yes

--- a/pmemcheck/tests/nt_stores.vgtest
+++ b/pmemcheck/tests/nt_stores.vgtest
@@ -1,2 +1,2 @@
 prog: nt_stores
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/set_clean.vgtest
+++ b/pmemcheck/tests/set_clean.vgtest
@@ -1,2 +1,2 @@
 prog: set_clean
-vgopts: -q --print-summary=no
+vgopts: --isa-rec=no -q --print-summary=no

--- a/pmemcheck/tests/small_stacktrace/trans_mt.vgtest
+++ b/pmemcheck/tests/small_stacktrace/trans_mt.vgtest
@@ -1,2 +1,2 @@
 prog: trans_mt
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/small_stacktrace/trans_mt_cross.vgtest
+++ b/pmemcheck/tests/small_stacktrace/trans_mt_cross.vgtest
@@ -1,2 +1,2 @@
 prog: trans_mt_cross
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/sse_stores.vgtest
+++ b/pmemcheck/tests/sse_stores.vgtest
@@ -1,2 +1,2 @@
 prog: sse_stores
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/state_machine.vgtest
+++ b/pmemcheck/tests/state_machine.vgtest
@@ -1,2 +1,2 @@
 prog: state_machine
-vgopts: -q --flush-align=yes
+vgopts: --isa-rec=no -q --flush-align=yes

--- a/pmemcheck/tests/state_machine2.vgtest
+++ b/pmemcheck/tests/state_machine2.vgtest
@@ -1,2 +1,2 @@
 prog: state_machine2
-vgopts: -q --flush-align=yes
+vgopts: --isa-rec=no -q --flush-align=yes

--- a/pmemcheck/tests/state_no_flush_align.vgtest
+++ b/pmemcheck/tests/state_no_flush_align.vgtest
@@ -1,2 +1,2 @@
 prog: state_no_flush_align
-vgopts: -q --flush-align=no
+vgopts: --isa-rec=no -q --flush-align=no

--- a/pmemcheck/tests/tmp_store.vgtest
+++ b/pmemcheck/tests/tmp_store.vgtest
@@ -1,2 +1,2 @@
 prog: tmp_store
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_cache_flush.vgtest
+++ b/pmemcheck/tests/trans_cache_flush.vgtest
@@ -1,2 +1,2 @@
 prog: trans_cache_flush
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_cache_overl.vgtest
+++ b/pmemcheck/tests/trans_cache_overl.vgtest
@@ -1,2 +1,2 @@
 prog: trans_cache_overl
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_excl.vgtest
+++ b/pmemcheck/tests/trans_excl.vgtest
@@ -1,2 +1,2 @@
 prog: trans_excl
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_expl.vgtest
+++ b/pmemcheck/tests/trans_expl.vgtest
@@ -1,2 +1,2 @@
 prog: trans_expl
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_impl.vgtest
+++ b/pmemcheck/tests/trans_impl.vgtest
@@ -1,2 +1,2 @@
 prog: trans_impl
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_impl_nest.vgtest
+++ b/pmemcheck/tests/trans_impl_nest.vgtest
@@ -1,2 +1,2 @@
 prog: trans_impl_nest
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_nest.vgtest
+++ b/pmemcheck/tests/trans_nest.vgtest
@@ -1,2 +1,2 @@
 prog: trans_nest
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_no_pmem.vgtest
+++ b/pmemcheck/tests/trans_no_pmem.vgtest
@@ -1,2 +1,2 @@
 prog: trans_no_pmem
-vgopts: -q
+vgopts: --isa-rec=no -q

--- a/pmemcheck/tests/trans_only.vgtest
+++ b/pmemcheck/tests/trans_only.vgtest
@@ -1,2 +1,2 @@
 prog: trans_only
-vgopts: -q --tx_only=yes
+vgopts: --isa-rec=no -q --tx-only=yes


### PR DESCRIPTION
VEX now supports and discerns PCOMMI/CLFLUSH/CLFLUSHOPT/CLWB and different
types of fences.

Added support for Ist_Flush in 'legacy' tools.
